### PR TITLE
fix(home): cursor e underline no nome da paróquia via SCSS puro

### DIFF
--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -339,7 +339,7 @@
                 <!-- Detalhes da Igreja -->
                 <div>
                   <div class="text-lg font-bold text-surface-900 dark:text-surface-0">
-                    <h2 [routerLink]="['/detalhes', church.endereco.cep]" class="cursor-pointer hover:underline">
+                    <h2 [routerLink]="['/detalhes', church.endereco.cep]" class="church-name-link">
                       {{ church.nome }}
                     </h2>
                     <p class="font-medium text-surface-700 dark:text-surface-200">

--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -2,8 +2,12 @@
     font-size: 1.5rem;
 }
 
-h2[routerlink]:hover {
-  text-decoration: underline;
+.church-name-link {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .image-container {


### PR DESCRIPTION
Remove dependência das classes Tailwind (cursor-pointer, hover:underline) que eram sobrescritas pelo PrimeNG. Substituído por classe .church-name-link no SCSS do componente com cursor: pointer e text-decoration: underline no hover.