### PR TITLE
fix(home): underline no hover do nome da paróquia

### DIFF
--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -2,6 +2,10 @@
     font-size: 1.5rem;
 }
 
+h2[routerlink]:hover {
+  text-decoration: underline;
+}
+
 .image-container {
   width: 150px;
   height: 200px;


### PR DESCRIPTION
Tailwind v4 usa CSS layers — PrimeNG (fora de layers) sobrescreve hover:underline. Corrigido com regra SCSS direta no componente.