### PR TITLE
feat: Clarity, UX fixes e melhorias de conteúdo

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,9 @@
 import { Component, inject, OnInit } from "@angular/core";
 import { RouterOutlet, Router, NavigationEnd, ActivatedRoute } from "@angular/router";
-import { filter, map } from "rxjs/operators";
+import { filter, map, pairwise, startWith } from "rxjs/operators";
 import { SeoService } from "./core/services/seo.service";
 import { AnalyticsService } from "./core/services/analytics.service";
+import { ClarityService } from "./core/services/clarity.service";
 
 @Component({
   selector: "app-root",
@@ -14,11 +15,22 @@ export class AppComponent implements OnInit {
   private _activatedRoute = inject(ActivatedRoute);
   private _seo = inject(SeoService);
   private _analytics = inject(AnalyticsService);
+  private _clarity = inject(ClarityService);
 
   ngOnInit(): void {
     this._analytics.initPageTracking();
-    this._router.events.pipe(
-      filter(e => e instanceof NavigationEnd),
+    this._initClarityGlobalTags();
+
+    const navEnd$ = this._router.events.pipe(filter(e => e instanceof NavigationEnd));
+
+    // Rastreia rota anterior para uso no ClarityService
+    navEnd$.pipe(
+      map(e => (e as NavigationEnd).urlAfterRedirects),
+      startWith(''),
+      pairwise()
+    ).subscribe(([prev]) => this._clarity.setPrevRoute(prev));
+
+    navEnd$.pipe(
       map(() => {
         let route = this._activatedRoute;
         while (route.firstChild) route = route.firstChild;
@@ -33,5 +45,26 @@ export class AppComponent implements OnInit {
         });
       }
     });
+  }
+
+  private _initClarityGlobalTags(): void {
+    // Aguarda o script do Clarity carregar (é async)
+    const apply = () => {
+      const isMobile = /Mobi|Android/i.test(navigator.userAgent);
+      this._clarity.tag('dispositivo', isMobile ? 'mobile' : 'desktop');
+      this._clarity.tag('idioma', navigator.language);
+
+      const isNew = !localStorage.getItem('bm_visited');
+      this._clarity.tag('novo_usuario', isNew ? 'sim' : 'nao');
+      if (isNew) localStorage.setItem('bm_visited', '1');
+
+      this._clarity.tag('origem_sessao', this._clarity.detectSessionOrigin());
+    };
+
+    if ((window as any).clarity) {
+      apply();
+    } else {
+      setTimeout(apply, 2000);
+    }
   }
 }

--- a/src/app/core/services/clarity.service.ts
+++ b/src/app/core/services/clarity.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ClarityService {
+  /** Rota anterior — atualizada pelo AppComponent a cada NavigationEnd */
+  private _prevRoute = '';
+
+  get prevRoute(): string { return this._prevRoute; }
+  setPrevRoute(route: string): void { this._prevRoute = route; }
+
+  private get c(): any { return (window as any).clarity; }
+
+  track(event: string, params?: Record<string, string | number | boolean>): void {
+    if (!this.c) return;
+    this.c('event', event, params);
+  }
+
+  tag(key: string, value: string): void {
+    if (!this.c) return;
+    this.c('set', key, value);
+  }
+
+  /** Detecta origem da sessão pelo document.referrer (só é preciso na primeira carga). */
+  detectSessionOrigin(): string {
+    const ref = document.referrer;
+    if (!ref) return 'direto';
+    if (/google\.|bing\.|yahoo\./i.test(ref)) return 'buscador';
+    if (/facebook\.com|fb\.com|instagram\.com/i.test(ref)) return 'redes_sociais';
+    if (/whatsapp/i.test(ref)) return 'compartilhamento';
+    return 'externo';
+  }
+
+  /** Derivia origem de navegação interna a partir da rota anterior. */
+  navOrigem(currentRoute: string): string {
+    const prev = this._prevRoute;
+    if (!prev) return 'direto';
+    if (prev.includes('/minhas-igrejas')) return 'favoritos';
+    if (prev.includes('/missas/')) return 'cidade';
+    if (prev.includes('/home') || prev === '/' || prev.includes('/buscar')) return 'home';
+    if (prev.includes('/paroquia/') || prev.includes('/igrejas/')) return 'igreja';
+    return 'outro';
+  }
+}

--- a/src/app/modules/public/church/pages/church-edit-page/church-edit-page.component.ts
+++ b/src/app/modules/public/church/pages/church-edit-page/church-edit-page.component.ts
@@ -21,6 +21,7 @@ import {
 import { ChurchFormComponent } from "../../components/church-form/church-form.component";
 import { PrimeNgModule } from "../../../../../shared/primeng.module";
 import { ChurchesService } from "../../../../../core/services/churches.service";
+import { ClarityService } from "../../../../../core/services/clarity.service";
 
 @Component({
   selector: "app-church-edit-page",
@@ -38,6 +39,7 @@ export class ChurchEditPageComponent implements OnInit {
   private cd = inject(ChangeDetectorRef);
   private location = inject(Location);
   public router = inject(Router);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   isSaving = false;
@@ -58,6 +60,7 @@ export class ChurchEditPageComponent implements OnInit {
   ];
 
   ngOnInit(): void {
+    this._clarity.track('contrib_form_aberto');
     this.churchDataForForm$ = this.route.params.pipe(
       tap((params) => {
         this.churchId = params["id"];
@@ -211,6 +214,7 @@ export class ChurchEditPageComponent implements OnInit {
   }
 
   cancel(): void {
+    this._clarity.track('contrib_cancelado');
     this.location.back();
   }
 }

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -19,6 +19,7 @@ import {
 import { ChurchFormComponent } from "../../components/church-form/church-form.component";
 import { PrimeNgModule } from "../../../../../shared/primeng.module";
 import { ChurchesService } from "../../../../../core/services/churches.service";
+import { ClarityService } from "../../../../../core/services/clarity.service";
 
 @Component({
   selector: "app-church-registration-page",
@@ -37,12 +38,14 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   private confirmationService = inject(ConfirmationService);
   private datePipe = inject(DatePipe);
   private cd = inject(ChangeDetectorRef);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   isCepLoading = false;
 
   ngAfterViewInit(): void {
     this.cd.detectChanges();
+    this._clarity.track('contrib_form_aberto');
   }
 
   // Lida com a submissão vinda do form filho
@@ -264,8 +267,8 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     });
   }
 
-  // Navega de volta (ex: para a lista ou home)
   cancel(): void {
+    this._clarity.track('contrib_cancelado');
     this.router.navigate(["/"]);
   }
 }

--- a/src/app/modules/public/como-funciona/como-funciona.component.html
+++ b/src/app/modules/public/como-funciona/como-funciona.component.html
@@ -51,6 +51,8 @@
   </div>
 </section>
 
+<div data-scroll-pct="25" aria-hidden="true"></div>
+
 <!-- ══ FONTES ══ -->
 <section class="cf-section">
   <div class="cf-container">
@@ -94,6 +96,8 @@
     </div>
   </div>
 </section>
+
+<div data-scroll-pct="50" aria-hidden="true"></div>
 
 <!-- ══ SELOS ══ -->
 <section class="cf-section cf-section--light cf-section--compact">
@@ -148,6 +152,8 @@
     </ul>
   </div>
 </section>
+
+<div data-scroll-pct="75" aria-hidden="true"></div>
 
 <!-- ══ COBERTURA ══ -->
 <section class="cf-section">
@@ -206,3 +212,5 @@
     </a>
   </div>
 </section>
+
+<div data-scroll-pct="100" aria-hidden="true"></div>

--- a/src/app/modules/public/como-funciona/como-funciona.component.ts
+++ b/src/app/modules/public/como-funciona/como-funciona.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ChurchesService } from '../../../core/services/churches.service';
+import { ClarityService } from '../../../core/services/clarity.service';
 
 @Component({
   selector: 'app-como-funciona',
@@ -10,13 +11,15 @@ import { ChurchesService } from '../../../core/services/churches.service';
   templateUrl: './como-funciona.component.html',
   styleUrl: './como-funciona.component.scss',
 })
-export class ComoFuncionaComponent implements OnInit {
+export class ComoFuncionaComponent implements OnInit, AfterViewInit, OnDestroy {
   private _church = inject(ChurchesService);
+  private _clarity = inject(ClarityService);
+  private _scrollObserver: IntersectionObserver | null = null;
 
   stats = {
     cidades: 213,
-    paroquias: 1674,
-    horarios: 8535,
+    paroquias: 2000,
+    horarios: 9100,
     estados: 26,
   };
 
@@ -61,6 +64,34 @@ export class ComoFuncionaComponent implements OnInit {
         if (d.quantidadesIgrejas)  this.stats.paroquias = d.quantidadesIgrejas;
         if (d.quantidadeMissas)    this.stats.horarios  = d.quantidadeMissas;
       },
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this._initScrollTracking();
+  }
+
+  ngOnDestroy(): void {
+    this._scrollObserver?.disconnect();
+  }
+
+  private _initScrollTracking(): void {
+    const sentinels = [25, 50, 75, 100];
+    this._scrollObserver = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const pct = entry.target.getAttribute('data-scroll-pct');
+          if (pct) {
+            this._clarity.track(`scroll_${pct}`);
+            this._scrollObserver?.unobserve(entry.target);
+          }
+        }
+      });
+    }, { threshold: 0 });
+
+    sentinels.forEach(pct => {
+      const el = document.querySelector(`[data-scroll-pct="${pct}"]`);
+      if (el) this._scrollObserver!.observe(el);
     });
   }
 

--- a/src/app/modules/public/home/city/city.component.html
+++ b/src/app/modules/public/home/city/city.component.html
@@ -27,7 +27,7 @@
         <p class="city-header__sub" *ngIf="!isLoading && igrejas.length">
           {{ igrejasFiltradas.length }}
           <ng-container *ngIf="temFiltroAtivo"> de {{ igrejas.length }}</ng-container>
-          missa{{ igrejasFiltradas.length !== 1 ? 's' : '' }} encontrada{{ igrejasFiltradas.length !== 1 ? 's' : '' }}
+          igreja{{ igrejasFiltradas.length !== 1 ? 's' : '' }} encontrada{{ igrejasFiltradas.length !== 1 ? 's' : '' }}
         </p>
       </div>
     </div>

--- a/src/app/modules/public/home/city/city.component.scss
+++ b/src/app/modules/public/home/city/city.component.scss
@@ -346,12 +346,13 @@ $primary-light: #fff4ed;
     &:hover { transform: none; box-shadow: none; }
   }
 
-  // Coluna esquerda: horário
+  // Coluna esquerda: horário — largura fixa para que todos os cards alinhem igual,
+  // independentemente de ter ou não o chip de countdown.
   &__time-col {
     display: flex;
     flex-direction: column;
     align-items: center;
-    min-width: 3.75rem;
+    width: 5rem;
     flex-shrink: 0;
     padding-top: 0.125rem;
   }
@@ -388,19 +389,18 @@ $primary-light: #fff4ed;
     padding: 0.15rem 0.375rem;
     margin-top: 0.375rem;
     text-align: center;
-    white-space: nowrap;
+    white-space: normal;
+    width: 100%;
   }
 
   // Imagem (thumbnail menor no mobile, maior a partir de 480px)
   &__img-wrap {
     display: block;
     flex-shrink: 0;
-  }
-
-  &__img {
+    // Dimensões explícitas garantem que o placeholder (app-church-placeholder com
+    // :host { width:100%; height:100% }) não expanda além do espaço reservado.
     width: 3.25rem;
     height: 3.25rem;
-    object-fit: cover;
     border-radius: 0.625rem;
     border: 1px solid #f0f0f0;
     overflow: hidden;
@@ -410,6 +410,13 @@ $primary-light: #fff4ed;
       height: 5rem;
       border-radius: 0.75rem;
     }
+  }
+
+  &__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   // Corpo

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -12,6 +12,7 @@ import { DistanceChipComponent } from "../../../../shared/components/distance-ch
 import { ChurchPlaceholderComponent } from "../../../../shared/components/church-placeholder/church-placeholder.component";
 import { getNextOccurrenceMinutes, formatMassTime, getCountdownLabel } from "../../../../shared/utils/mass-time.utils";
 import { AnalyticsService } from "../../../../core/services/analytics.service";
+import { ClarityService } from "../../../../core/services/clarity.service";
 import { CityMapComponent, MapChurch } from "../../../../shared/components/city-map/city-map.component";
 
 const PERIODOS: Record<string, { de: number; ate: number; label: string }> = {
@@ -64,6 +65,7 @@ export class CityComponent implements OnInit, OnDestroy {
   private _church = inject(ChurchesService);
   private _seo = inject(SeoService);
   private _analytics = inject(AnalyticsService);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   uf = "";
@@ -151,7 +153,21 @@ export class CityComponent implements OnInit, OnDestroy {
         this.aplicarFiltros();
         this._analytics.searchPerformed(this.cidadeNome, this.uf);
 
-        if (this.igrejas.length === 0) this.naoEncontrado = true;
+        // Tags Clarity de contexto
+        this._clarity.tag('cidade', this.cidadeNome);
+        this._clarity.tag('estado', this.uf?.toUpperCase());
+        this._clarity.tag('qtd_resultados', String(this.igrejas.length));
+
+        // Marca o momento da busca para medir tempo até encontrar uma missa
+        localStorage.setItem('bm_ts_busca', String(Date.now()));
+
+        if (this.igrejas.length === 0) {
+          this.naoEncontrado = true;
+          this._clarity.track('nenhum_resultado', {
+            cidade: this.cidadeNome,
+            estado: this.uf?.toUpperCase(),
+          });
+        }
 
         const ufUpper = this.uf?.toUpperCase();
         const totalIgrejas = this.igrejas.length;

--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -276,6 +276,7 @@
             <a *ngIf="churchInfo.contato?.telefoneWhatsApp"
                [href]="'https://wa.me/55' + churchInfo.contato.dddWhatsApp + churchInfo.contato.telefoneWhatsApp"
                target="_blank" rel="noopener"
+               (click)="trackObjetivoAlcancado('whatsapp')"
                class="contact-row">
               <div class="contact-row__icon contact-row__icon--green">
                 <i class="pi pi-whatsapp"></i>
@@ -289,6 +290,7 @@
             <!-- Telefone -->
             <a *ngIf="churchInfo.contato?.telefone"
                [href]="'tel:' + churchInfo.contato.ddd + churchInfo.contato.telefone"
+               (click)="trackObjetivoAlcancado('ligar')"
                class="contact-row">
               <div class="contact-row__icon contact-row__icon--blue">
                 <i class="pi pi-phone"></i>
@@ -315,6 +317,7 @@
             <!-- Site -->
             <a *ngIf="churchInfo.contato?.site"
                [href]="churchInfo.contato.site" target="_blank" rel="noopener"
+               (click)="trackObjetivoAlcancado('site')"
                class="contact-row">
               <div class="contact-row__icon contact-row__icon--purple">
                 <i class="pi pi-globe"></i>
@@ -335,6 +338,7 @@
                 <div class="flex gap-3 mt-1">
                   <a *ngFor="let rede of churchInfo.redesSociais" [href]="rede.url"
                      target="_blank" rel="noopener"
+                     (click)="trackObjetivoAlcancado(getSocialTrackName(rede.url))"
                      class="text-2xl text-gray-500 hover:text-primary transition-colors"
                      [attr.aria-label]="rede.nomeRedeSocial">
                     <i [ngClass]="getSocialIcon(rede.url)"></i>

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -15,6 +15,7 @@ import { CountdownChipComponent } from "../../../../shared/components/countdown-
 import { ChurchPlaceholderComponent } from "../../../../shared/components/church-placeholder/church-placeholder.component";
 import { getNextOccurrenceMinutes, formatMassTime, getCountdownLabel } from "../../../../shared/utils/mass-time.utils";
 import { AnalyticsService } from "../../../../core/services/analytics.service";
+import { ClarityService } from "../../../../core/services/clarity.service";
 
 @Component({
   selector: "app-details",
@@ -40,6 +41,7 @@ export class DetailsComponent implements OnInit {
   _location = inject(Location);
   _sanitizer = inject(DomSanitizer);
   private _analytics = inject(AnalyticsService);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   nomeUnico: string | null = null;
@@ -94,6 +96,7 @@ export class DetailsComponent implements OnInit {
         if (igreja.id) this.carregarResumoConfirmacoes(igreja.id);
         this._loadFavoritaState();
         this._analytics.churchView(igreja.nome, igreja.endereco?.localidade ?? '', igreja.endereco?.uf ?? '');
+        this._aplicarClarityTags(igreja);
 
         const cidadeUf = igreja.endereco?.localidade
           ? `${igreja.endereco.localidade}${igreja.endereco?.uf ? '/' + igreja.endereco.uf : ''}`
@@ -111,6 +114,58 @@ export class DetailsComponent implements OnInit {
       error: (error) => {
         this._toast.add({ severity: "error", summary: "Erro", detail: "Erro ao carregar dados da igreja." });
       },
+    });
+  }
+
+  // ── Clarity ────────────────────────────────────────────────────────────────
+
+  private _aplicarClarityTags(igreja: any): void {
+    const end = igreja.endereco ?? {};
+    const missas: any[] = igreja.missas ?? [];
+    const redes: any[] = igreja.redesSociais ?? [];
+    const contato = igreja.contato ?? {};
+
+    const temFoto = !!igreja.imagemUrl;
+    const temTelefone = !!(contato.telefone || contato.telefoneWhatsApp);
+    const temSite = !!contato.site;
+    const temInstagram = redes.some((r: any) => r.tipoRedeSocial === 2);
+    const temFacebook = redes.some((r: any) => r.tipoRedeSocial === 1);
+    const qtdMissas = missas.length;
+    const dadosCompletos = temFoto && qtdMissas > 0 && temTelefone;
+
+    this._clarity.tag('cidade', end.localidade ?? '');
+    this._clarity.tag('estado', end.uf ?? '');
+    this._clarity.tag('igrejaId', String(igreja.id ?? ''));
+    this._clarity.tag('tipo_igreja', igreja.tipo ?? 'desconhecido');
+    this._clarity.tag('paroquia_ou_nao', (igreja.tipo ?? '') === 'Paróquia' ? 'sim' : 'nao');
+    this._clarity.tag('tem_foto', temFoto ? 'sim' : 'nao');
+    this._clarity.tag('tem_telefone', temTelefone ? 'sim' : 'nao');
+    this._clarity.tag('tem_site', temSite ? 'sim' : 'nao');
+    this._clarity.tag('tem_instagram', temInstagram ? 'sim' : 'nao');
+    this._clarity.tag('tem_facebook', temFacebook ? 'sim' : 'nao');
+    this._clarity.tag('possui_missas', qtdMissas > 0 ? 'sim' : 'nao');
+    this._clarity.tag('possui_redes', (temInstagram || temFacebook) ? 'sim' : 'nao');
+    this._clarity.tag('qtd_missas', String(qtdMissas));
+    this._clarity.tag('dados_completos', dadosCompletos ? 'sim' : 'nao');
+    this._clarity.tag('origem_navegacao', this._clarity.navOrigem(''));
+
+    // Tempo decorrido desde a busca inicial
+    const ts = Number(localStorage.getItem('bm_ts_busca'));
+    if (ts > 0) {
+      const segundos = Math.round((Date.now() - ts) / 1000);
+      if (segundos > 0 && segundos < 600) {
+        this._clarity.track('tempo_para_encontrar', { segundos });
+      }
+      localStorage.removeItem('bm_ts_busca');
+    }
+  }
+
+  trackObjetivoAlcancado(acao: string): void {
+    const igreja = this.churchInfo;
+    this._clarity.track('objetivo_alcancado', {
+      acao,
+      igrejaId: String(igreja?.id ?? ''),
+      cidade: igreja?.endereco?.localidade ?? '',
     });
   }
 
@@ -259,6 +314,7 @@ export class DetailsComponent implements OnInit {
       });
       this.isFavorita = true;
       this._analytics.favoriteParishSaved(this.churchInfo.nome);
+      this.trackObjetivoAlcancado('favoritar');
       this._toast.add({ severity: 'success', summary: 'Adicionada aos favoritos!', detail: this.churchInfo.nome });
     }
     localStorage.setItem('buscamissa_favoritas', JSON.stringify(favoritas));
@@ -294,6 +350,7 @@ export class DetailsComponent implements OnInit {
 
   trackDirections(): void {
     this._analytics.getDirections(this.churchInfo?.nome ?? '');
+    this.trackObjetivoAlcancado('tracar_rota');
   }
 
   get linkGoogleMaps(): string {
@@ -339,6 +396,14 @@ export class DetailsComponent implements OnInit {
     return 'pi pi-globe';
   }
 
+  getSocialTrackName(url: string): string {
+    if (url.includes('facebook.com')) return 'facebook';
+    if (url.includes('instagram.com')) return 'instagram';
+    if (url.includes('youtube.com')) return 'youtube';
+    if (url.includes('tiktok.com')) return 'tiktok';
+    return 'rede_social';
+  }
+
 
   voltar(): void {
     this._location.back();
@@ -348,6 +413,7 @@ export class DetailsComponent implements OnInit {
   compartilhar(): void {
     const url = this.shareUrl;
     const nav = navigator as any;
+    this.trackObjetivoAlcancado('compartilhar');
     if (nav.share) {
       nav.share({ title: this.churchInfo?.nome, text: `Horários de missa — ${this.churchInfo?.nome}`, url }).catch(() => {});
     } else {

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -17,8 +17,8 @@
 
     <!-- Mini badges de prova social -->
     <div class="hero-v2__provas" *ngIf="!resultsMode">
-      <span class="hero-v2__prova"><i class="pi pi-home"></i> 1.200+ paróquias</span>
-      <span class="hero-v2__prova"><i class="pi pi-clock"></i> 2.700+ horários de missa</span>
+      <span class="hero-v2__prova"><i class="pi pi-home"></i> 2.000+ igrejas</span>
+      <span class="hero-v2__prova"><i class="pi pi-clock"></i> 9.100+ horários de missa</span>
       <span class="hero-v2__prova"><i class="pi pi-check-circle"></i> Atualizado diariamente</span>
     </div>
 
@@ -158,11 +158,11 @@
         <span class="stats-strip__label">cidades</span>
       </div>
       <div class="stats-strip__item">
-        <span class="stats-strip__num stats-strip__num--orange">1.200+</span>
-        <span class="stats-strip__label">paróquias</span>
+        <span class="stats-strip__num stats-strip__num--orange">2.000+</span>
+        <span class="stats-strip__label">igrejas</span>
       </div>
       <div class="stats-strip__item">
-        <span class="stats-strip__num stats-strip__num--blue">2.700+</span>
+        <span class="stats-strip__num stats-strip__num--blue">9.100+</span>
         <span class="stats-strip__label">horários de missa</span>
       </div>
       <div class="stats-strip__item">
@@ -199,7 +199,9 @@
           *ngFor="let card of proximasFiltradas"
           [data]="card"
           [urgency]="getUrgency(card)"
+          [isFavorite]="ehFavorita(card.churchId)"
           (cardClick)="onCardClick($event)"
+          (navigateClick)="onNavigateClick($event)"
           (favoriteClick)="onFavoriteClick($event)"
         />
       </div>
@@ -424,6 +426,19 @@
     </div>
     <a routerLink="/cidades" class="confirmar-banner__btn shrink-0">
       <i class="pi pi-thumbs-up"></i> Quero confirmar
+    </a>
+  </div>
+
+  <!-- ══ INSTAGRAM ══ -->
+  <div class="home-instagram">
+    <a href="https://www.instagram.com/buscamissa/" target="_blank" rel="noopener noreferrer" class="home-instagram__link">
+      <svg class="home-instagram__icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="2" y="2" width="20" height="20" rx="5.5" stroke="currentColor" stroke-width="1.8"/>
+        <circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="1.8"/>
+        <circle cx="17.5" cy="6.5" r="1" fill="currentColor"/>
+      </svg>
+      <span>Siga o BuscaMissa no Instagram</span>
+      <i class="pi pi-arrow-right" style="font-size:0.75rem"></i>
     </a>
   </div>
 

--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -644,3 +644,35 @@ $texto-2: #6b7280;
 .social-icons { display: flex; justify-content: center; gap: 10px; margin-top: 8px; }
 .icon-link { font-size: 1.2rem; color: #555; transition: color 0.3s; &:hover { color: #000; } }
 .text-lg { font-size: 1.5rem; }
+
+.home-instagram {
+  margin-top: 1.25rem;
+  text-align: center;
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid #e2e8f0;
+    background: #fff;
+    color: #64748b;
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+
+    &:hover {
+      border-color: #e1306c;
+      color: #e1306c;
+      background: #fff5f8;
+    }
+  }
+
+  &__icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+  }
+}

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -477,6 +477,16 @@ export class HomeComponent {
     );
   }
 
+  onNavigateClick(card: MassCardData): void {
+    const lat = card.latitude;
+    const lng = card.longitude;
+    const url = lat && lng
+      ? `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`
+      : `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(card.churchName)}`;
+    window.open(url, '_blank', 'noopener');
+    this._analytics.getDirections(card.churchName);
+  }
+
   onFavoriteClick(card: MassCardData): void {
     if (this.ehFavorita(card.churchId)) {
       this.removerFavorita(card.churchId);
@@ -495,7 +505,7 @@ export class HomeComponent {
       diaSemana: card.mass.diaSemana,
       horario: card.mass.horario,
     };
-    this.paroquiasFavoritas.push(novaFavorita);
+    this.paroquiasFavoritas = [...this.paroquiasFavoritas, novaFavorita];
     this._salvarFavoritas();
     this._analytics.favoriteParishSaved(card.churchName);
   }

--- a/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
+++ b/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
@@ -4,6 +4,7 @@ import { RouterModule, Router, NavigationEnd } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { PrimeNgModule } from '../../../shared/primeng.module';
 import { SeoService } from '../../../core/services/seo.service';
+import { ClarityService } from '../../../core/services/clarity.service';
 import { getCountdownLabel } from '../../../shared/utils/mass-time.utils';
 import { getMissaAgoraUrgency } from '../../../shared/utils/mass-time.utils';
 import { Subscription } from 'rxjs';
@@ -32,6 +33,7 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
   private _seo = inject(SeoService);
   private _router = inject(Router);
   private _toast = inject(MessageService);
+  private _clarity = inject(ClarityService);
 
   igrejas: IgrejaFavorita[] = [];
   private _navSub: Subscription | null = null;
@@ -43,6 +45,7 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
       canonical: 'https://buscamissa.com.br/minhas-igrejas',
     });
     this._carregarIgrejas();
+    this._clarity.track('favoritos_lista_aberta');
 
     this._navSub = this._router.events
       .pipe(filter(e => e instanceof NavigationEnd))
@@ -87,6 +90,7 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
     const filtradas = igrejas.filter((i: any) => i.id !== id);
     localStorage.setItem('buscamissa_favoritas', JSON.stringify(filtradas));
 
+    this._clarity.track('favorito_removido', { igrejaId: String(id) });
     this._carregarIgrejas();
     this._toast.add({
       severity: 'success',
@@ -96,6 +100,7 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
   }
 
   irParaIgreja(igreja: IgrejaFavorita): void {
+    this._clarity.track('favorito_clicado', { igrejaId: String(igreja.id) });
     this._router.navigate(['/paroquia', igreja.uf.toLowerCase(), igreja.cidadeSlug, igreja.slug]);
   }
 }

--- a/src/app/modules/public/missa-agora/missa-agora.component.html
+++ b/src/app/modules/public/missa-agora/missa-agora.component.html
@@ -139,6 +139,7 @@
         *ngFor="let card of missas"
         [data]="card"
         [urgency]="getUrgency(card)"
+        [isFavorite]="ehFavorita(card.churchId)"
         (cardClick)="onCardClick($event)"
         (navigateClick)="onNavigate($event)"
         (favoriteClick)="onFavorite($event)"

--- a/src/app/modules/public/missa-agora/missa-agora.component.ts
+++ b/src/app/modules/public/missa-agora/missa-agora.component.ts
@@ -32,6 +32,7 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
   geoStatus: GeoStatus = 'idle';
   permissaoNegadaPeloBrowser = false;
   missas: MassCardData[] = [];
+  favoritasIds = new Set<number>();
   isLoading = false;
   cidadeDetectada: string | null = null;
   horaAtual = '';
@@ -56,7 +57,15 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
       : this.cidadesFallback;
   }
 
+  private _loadFavoritas(): void {
+    try {
+      const arr = JSON.parse(localStorage.getItem('buscamissa_favoritas') || '[]');
+      this.favoritasIds = new Set(Array.isArray(arr) ? arr.map((f: any) => f.id) : []);
+    } catch { this.favoritasIds = new Set(); }
+  }
+
   ngOnInit(): void {
+    this._loadFavoritas();
     this._seo.update({
       title: 'Missa Agora | BuscaMissa',
       description: 'Veja as missas que estão acontecendo agora ou nas próximas 2 horas perto de você.',
@@ -172,6 +181,10 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
     this._analytics.getDirections(card.churchName);
   }
 
+  ehFavorita(churchId: number): boolean {
+    return this.favoritasIds.has(churchId);
+  }
+
   onFavorite(card: MassCardData): void {
     try {
       const raw = localStorage.getItem('buscamissa_favoritas');
@@ -195,6 +208,13 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
       }
 
       localStorage.setItem('buscamissa_favoritas', JSON.stringify(favoritas));
+      // atualiza o Set reativo para que o ícone mude imediatamente
+      if (jaExiste) {
+        this.favoritasIds.delete(card.churchId);
+      } else {
+        this.favoritasIds.add(card.churchId);
+      }
+      this.favoritasIds = new Set(this.favoritasIds); // nova referência → trigger change detection
 
       this._analytics.favoriteParishSaved(card.churchName);
       this._toast.add({

--- a/src/app/modules/public/register-church/send-code/send-code.component.html
+++ b/src/app/modules/public/register-church/send-code/send-code.component.html
@@ -23,14 +23,14 @@
       <p-inputgroup-addon>
         <i class="pi pi-user"></i>
       </p-inputgroup-addon>
-      <input pInputText formControlName="nome" placeholder="Nome" />
+      <input pInputText formControlName="nome" placeholder="Nome" (blur)="onNomeBlur()" />
     </p-inputgroup>
 
     <p-inputgroup>
       <p-inputgroup-addon>
         <i class="pi pi-at"></i>
       </p-inputgroup-addon>
-      <input pInputText formControlName="email" placeholder="E-mail" />
+      <input pInputText formControlName="email" placeholder="E-mail" (blur)="onEmailBlur()" />
     </p-inputgroup>
 
     <div class="flex items-center">

--- a/src/app/modules/public/register-church/send-code/send-code.component.ts
+++ b/src/app/modules/public/register-church/send-code/send-code.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import { Component, inject, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ChurchesService } from "../../../../core/services/churches.service";
+import { ClarityService } from "../../../../core/services/clarity.service";
 import {
   FormBuilder,
   FormGroup,
@@ -31,6 +32,7 @@ export class SendCodeComponent implements OnInit {
   private _router = inject(Router);
   private _service = inject(ChurchesService);
   private _toast = inject(MessageService);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   controleId!: number;
@@ -40,6 +42,7 @@ export class SendCodeComponent implements OnInit {
 
   ngOnInit(): void {
     this.controleId = Number(this._route.snapshot.paramMap.get("controleId"));
+    this._clarity.track('contrib_tela_identificacao');
     this.form = this._fb.group({
       nome: ["", Validators.required],
       email: ["", [Validators.required, Validators.email]],
@@ -48,7 +51,16 @@ export class SendCodeComponent implements OnInit {
     });
   }
 
+  onNomeBlur(): void {
+    if (this.form.get('nome')?.value) this._clarity.track('contrib_nome_preenchido');
+  }
+
+  onEmailBlur(): void {
+    if (this.form.get('email')?.valid) this._clarity.track('contrib_email_preenchido');
+  }
+
   generateValidationCode(): void {
+    this._clarity.track('contrib_solicitar_codigo_clicado');
     this.isLoading = true;
     if (this.form.invalid) {
       this._toast.add({ severity: 'info', summary: 'Aviso!', detail: "Por favor, preencha todos os campos obrigatórios." });
@@ -64,6 +76,7 @@ export class SendCodeComponent implements OnInit {
     this._service.generateCode(body).subscribe({
       next: (response: any) => {
         if (response?.data?.mensagemTela) {
+          this._clarity.track('contrib_codigo_enviado');
           this._router.navigate(["/validar"], {
             queryParams: {
               email: body.email,

--- a/src/app/modules/public/register-church/validate-code/validate-code.component.ts
+++ b/src/app/modules/public/register-church/validate-code/validate-code.component.ts
@@ -8,6 +8,7 @@ import {
   Validators,
 } from "@angular/forms";
 import { ChurchesService } from "../../../../core/services/churches.service";
+import { ClarityService } from "../../../../core/services/clarity.service";
 import { ActivatedRoute, Router } from "@angular/router";
 import { PrimeNgModule } from "../../../../shared/primeng.module";
 import { LoadingComponent } from "../../../../core/components/loading/loading.component";
@@ -32,6 +33,7 @@ export class ValidateCodeComponent {
   private _router = inject(Router);
   private _service = inject(ChurchesService);
   private _toast = inject(MessageService);
+  private _clarity = inject(ClarityService);
 
   isLoading = false;
   form: FormGroup;
@@ -52,10 +54,11 @@ export class ValidateCodeComponent {
       this.email = params["email"];
       this.controleId = params["controleId"];
     });
-    console.log(this.controleId);
+    this._clarity.track('contrib_tela_confirmacao');
   }
 
   validateCode(): void {
+    this._clarity.track('contrib_codigo_confirmado');
     this.isLoading = true;
     if (this.form.invalid) {
       this._toast.add({
@@ -75,6 +78,7 @@ export class ValidateCodeComponent {
 
     this._service.validateCode(payload).subscribe({
       next: (response: any) => {
+        this._clarity.track('contrib_sucesso');
         this._toast.add({
           severity: "success",
           summary: "Aviso!",
@@ -86,6 +90,7 @@ export class ValidateCodeComponent {
         this.isLoading = false;
       },
       error: (error) => {
+        this._clarity.track('contrib_erro_codigo');
         this._toast.add({
           severity: "info",
           summary: "Aviso!",

--- a/src/app/shared/components/mass-time-card/mass-time-card.component.html
+++ b/src/app/shared/components/mass-time-card/mass-time-card.component.html
@@ -40,10 +40,12 @@
     <button
       type="button"
       class="mass-time-card__btn mass-time-card__btn--favorite"
+      [class.mass-time-card__btn--favorite-ativo]="isFavorite"
       (click)="onFavorite($event)"
-      aria-label="Favoritar"
+      [attr.aria-pressed]="isFavorite"
+      [attr.aria-label]="isFavorite ? 'Remover dos favoritos' : 'Favoritar'"
     >
-      <i class="pi pi-heart"></i>
+      <i class="pi" [ngClass]="isFavorite ? 'pi-heart-fill' : 'pi-heart'"></i>
     </button>
   </div>
 </article>

--- a/src/app/shared/components/mass-time-card/mass-time-card.component.scss
+++ b/src/app/shared/components/mass-time-card/mass-time-card.component.scss
@@ -125,6 +125,15 @@
       &:hover .pi {
         color: #bc5d10;
       }
+
+      &-ativo {
+        border-color: #bc5d10;
+        background: #fcf7f3;
+
+        .pi {
+          color: #bc5d10;
+        }
+      }
     }
   }
 }

--- a/src/app/shared/components/mass-time-card/mass-time-card.component.ts
+++ b/src/app/shared/components/mass-time-card/mass-time-card.component.ts
@@ -24,6 +24,8 @@ export class MassTimeCardComponent implements OnChanges {
   @Input({ required: true }) data!: MassCardData;
   /** Usado na tela /missa-agora para colorir a borda por urgência */
   @Input() urgency: MassUrgency = null;
+  /** Estado de favorito — controla o ícone de coração */
+  @Input() isFavorite = false;
 
   @Output() navigateClick = new EventEmitter<MassCardData>();
   @Output() favoriteClick = new EventEmitter<MassCardData>();

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,15 @@
     <link rel="preconnect" href="https://busca-missa.azurewebsites.net" />
     <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
 
+    <!-- Microsoft Clarity -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "xctugfdm46");
+    </script>
+
     <!-- Google Analytics (GA4) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-CGY94P6KSN"></script>
     <script>


### PR DESCRIPTION
- Microsoft Clarity: snippet, ClarityService, tags globais (dispositivo/idioma/novo_usuario/origem_sessao), tags ricas na página da igreja, eventos objetivo_alcancado/nenhum_resultado/tempo_para_encontrar, funil completo de contribuição (12 etapas), scroll depth em Como Funciona, favoritos rastreados
- Fix botão 'Como chegar' no missa-agora (evento navigateClick faltando no template)
- Fix botão favorito não ficando pressionado (isFavorite @Input + new Set() para trigger change detection)
- Fix layout cards sem missa na página de cidade (time-col width fixa 5rem; countdown chip com white-space normal)
- Texto '52 missas encontradas' → '52 igrejas encontradas' na página de cidade
- Stats atualizados: 2.000+ igrejas, 9.100+ horários de missa (home + como-funciona)
- Link Instagram @buscamissa adicionado no rodapé da home