### PR TITLE
Etapa 3: ServicoMetricas com controle de janela de visualização

### DIFF
--- a/src/app/core/services/metricas.service.ts
+++ b/src/app/core/services/metricas.service.ts
@@ -1,0 +1,59 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+
+const JANELA_VISUALIZACAO_MS = 30 * 60 * 1000; // 30 minutos
+
+@Injectable({ providedIn: 'root' })
+export class MetricasService {
+  private http = inject(HttpClient);
+
+  registrarVisualizacaoIgreja(igrejaId: number): void {
+    const chave = `igreja_${igrejaId}_ultima_visualizacao`;
+    const agora = Date.now();
+    const ultimaVisualizacao = Number(localStorage.getItem(chave) ?? 0);
+
+    if (agora - ultimaVisualizacao < JANELA_VISUALIZACAO_MS) return;
+
+    this.http
+      .post('v2/metricas/visualizacao-igreja', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+
+    localStorage.setItem(chave, String(agora));
+  }
+
+  registrarCliqueRota(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/clique-rota', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+
+  registrarFavorito(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/favorito', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+
+  registrarCompartilhamento(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/compartilhamento', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+
+  registrarCliqueTelefone(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/clique-telefone', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+
+  registrarCliqueInstagram(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/clique-instagram', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+
+  registrarSugestaoEdicao(igrejaId: number): void {
+    this.http
+      .post('v2/metricas/sugestao-edicao', { entidadeId: igrejaId })
+      .subscribe({ error: () => {} });
+  }
+}

--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -276,7 +276,7 @@
             <a *ngIf="churchInfo.contato?.telefoneWhatsApp"
                [href]="'https://wa.me/55' + churchInfo.contato.dddWhatsApp + churchInfo.contato.telefoneWhatsApp"
                target="_blank" rel="noopener"
-               (click)="trackObjetivoAlcancado('whatsapp')"
+               (click)="trackObjetivoAlcancado('whatsapp'); trackCliqueTelefone()"
                class="contact-row">
               <div class="contact-row__icon contact-row__icon--green">
                 <i class="pi pi-whatsapp"></i>
@@ -290,7 +290,7 @@
             <!-- Telefone -->
             <a *ngIf="churchInfo.contato?.telefone"
                [href]="'tel:' + churchInfo.contato.ddd + churchInfo.contato.telefone"
-               (click)="trackObjetivoAlcancado('ligar')"
+               (click)="trackObjetivoAlcancado('ligar'); trackCliqueTelefone()"
                class="contact-row">
               <div class="contact-row__icon contact-row__icon--blue">
                 <i class="pi pi-phone"></i>
@@ -338,7 +338,7 @@
                 <div class="flex gap-3 mt-1">
                   <a *ngFor="let rede of churchInfo.redesSociais" [href]="rede.url"
                      target="_blank" rel="noopener"
-                     (click)="trackObjetivoAlcancado(getSocialTrackName(rede.url))"
+                     (click)="trackSocialClick(rede.url)"
                      class="text-2xl text-gray-500 hover:text-primary transition-colors"
                      [attr.aria-label]="rede.nomeRedeSocial">
                     <i [ngClass]="getSocialIcon(rede.url)"></i>

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -17,6 +17,7 @@ import { getNextOccurrenceMinutes, formatMassTime, getCountdownLabel } from "../
 import { AnalyticsService } from "../../../../core/services/analytics.service";
 import { ClarityService } from "../../../../core/services/clarity.service";
 import { RedesSociaisService, TipoRedeSocial } from "../../../../core/services/redes-sociais.service";
+import { MetricasService } from "../../../../core/services/metricas.service";
 import { getSocialIconFromTipos } from "../../../../shared/utils/social-icon.utils";
 
 @Component({
@@ -45,6 +46,7 @@ export class DetailsComponent implements OnInit {
   private _analytics = inject(AnalyticsService);
   private _clarity = inject(ClarityService);
   private _redesSociais = inject(RedesSociaisService);
+  private _metricas = inject(MetricasService);
 
   tiposRedeSocial: TipoRedeSocial[] = [];
   isLoading = false;
@@ -102,6 +104,7 @@ export class DetailsComponent implements OnInit {
         if (igreja.id) this.carregarResumoConfirmacoes(igreja.id);
         this._loadFavoritaState();
         this._analytics.churchView(igreja.nome, igreja.endereco?.localidade ?? '', igreja.endereco?.uf ?? '');
+        if (igreja.id) this._metricas.registrarVisualizacaoIgreja(igreja.id);
         this._aplicarClarityTags(igreja);
 
         const cidadeUf = igreja.endereco?.localidade
@@ -321,6 +324,7 @@ export class DetailsComponent implements OnInit {
       this.isFavorita = true;
       this._analytics.favoriteParishSaved(this.churchInfo.nome);
       this.trackObjetivoAlcancado('favoritar');
+      this._metricas.registrarFavorito(id);
       this._toast.add({ severity: 'success', summary: 'Adicionada aos favoritos!', detail: this.churchInfo.nome });
     }
     localStorage.setItem('buscamissa_favoritas', JSON.stringify(favoritas));
@@ -357,6 +361,7 @@ export class DetailsComponent implements OnInit {
   trackDirections(): void {
     this._analytics.getDirections(this.churchInfo?.nome ?? '');
     this.trackObjetivoAlcancado('tracar_rota');
+    if (this.churchInfo?.id) this._metricas.registrarCliqueRota(this.churchInfo.id);
   }
 
   get linkGoogleMaps(): string {
@@ -406,6 +411,16 @@ export class DetailsComponent implements OnInit {
     return 'rede_social';
   }
 
+  trackSocialClick(url: string): void {
+    this.trackObjetivoAlcancado(this.getSocialTrackName(url));
+    if (url.includes('instagram.com') && this.churchInfo?.id)
+      this._metricas.registrarCliqueInstagram(this.churchInfo.id);
+  }
+
+  trackCliqueTelefone(): void {
+    if (this.churchInfo?.id) this._metricas.registrarCliqueTelefone(this.churchInfo.id);
+  }
+
 
   voltar(): void {
     this._location.back();
@@ -416,6 +431,7 @@ export class DetailsComponent implements OnInit {
     const url = this.shareUrl;
     const nav = navigator as any;
     this.trackObjetivoAlcancado('compartilhar');
+    if (this.churchInfo?.id) this._metricas.registrarCompartilhamento(this.churchInfo.id);
     if (nav.share) {
       nav.share({ title: this.churchInfo?.nome, text: `Horários de missa — ${this.churchInfo?.nome}`, url }).catch(() => {});
     } else {
@@ -439,6 +455,7 @@ export class DetailsComponent implements OnInit {
   reportarErro(): void {
     if (this.churchInfo?.id) {
       this._analytics.userContribution('report', this.churchInfo.nome);
+      this._metricas.registrarSugestaoEdicao(this.churchInfo.id);
       this._router.navigate(['/editar', this.churchInfo.id]);
     }
   }


### PR DESCRIPTION
## Summary
- Cria `MetricasService` (`src/app/core/services/metricas.service.ts`) com os 7 métodos de registro
- Controle de janela de 30 min para visualização de igreja via `localStorage` (`igreja_{id}_ultima_visualizacao`): se a última visualização ocorreu há menos de 30 min, a requisição não é enviada
- Todos os demais eventos são enviados normalmente a cada chamada
- Requisições fire-and-forget — erros são absorvidos silenciosamente para não impactar a UX

## Test plan
- [ ] Abrir a página de uma igreja: métrica de visualização enviada, timestamp gravado no localStorage
- [ ] Recarregar a página antes de 30 min: nenhuma requisição enviada ao backend
- [ ] Recarregar após 30 min: métrica enviada novamente, timestamp atualizado
- [ ] Demais métricas (rota, telefone, instagram etc.) enviadas normalmente em cada clique

🤖 Generated with [Claude Code](https://claude.com/claude-code)