### PR TITLE
redes sociais dinâmicas via endpoint da API

### DIFF
--- a/src/app/core/services/redes-sociais.service.ts
+++ b/src/app/core/services/redes-sociais.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from "@angular/common/http";
+import { inject, Injectable } from "@angular/core";
+import { Observable, shareReplay } from "rxjs";
+
+export interface TipoRedeSocial {
+  id: number;
+  nome: string;
+  urlBase: string;
+  icone: string;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class RedesSociaisService {
+  private http = inject(HttpClient);
+
+  private tipos$: Observable<TipoRedeSocial[]> = this.http
+    .get<TipoRedeSocial[]>("v1/RedeSocial/tipos")
+    .pipe(shareReplay(1));
+
+  obterTipos(): Observable<TipoRedeSocial[]> {
+    return this.tipos$;
+  }
+}

--- a/src/app/modules/public/church/components/church-form/church-form.component.html
+++ b/src/app/modules/public/church/components/church-form/church-form.component.html
@@ -247,29 +247,11 @@
 
   <p-fieldset legend="Redes sociais" *ngIf="!isEditMode">
     <div class="card grid grid-cols-1 md:grid-cols-2 gap-4">
-      <p-inputgroup>
+      <p-inputgroup *ngFor="let tipo of tiposRedeSocial">
         <p-inputgroup-addon>
-          <i class="pi pi-facebook"></i>
+          <i [class]="tipo.icone"></i>
         </p-inputgroup-addon>
-        <input pInputText formControlName="facebook" placeholder="Facebook" />
-      </p-inputgroup>
-      <p-inputgroup>
-        <p-inputgroup-addon>
-          <i class="pi pi-instagram"></i>
-        </p-inputgroup-addon>
-        <input pInputText formControlName="instagram" placeholder="Instagram" />
-      </p-inputgroup>
-      <p-inputgroup>
-        <p-inputgroup-addon>
-          <i class="pi pi-youtube"></i>
-        </p-inputgroup-addon>
-        <input pInputText formControlName="youtube" placeholder="YouTube" />
-      </p-inputgroup>
-      <p-inputgroup>
-        <p-inputgroup-addon>
-          <i class="pi pi-tiktok"></i>
-        </p-inputgroup-addon>
-        <input pInputText formControlName="tiktok" placeholder="TikTok" />
+        <input pInputText [formControlName]="tipo.nome.toLowerCase()" [placeholder]="tipo.nome" />
       </p-inputgroup>
     </div>
   </p-fieldset>

--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -24,6 +24,7 @@ import { CommonModule, DatePipe } from "@angular/common";
 import { PrimeNgModule } from "../../../../../shared/primeng.module";
 import { ChurchFormData, Mass } from "../../models/church.model";
 import { MessageService } from "primeng/api";
+import { RedesSociaisService, TipoRedeSocial } from "../../../../../core/services/redes-sociais.service";
 
 interface TypeChurchOption {
   name: string;
@@ -40,6 +41,9 @@ interface TypeChurchOption {
 })
 export class ChurchFormComponent implements OnInit, OnChanges {
   private messageService = inject(MessageService);
+  private redesSociaisService = inject(RedesSociaisService);
+
+  tiposRedeSocial: TipoRedeSocial[] = [];
   @Input() initialData: ChurchFormData | null = null;
   @Input() isSaving: boolean = false;
   @Input() isEditMode: boolean = false; // Para desabilitar CEP na edição
@@ -79,6 +83,19 @@ export class ChurchFormComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.initForm();
+
+    this.redesSociaisService.obterTipos().subscribe((tipos) => {
+      this.tiposRedeSocial = tipos;
+      tipos.forEach((t) => {
+        const key = t.nome.toLowerCase();
+        if (!this.form.contains(key)) {
+          this.form.addControl(key, this.fb.control(""));
+        }
+      });
+      if (this.initialData) {
+        this.populateForm(this.initialData);
+      }
+    });
 
     if (this.initialData) {
       this.populateForm(this.initialData);
@@ -144,10 +161,6 @@ export class ChurchFormComponent implements OnInit, OnChanges {
       whatsapp: [""],
       emailContato: ["", Validators.email],
       missas: this.fb.array([], Validators.required), // Pelo menos uma missa?
-      facebook: [""],
-      instagram: [""],
-      tiktok: [""],
-      youtube: [""],
       imagem: [""], // Armazena base64
     });
   }

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -19,6 +19,7 @@ import {
 import { ChurchFormComponent } from "../../components/church-form/church-form.component";
 import { PrimeNgModule } from "../../../../../shared/primeng.module";
 import { ChurchesService } from "../../../../../core/services/churches.service";
+import { RedesSociaisService, TipoRedeSocial } from "../../../../../core/services/redes-sociais.service";
 
 @Component({
   selector: "app-church-registration-page",
@@ -37,11 +38,14 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   private confirmationService = inject(ConfirmationService);
   private datePipe = inject(DatePipe);
   private cd = inject(ChangeDetectorRef);
+  private redesSociaisService = inject(RedesSociaisService);
 
+  private tiposRedeSocial: TipoRedeSocial[] = [];
   isLoading = false;
   isCepLoading = false;
 
   ngAfterViewInit(): void {
+    this.redesSociaisService.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
     this.cd.detectChanges();
   }
 
@@ -227,22 +231,18 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
         telefoneWhatsApp: whatsappLimpo.substring(2),
         emailContato: formData.emailContato,
       },
-      redesSociais: [
-        ...(formData.facebook
-          ? [{ tipoRedeSocial: 1, nomeRedeSocial: formData.facebook }]
-          : []),
-        ...(formData.instagram
-          ? [{ tipoRedeSocial: 2, nomeRedeSocial: formData.instagram }]
-          : []),
-        ...(formData.youtube
-          ? [{ tipoRedeSocial: 3, nomeRedeSocial: formData.youtube }]
-          : []),
-        ...(formData.tiktok
-          ? [{ tipoRedeSocial: 4, nomeRedeSocial: formData.tiktok }]
-          : []),
-      ],
+      redesSociais: this._mapearRedesSociais(formData),
     };
     return payload;
+  }
+
+  private _mapearRedesSociais(formData: any) {
+    return this.tiposRedeSocial
+      .map((tipo) => ({
+        tipoRedeSocial: tipo.id,
+        nomeRedeSocial: (formData[tipo.nome.toLowerCase()] as string) ?? "",
+      }))
+      .filter(({ nomeRedeSocial }) => !!nomeRedeSocial.trim());
   }
 
   private showErrorToast(error: HttpErrorResponse, summary: string): void {

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -13,6 +13,8 @@ import { ChurchPlaceholderComponent } from "../../../../shared/components/church
 import { getNextOccurrenceMinutes, formatMassTime, getCountdownLabel } from "../../../../shared/utils/mass-time.utils";
 import { AnalyticsService } from "../../../../core/services/analytics.service";
 import { CityMapComponent, MapChurch } from "../../../../shared/components/city-map/city-map.component";
+import { RedesSociaisService, TipoRedeSocial } from "../../../../core/services/redes-sociais.service";
+import { getSocialIconFromTipos } from "../../../../shared/utils/social-icon.utils";
 
 const PERIODOS: Record<string, { de: number; ate: number; label: string }> = {
   manha: { de: 5 * 60, ate: 11 * 60 + 59, label: "Manhã" },
@@ -64,6 +66,8 @@ export class CityComponent implements OnInit, OnDestroy {
   private _church = inject(ChurchesService);
   private _seo = inject(SeoService);
   private _analytics = inject(AnalyticsService);
+  private _redesSociais = inject(RedesSociaisService);
+  tiposRedeSocial: TipoRedeSocial[] = [];
 
   isLoading = false;
   uf = "";
@@ -117,6 +121,8 @@ export class CityComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this._redesSociais.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
+
     this._route.params.subscribe((params) => {
       this.uf = params["uf"];
       this.cidade = params["cidade"];
@@ -482,11 +488,7 @@ export class CityComponent implements OnInit, OnDestroy {
   }
 
   getSocialIcon(url: string): string {
-    if (url.includes("facebook.com")) return "pi pi-facebook";
-    if (url.includes("instagram.com")) return "pi pi-instagram";
-    if (url.includes("youtube.com")) return "pi pi-youtube";
-    if (url.includes("tiktok.com")) return "pi pi-tiktok";
-    return "pi pi-globe";
+    return getSocialIconFromTipos(url, this.tiposRedeSocial);
   }
 
   // ── SEO ───────────────────────────────────────────────────────────────────

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -15,6 +15,8 @@ import { CountdownChipComponent } from "../../../../shared/components/countdown-
 import { ChurchPlaceholderComponent } from "../../../../shared/components/church-placeholder/church-placeholder.component";
 import { getNextOccurrenceMinutes, formatMassTime, getCountdownLabel } from "../../../../shared/utils/mass-time.utils";
 import { AnalyticsService } from "../../../../core/services/analytics.service";
+import { RedesSociaisService, TipoRedeSocial } from "../../../../core/services/redes-sociais.service";
+import { getSocialIconFromTipos } from "../../../../shared/utils/social-icon.utils";
 
 @Component({
   selector: "app-details",
@@ -40,7 +42,9 @@ export class DetailsComponent implements OnInit {
   _location = inject(Location);
   _sanitizer = inject(DomSanitizer);
   private _analytics = inject(AnalyticsService);
+  private _redesSociais = inject(RedesSociaisService);
 
+  tiposRedeSocial: TipoRedeSocial[] = [];
   isLoading = false;
   nomeUnico: string | null = null;
   churchInfo: any;
@@ -58,6 +62,8 @@ export class DetailsComponent implements OnInit {
   isFavorita = false;
 
   ngOnInit(): void {
+    this._redesSociais.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
+
     this._route.params.subscribe((params) => {
       const uf = params["uf"];
       const cidade = params["cidade"];
@@ -332,11 +338,7 @@ export class DetailsComponent implements OnInit {
   }
 
   getSocialIcon(url: string): string {
-    if (url.includes('facebook.com')) return 'pi pi-facebook';
-    if (url.includes('instagram.com')) return 'pi pi-instagram';
-    if (url.includes('youtube.com')) return 'pi pi-youtube';
-    if (url.includes('tiktok.com')) return 'pi pi-tiktok';
-    return 'pi pi-globe';
+    return getSocialIconFromTipos(url, this.tiposRedeSocial);
   }
 
 

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -27,6 +27,8 @@ import { CityMapComponent } from "../../../shared/components/city-map/city-map.c
 import { MassCardData } from "../../../shared/models/mass-card.model";
 import { getMissaAgoraUrgency, getCountdownLabel, getNextOccurrenceMinutes, formatMassTime } from "../../../shared/utils/mass-time.utils";
 import { AnalyticsService } from "../../../core/services/analytics.service";
+import { RedesSociaisService, TipoRedeSocial } from "../../../core/services/redes-sociais.service";
+import { getSocialIconFromTipos } from "../../../shared/utils/social-icon.utils";
 
 interface AddressData {
   [uf: string]: {
@@ -60,6 +62,8 @@ export class HomeComponent {
   public _router = inject(Router);
   private _route = inject(ActivatedRoute);
   private _analytics = inject(AnalyticsService);
+  private _redesSociais = inject(RedesSociaisService);
+  tiposRedeSocial: TipoRedeSocial[] = [];
 
   /** Status da geolocalização */
   geoStatus: 'idle' | 'loading' | 'found' | 'denied' | 'error' = 'idle';
@@ -293,6 +297,7 @@ export class HomeComponent {
   resultsMode = false;
 
   ngOnInit(): void {
+    this._redesSociais.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
     this.resultsMode = !!this._route.snapshot.data['resultsMode'];
 
     this.form = this._fb.group({
@@ -963,11 +968,7 @@ export class HomeComponent {
   }
 
   getSocialIcon(url: string): string {
-    if (url.includes("facebook.com")) return "pi pi-facebook";
-    if (url.includes("instagram.com")) return "pi pi-instagram";
-    if (url.includes("youtube.com")) return "pi pi-youtube";
-    if (url.includes("tiktok.com")) return "pi pi-tiktok";
-    return "pi pi-globe";
+    return getSocialIconFromTipos(url, this.tiposRedeSocial);
   }
 
   // Usa a URL canônica nova se houver slug+cidade; senão cai no legado /igrejas

--- a/src/app/shared/utils/social-icon.utils.ts
+++ b/src/app/shared/utils/social-icon.utils.ts
@@ -1,0 +1,7 @@
+import { TipoRedeSocial } from "../../core/services/redes-sociais.service";
+
+export function getSocialIconFromTipos(url: string, tipos: TipoRedeSocial[]): string {
+  if (!url) return "pi pi-link";
+  const tipo = tipos.find((t) => url.includes(new URL(t.urlBase).hostname));
+  return tipo?.icone ?? "pi pi-link";
+}


### PR DESCRIPTION
- Criado RedesSociaisService com shareReplay(1) que consome GET v1/RedeSocial/tipos e cacheia o resultado para toda a sessão
- church-form: campos de redes sociais gerados dinamicamente via *ngFor, eliminando hardcode de Facebook/Instagram/YouTube/TikTok e suportando automaticamente novas redes (ex: Twitter) sem alteração no frontend
- church-registration-page: _mapearRedesSociais itera sobre tiposRedeSocial da API em vez de array fixo com IDs hardcoded
- getSocialIcon centralizado em social-icon.utils.ts e removido dos componentes home, city e details (estava duplicado nos 3)