### PR TITLE
Redes sociais dinâmicas, redirecionamento /detalhes/:cep e correção de conflitos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -139,11 +139,13 @@ export const routes: Routes = [
             (m) => m.CidadesComponent
           ),
       },
-      // Redirect da rota antiga para manter links existentes funcionando
+      // Rota legada do Google Maps — redireciona para a cidade via ViaCEP
       {
         path: "detalhes/:cep",
-        redirectTo: "home",
-        pathMatch: "full"
+        loadComponent: () =>
+          import("./modules/public/cep-redirect/cep-redirect.component").then(
+            (m) => m.CepRedirectComponent
+          ),
       },
       {
         path: "enviar-codigo/:controleId",

--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -33,6 +33,13 @@ export class ChurchesService {
     return this.http.get(`v1/Igreja/buscar-por-cep?cep=${cep}`);
   }
 
+  /** Busca igrejas pelo CEP (v2) — retorna dadosEndereco com localidade e uf */
+  searchByCEPv2(cep: string) {
+    return this.http.get<{ data: { dadosEndereco: { localidade: string; uf: string } }[] }>(
+      `v2/Igreja/buscar-por-cep/${cep}`
+    );
+  }
+
   /** Busca cidades e bairros através da UF, Localidade e Bairro */
   public addressRange(): Observable<any> {
     return this.http.get<any>("v1/Igreja/v2/obter-enderecos");

--- a/src/app/modules/public/cep-redirect/cep-redirect.component.ts
+++ b/src/app/modules/public/cep-redirect/cep-redirect.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
-import { HttpClient } from "@angular/common/http";
+import { ChurchesService } from "../../../core/services/churches.service";
 
 @Component({
   selector: "app-cep-redirect",
@@ -10,7 +10,7 @@ import { HttpClient } from "@angular/common/http";
 export class CepRedirectComponent implements OnInit {
   private _route = inject(ActivatedRoute);
   private _router = inject(Router);
-  private _http = inject(HttpClient);
+  private _churches = inject(ChurchesService);
 
   ngOnInit(): void {
     const cep = this._route.snapshot.paramMap.get("cep")?.replace(/\D/g, "") ?? "";
@@ -20,22 +20,19 @@ export class CepRedirectComponent implements OnInit {
       return;
     }
 
-    this._http
-      .get<{ localidade: string; uf: string; erro?: boolean }>(
-        `https://viacep.com.br/ws/${cep}/json/`
-      )
-      .subscribe({
-        next: (data) => {
-          if (data.erro || !data.localidade || !data.uf) {
-            this._router.navigate(["/home"]);
-            return;
-          }
-          const cidadeSlug = this._toSlug(data.localidade);
-          const uf = data.uf.toLowerCase();
-          this._router.navigate(["/missas", uf, cidadeSlug]);
-        },
-        error: () => this._router.navigate(["/home"]),
-      });
+    this._churches.searchByCEPv2(cep).subscribe({
+      next: (res) => {
+        const endereco = res?.data?.[0]?.dadosEndereco;
+        if (!endereco?.localidade || !endereco?.uf) {
+          this._router.navigate(["/home"]);
+          return;
+        }
+        const cidadeSlug = this._toSlug(endereco.localidade);
+        const uf = endereco.uf.toLowerCase();
+        this._router.navigate(["/missas", uf, cidadeSlug]);
+      },
+      error: () => this._router.navigate(["/home"]),
+    });
   }
 
   private _toSlug(nome: string): string {

--- a/src/app/modules/public/cep-redirect/cep-redirect.component.ts
+++ b/src/app/modules/public/cep-redirect/cep-redirect.component.ts
@@ -1,0 +1,49 @@
+import { Component, inject, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { HttpClient } from "@angular/common/http";
+
+@Component({
+  selector: "app-cep-redirect",
+  standalone: true,
+  template: ``,
+})
+export class CepRedirectComponent implements OnInit {
+  private _route = inject(ActivatedRoute);
+  private _router = inject(Router);
+  private _http = inject(HttpClient);
+
+  ngOnInit(): void {
+    const cep = this._route.snapshot.paramMap.get("cep")?.replace(/\D/g, "") ?? "";
+
+    if (!cep || cep.length !== 8) {
+      this._router.navigate(["/home"]);
+      return;
+    }
+
+    this._http
+      .get<{ localidade: string; uf: string; erro?: boolean }>(
+        `https://viacep.com.br/ws/${cep}/json/`
+      )
+      .subscribe({
+        next: (data) => {
+          if (data.erro || !data.localidade || !data.uf) {
+            this._router.navigate(["/home"]);
+            return;
+          }
+          const cidadeSlug = this._toSlug(data.localidade);
+          const uf = data.uf.toLowerCase();
+          this._router.navigate(["/missas", uf, cidadeSlug]);
+        },
+        error: () => this._router.navigate(["/home"]),
+      });
+  }
+
+  private _toSlug(nome: string): string {
+    return nome
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, "-");
+  }
+}


### PR DESCRIPTION
## O que mudou

### Redes sociais dinâmicas via API
- Criado `RedesSociaisService` com `shareReplay(1)` — uma única requisição `GET v1/RedeSocial/tipos` por sessão
- `church-form`: campos de redes sociais gerados com `*ngFor` sobre os tipos da API — Twitter e qualquer rede futura aparecem automaticamente
- `church-registration-page`: `_mapearRedesSociais` itera dinamicamente sobre os tipos, sem IDs hardcoded
- `getSocialIcon()` centralizado em `social-icon.utils.ts`, removendo duplicação de `home`, `city` e `details`

### Redirecionamento de rota legada `/detalhes/:cep`
- Rota antiga existente no Google Maps que redirecionava para `/home`
- Criado `CepRedirectComponent` que chama `v2/Igreja/buscar-por-cep/{cep}` no backend próprio, extrai `localidade` e `uf` do primeiro resultado e navega para `/missas/{uf}/{cidade-slug}`
- Fallback para `/home` em caso de CEP inválido ou sem igrejas cadastradas

### Resolução de conflitos com `dev`
- Mantidos `ClarityService` (vindo da dev) e `RedesSociaisService` (nosso branch) nos componentes `details`, `city` e `church-registration-page`

## O que um revisor deve saber
- Depende do endpoint `GET /api/v1/RedeSocial/tipos` já implementado no backend
- O redirecionamento de CEP usa `v2/Igreja/buscar-por-cep/{cep}` — validar que o endpoint está disponível em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)