### PR TITLE
fix(home+form): snap de minutos para 00/15/30/45 ao abrir o picker de…

### DIFF
--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -208,11 +208,13 @@ export class ChurchFormComponent implements OnInit, OnChanges {
   }
 
   setDefaultTimeIfNull(control: AbstractControl | null): void {
-    if (control && !control.value) {
-      const defaultTime = new Date();
-      defaultTime.setHours(0, 0, 0, 0);
-      control.setValue(defaultTime);
-    }
+    if (!control) return;
+    const current = control.value;
+    const d = current ? new Date(current) : new Date();
+    const snapped = Math.round(d.getMinutes() / 15) * 15;
+    d.setMinutes(snapped % 60, 0, 0);
+    if (snapped === 60) d.setHours(d.getHours() + 1);
+    control.setValue(d);
   }
 
   // Validador customizado para minutos

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -87,6 +87,7 @@
         showIcon
         iconDisplay="input"
         [stepMinute]="15"
+        (onFocus)="setDefaultTimeIfNull()"
       />
       <label for="Horario">Horário</label>
     </p-floatlabel>

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -103,12 +103,12 @@ export class HomeComponent {
   }
 
   setDefaultTimeIfNull() {
-    const currentValue = this.form.get("Horario")?.value;
-    if (!currentValue) {
-      const defaultTime = new Date();
-      defaultTime.setHours(0, 0, 0, 0);
-      this.form.get("Horario")?.setValue(defaultTime);
-    }
+    const current = this.form.get("Horario")?.value;
+    const d = current ? new Date(current) : new Date();
+    const snapped = Math.round(d.getMinutes() / 15) * 15;
+    d.setMinutes(snapped % 60, 0, 0);
+    if (snapped === 60) d.setHours(d.getHours() + 1);
+    this.form.get("Horario")?.setValue(d);
   }
 
   public getAddress(): void {


### PR DESCRIPTION
… hora

Ao focar o campo de horário, arredonda para o intervalo de 15 min mais próximo antes de o spinner iniciar. Evita steps quebrados (ex: 15:08 → 15:23) tanto na busca quanto no formulário de cadastro/edição.