### PR TITLE
Redes sociais dinâmicas, redirecionamento inteligente de /detalhes/:cep e correção de conflitos

### DIFF
--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -35,9 +35,12 @@ export class ChurchesService {
 
   /** Busca igrejas pelo CEP (v2) — retorna dadosEndereco com localidade e uf */
   searchByCEPv2(cep: string) {
-    return this.http.get<{ data: { dadosEndereco: { localidade: string; uf: string } }[] }>(
-      `v2/Igreja/buscar-por-cep/${cep}`
-    );
+    return this.http.get<{
+      data: {
+        nomeUnico: string;
+        dadosEndereco: { localidade: string; uf: string };
+      }[];
+    }>(`v2/Igreja/buscar-por-cep/${cep}`);
   }
 
   /** Busca cidades e bairros através da UF, Localidade e Bairro */

--- a/src/app/modules/public/cep-redirect/cep-redirect.component.ts
+++ b/src/app/modules/public/cep-redirect/cep-redirect.component.ts
@@ -22,14 +22,24 @@ export class CepRedirectComponent implements OnInit {
 
     this._churches.searchByCEPv2(cep).subscribe({
       next: (res) => {
-        const endereco = res?.data?.[0]?.dadosEndereco;
+        const igrejas = res?.data ?? [];
+        const endereco = igrejas[0]?.dadosEndereco;
+
         if (!endereco?.localidade || !endereco?.uf) {
           this._router.navigate(["/home"]);
           return;
         }
-        const cidadeSlug = this._toSlug(endereco.localidade);
+
         const uf = endereco.uf.toLowerCase();
-        this._router.navigate(["/missas", uf, cidadeSlug]);
+        const cidadeSlug = this._toSlug(endereco.localidade);
+
+        if (igrejas.length === 1 && igrejas[0].nomeUnico) {
+          // CEP pertence a uma única igreja — vai direto para a página dela
+          this._router.navigate(["/paroquia", uf, cidadeSlug, igrejas[0].nomeUnico]);
+        } else {
+          // Múltiplas igrejas no CEP — mostra a lista da cidade
+          this._router.navigate(["/missas", uf, cidadeSlug]);
+        }
       },
       error: () => this._router.navigate(["/home"]),
     });


### PR DESCRIPTION
## O que mudou

### Redes sociais dinâmicas via API
- Criado `RedesSociaisService` com `shareReplay(1)` — uma única requisição `GET v1/RedeSocial/tipos` por sessão, resultado cacheado para todos os componentes
- `church-form`: campos gerados com `*ngFor` sobre os tipos da API — Twitter e qualquer rede futura aparecem automaticamente sem alterar o frontend
- `church-registration-page`: `_mapearRedesSociais` itera dinamicamente, sem IDs hardcoded
- `getSocialIcon()` centralizado em `social-icon.utils.ts`, removendo duplicação em `home`, `city` e `details`

### Redirecionamento inteligente da rota legada `/detalhes/:cep`
- Rota antiga cadastrada no Google Maps que antes jogava o usuário no `/home`
- `CepRedirectComponent` chama `v2/Igreja/buscar-por-cep/{cep}` e decide o destino:
  - **1 igreja no CEP** → `/paroquia/{uf}/{cidade}/{nomeUnico}` (página exata da igreja)
  - **Múltiplas igrejas** → `/missas/{uf}/{cidade}` (lista da cidade)
  - **Sem resultado / erro** → `/home`

### Resolução de conflitos com `dev`
- Mantidos `ClarityService` (vindo da dev) e `RedesSociaisService` (nosso branch) nos componentes `details`, `city` e `church-registration-page`

## O que um revisor deve saber
- Depende do endpoint `GET /api/v1/RedeSocial/tipos` no backend
- O redirecionamento usa `v2/Igreja/buscar-por-cep/{cep}` — confirmar disponibilidade em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)