### PR TITLE
SEO: enriquece dados estruturados de Event e adiciona schema nas pagi…

### DIFF
--- a/src/app/modules/public/home/city/city.component.html
+++ b/src/app/modules/public/home/city/city.component.html
@@ -17,9 +17,10 @@
 
   <!-- Texto contextual (bom para SEO) -->
   <p *ngIf="!isLoading && igrejas.length" class="text-gray-600 text-sm px-6 pt-3">
-    Encontre os horários de missa das paróquias e comunidades católicas de
-    <strong>{{ cidadeNome }}/{{ uf.toUpperCase() }}</strong>.
-    São <strong>{{ igrejas.length }}</strong> paróquia(s) com endereço, contato e horários.
+    Encontre os horários de missa em <strong>{{ cidadeNome }}/{{ uf.toUpperCase() }}</strong>.
+    Consulte <strong>missa hoje</strong>, <strong>missa de domingo</strong> e as celebrações
+    das <strong>{{ igrejas.length }}</strong> paróquia(s) e comunidades católicas da cidade,
+    com endereço, contato e horários atualizados pela comunidade.
   </p>
 
   <!-- Lista de paróquias (layout de card, igual à busca) -->
@@ -99,6 +100,15 @@
       </article>
     </div>
   </div>
+
+  <!-- FAQ (visível + FAQPage schema, bom para rich result) -->
+  <section *ngIf="!isLoading && faqs.length" class="px-6 py-6 border-t border-surface-200">
+    <h2 class="text-lg font-bold text-surface-900 mb-3">Perguntas frequentes</h2>
+    <details *ngFor="let f of faqs" class="mb-2 border-b border-surface-100 pb-2">
+      <summary class="cursor-pointer font-medium text-surface-800">{{ f.pergunta }}</summary>
+      <p class="text-gray-600 text-sm mt-2">{{ f.resposta }}</p>
+    </details>
+  </section>
 
   <!-- Vazio -->
   <div *ngIf="!isLoading && naoEncontrado" class="text-center py-12 px-4">

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from "@angular/core";
+import { Component, inject, OnDestroy, OnInit } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { finalize } from "rxjs/operators";
@@ -13,7 +13,7 @@ import { SeoService } from "../../../../core/services/seo.service";
   templateUrl: "./city.component.html",
   styleUrl: "./city.component.scss",
 })
-export class CityComponent implements OnInit {
+export class CityComponent implements OnInit, OnDestroy {
   private _route = inject(ActivatedRoute);
   private _church = inject(ChurchesService);
   private _seo = inject(SeoService);
@@ -24,6 +24,7 @@ export class CityComponent implements OnInit {
   cidadeNome = "";
   igrejas: any[] = [];
   naoEncontrado = false;
+  faqs: { pergunta: string; resposta: string }[] = [];
 
   ngOnInit(): void {
     this._route.params.subscribe((params) => {
@@ -52,6 +53,11 @@ export class CityComponent implements OnInit {
           description: seo?.description ?? `Horários de missa em ${this.cidadeNome}/${this.uf?.toUpperCase()}.`,
           canonical: seo?.canonicalUrl,
         });
+        if (this.igrejas.length) {
+          this.aplicarBreadcrumbSchema();
+          this.montarFaqs();
+          this.aplicarFaqSchema();
+        }
       },
       error: () => {
         this.naoEncontrado = true;
@@ -62,9 +68,64 @@ export class CityComponent implements OnInit {
     });
   }
 
+  ngOnDestroy(): void {
+    this._seo.removeJsonLd("breadcrumb");
+    this._seo.removeJsonLd("faq");
+  }
+
   // Monta a URL canônica da paróquia
   linkParoquia(igreja: any): string[] {
     return ["/paroquia", this.uf, this.cidade, igreja.slug];
+  }
+
+  // Schema.org BreadcrumbList: Início > Cidade/UF
+  private aplicarBreadcrumbSchema(): void {
+    const base = "https://buscamissa.com.br";
+    this._seo.setJsonLd("breadcrumb", {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Início", item: `${base}/home` },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: `${this.cidadeNome}/${this.uf.toUpperCase()}`,
+          item: `${base}/missas/${this.uf}/${this.cidade}`,
+        },
+      ],
+    });
+  }
+
+  // Perguntas frequentes geradas a partir da cidade (alinhadas ao FAQ visível)
+  private montarFaqs(): void {
+    const local = `${this.cidadeNome}/${this.uf.toUpperCase()}`;
+    this.faqs = [
+      {
+        pergunta: `Que horas é a missa hoje em ${this.cidadeNome}?`,
+        resposta: `Consulte nesta página os horários de missa das ${this.igrejas.length} paróquia(s) de ${local}, organizados por dia da semana. Selecione uma paróquia para ver os horários de hoje.`,
+      },
+      {
+        pergunta: `Tem missa de domingo em ${this.cidadeNome}?`,
+        resposta: `Sim. Diversas paróquias de ${local} celebram missas aos domingos. Veja a lista de igrejas nesta página e os respectivos horários de domingo.`,
+      },
+      {
+        pergunta: `Como encontrar uma igreja católica perto de mim em ${this.cidadeNome}?`,
+        resposta: `Liste abaixo as paróquias e comunidades católicas de ${local} com endereço, contato e horários de missa atualizados pela comunidade.`,
+      },
+    ];
+  }
+
+  // Schema.org FAQPage (rich result) — espelha o FAQ visível na página
+  private aplicarFaqSchema(): void {
+    this._seo.setJsonLd("faq", {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: this.faqs.map((f) => ({
+        "@type": "Question",
+        name: f.pergunta,
+        acceptedAnswer: { "@type": "Answer", text: f.resposta },
+      })),
+    });
   }
 
   // Agrupa missas por dia: "Domingo: 7:00, 10:00, 18:00"

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -398,8 +398,19 @@ export class DetailsComponent implements OnInit {
           eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
           location: { "@type": "Church", name: igreja.nome, address },
           description: `Missa ${diaNome.toLowerCase()} às ${hora} na ${igreja.nome}, ${end.localidade}/${end.uf}.`,
+          organizer: { "@type": "Organization", name: igreja.nome },
+          performer: igreja.paroco
+            ? { "@type": "Person", name: igreja.paroco }
+            : { "@type": "Organization", name: igreja.nome },
+          offers: {
+            "@type": "Offer",
+            price: "0",
+            priceCurrency: "BRL",
+            availability: "https://schema.org/InStock",
+            url,
+          },
         };
-        if (igreja.imagemUrl) ev.image = igreja.imagemUrl;
+        ev.image = igreja.imagemUrl || `${base}/assets/images/og-image.jpg`;
         return ev;
       });
 


### PR DESCRIPTION
…nas de cidade

P1 - Event Schema (details.component.ts): adiciona os campos recomendados organizer, performer e offers a cada missa, e garante image sempre presente com fallback para a OG image. Corrige os 4 avisos do Search Console.

P2 - Paginas de cidade (city.component): injeta BreadcrumbList e FAQPage (JSON-LD) com FAQ visivel correspondente, e enriquece o texto introdutorio com palavras-chave. Limpa os schemas no ngOnDestroy.