### PR TITLE
fix: corrige links quebrados para igrejas sem slug (auditoria de visualizações)

### DIFF
--- a/src/app/core/services/favorites.service.ts
+++ b/src/app/core/services/favorites.service.ts
@@ -11,6 +11,8 @@ export interface IgrejaFavorita {
   uf?: string;
   cidadeSlug?: string;
   slug?: string;
+  /** Fallback para a rota legada /igrejas/:nomeUnico quando `slug` não é confiável. */
+  nomeUnico?: string;
   diaSemana?: number | null;
   horario?: string | null;
   proximaMissaLabel?: string;

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -20,6 +20,7 @@ import { ClarityService } from "../../../../core/services/clarity.service";
 import { CityMapComponent, MapChurch } from "../../../../shared/components/city-map/city-map.component";
 import { RedesSociaisService, TipoRedeSocial } from "../../../../core/services/redes-sociais.service";
 import { getSocialIconFromTipos } from "../../../../shared/utils/social-icon.utils";
+import { linkParoquia as buildLinkParoquia } from "../../../../shared/utils/church-link.utils";
 
 const PERIODOS: Record<string, { de: number; ate: number; label: string }> = {
   manha: { de: 5 * 60, ate: 11 * 60 + 59, label: "Manhã" },
@@ -417,7 +418,10 @@ export class CityComponent implements OnInit, OnDestroy {
   }
 
   linkParoquia(igreja: any): string[] {
-    return ["/paroquia", this.uf, this.cidade, igreja.slug];
+    return buildLinkParoquia({
+      ...igreja,
+      endereco: { ...igreja?.endereco, uf: this.uf, cidadeSlug: this.cidade },
+    });
   }
 
   onChurchClick(igreja: any): void {
@@ -445,6 +449,7 @@ export class CityComponent implements OnInit, OnDestroy {
       uf: this.uf?.toLowerCase(),
       cidadeSlug: this.cidade,
       slug: ig.slug,
+      nomeUnico: ig.nomeUnico,
       diaSemana: pm?.diaSemana,
       horario: pm?.horario,
     });

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -344,6 +344,7 @@ export class DetailsComponent implements OnInit {
       uf: (end.uf ?? '').toLowerCase(),
       cidadeSlug: end.cidadeSlug,
       slug: this.churchInfo.slug,
+      nomeUnico: this.churchInfo.nomeUnico,
       diaSemana: pm?.diaSemana,
       horario: pm?.horario,
     });

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -34,6 +34,7 @@ import { HomeComoFuncionaComponent } from "./sections/home-como-funciona/home-co
 import { HomeFavoritosComponent } from "./sections/home-favoritos/home-favoritos.component";
 import { HomeCidadesComponent } from "./sections/home-cidades/home-cidades.component";
 import { HomeMissasMapaComponent } from "./sections/home-missas-mapa/home-missas-mapa.component";
+import { linkParoquia } from "../../../shared/utils/church-link.utils";
 
 interface AddressData {
   [uf: string]: {
@@ -1042,12 +1043,7 @@ export class HomeComponent {
 
   // Usa a URL canônica nova se houver slug+cidade; senão cai no legado /igrejas
   linkParoquia(church: any): string[] {
-    const uf = church?.endereco?.uf;
-    const cidadeSlug = church?.endereco?.cidadeSlug;
-    if (uf && cidadeSlug && church?.slug) {
-      return ["/paroquia", uf.toLowerCase(), cidadeSlug, church.slug];
-    }
-    return ["/igrejas", church?.nomeUnico];
+    return linkParoquia(church);
   }
 
   /** URL completa para compartilhamento (SEO3 revisado) */

--- a/src/app/modules/public/home/sections/home-favoritos/home-favoritos.component.html
+++ b/src/app/modules/public/home/sections/home-favoritos/home-favoritos.component.html
@@ -9,7 +9,7 @@
 
   <div class="minhas-paroquias__grid" *ngIf="favoritas.length > 0">
     @for (fav of favoritas; track fav.id) {
-    <a [routerLink]="['/paroquia', (fav.uf ?? '').toLowerCase(), fav.cidadeSlug, fav.slug]"
+    <a [routerLink]="linkFav(fav)"
        class="minhas-paroquias__card"
        [class.minhas-paroquias__card--hot]="getUrgencia(fav) === 'hot'"
        [class.minhas-paroquias__card--soon]="getUrgencia(fav) === 'soon'">

--- a/src/app/modules/public/home/sections/home-favoritos/home-favoritos.component.ts
+++ b/src/app/modules/public/home/sections/home-favoritos/home-favoritos.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { IgrejaFavorita } from '../../../../../core/services/favorites.service';
 import { getCountdownLabel, getNextOccurrenceMinutes } from '../../../../../shared/utils/mass-time.utils';
+import { linkParoquia } from '../../../../../shared/utils/church-link.utils';
 
 /** Seção "Seus favoritos" da home (extraída do HomeComponent — auditoria 2.1). */
 @Component({
@@ -16,6 +17,14 @@ import { getCountdownLabel, getNextOccurrenceMinutes } from '../../../../../shar
 export class HomeFavoritosComponent {
   @Input({ required: true }) favoritas: IgrejaFavorita[] = [];
   @Output() remover = new EventEmitter<number>();
+
+  linkFav(fav: IgrejaFavorita): string[] {
+    return linkParoquia({
+      slug: fav.slug,
+      nomeUnico: fav.nomeUnico,
+      endereco: { uf: (fav.uf ?? '').toLowerCase(), cidadeSlug: fav.cidadeSlug },
+    });
+  }
 
   onRemover(id: number, event: Event): void {
     event.preventDefault();

--- a/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
+++ b/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
@@ -10,6 +10,7 @@ import { getMissaAgoraUrgency } from '../../../shared/utils/mass-time.utils';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { FavoritesService, IgrejaFavorita } from '../../../core/services/favorites.service';
+import { linkParoquia } from '../../../shared/utils/church-link.utils';
 
 @Component({
   selector: 'app-minhas-igrejas',
@@ -78,6 +79,10 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
 
   irParaIgreja(igreja: IgrejaFavorita): void {
     this._clarity.track('favorito_clicado', { igrejaId: String(igreja.id) });
-    this._router.navigate(['/paroquia', (igreja.uf ?? '').toLowerCase(), igreja.cidadeSlug, igreja.slug]);
+    this._router.navigate(linkParoquia({
+      slug: igreja.slug,
+      nomeUnico: igreja.nomeUnico,
+      endereco: { uf: (igreja.uf ?? '').toLowerCase(), cidadeSlug: igreja.cidadeSlug },
+    }));
   }
 }

--- a/src/app/modules/public/missa-agora/missa-agora.component.ts
+++ b/src/app/modules/public/missa-agora/missa-agora.component.ts
@@ -311,6 +311,7 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
         uf: card.uf,
         cidadeSlug: card.cidadeSlug,
         slug: card.slug,
+        nomeUnico: card.nomeUnico,
         diaSemana: card.mass.diaSemana,
         horario: card.mass.horario,
       });

--- a/src/app/shared/components/church-result-card/church-result-card.component.ts
+++ b/src/app/shared/components/church-result-card/church-result-card.component.ts
@@ -10,6 +10,7 @@ import {
   getCountdownLabel,
 } from "../../utils/mass-time.utils";
 import { distanciaMetrosAte } from "../../utils/distance.utils";
+import { linkParoquia } from "../../utils/church-link.utils";
 
 /**
  * Card de igreja reutilizável (resultado de busca / página de cidade).
@@ -73,7 +74,10 @@ export class ChurchResultCardComponent implements OnInit {
   }
 
   linkParoquia(): string[] {
-    return ["/paroquia", this.ufResolved, this.cidadeResolved, this.igreja.slug];
+    return linkParoquia({
+      ...this.igreja,
+      endereco: { ...this.igreja?.endereco, uf: this.ufResolved, cidadeSlug: this.cidadeResolved },
+    });
   }
 
   // ── Próxima missa ───────────────────────────────────────────────────────────
@@ -168,6 +172,7 @@ export class ChurchResultCardComponent implements OnInit {
       uf: this.ufResolved,
       cidadeSlug: this.cidadeResolved,
       slug: this.igreja.slug,
+      nomeUnico: this.igreja.nomeUnico,
       diaSemana: pm?.diaSemana,
       horario: pm?.horario,
     });

--- a/src/app/shared/components/mass-time-card/mass-time-card.component.ts
+++ b/src/app/shared/components/mass-time-card/mass-time-card.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MassCardData, MassUrgency } from '../../models/mass-card.model';
 import { formatMassTime } from '../../utils/mass-time.utils';
+import { linkParoquia } from '../../utils/church-link.utils';
 import { ConfidenceBadgeComponent } from '../confidence-badge/confidence-badge.component';
 import { CountdownChipComponent } from '../countdown-chip/countdown-chip.component';
 import { DistanceChipComponent } from '../distance-chip/distance-chip.component';
@@ -36,12 +37,11 @@ export class MassTimeCardComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.formattedTime = formatMassTime(this.data.mass.horario);
-    this.parishRoute = [
-      '/paroquia',
-      this.data.uf,
-      this.data.cidadeSlug,
-      this.data.slug,
-    ];
+    this.parishRoute = linkParoquia({
+      slug: this.data.slug,
+      nomeUnico: this.data.nomeUnico ?? this.data.slug,
+      endereco: { uf: this.data.uf, cidadeSlug: this.data.cidadeSlug },
+    });
   }
 
   onNavigate(event: Event): void {

--- a/src/app/shared/models/mass-card.model.ts
+++ b/src/app/shared/models/mass-card.model.ts
@@ -8,6 +8,8 @@ export interface MassCardData {
   churchId: number;
   churchName: string;
   slug: string;
+  /** Fallback para a rota legada /igrejas/:nomeUnico quando `slug` não é confiável. */
+  nomeUnico?: string;
   uf: string;
   cidadeSlug: string;
   bairro: string;

--- a/src/app/shared/utils/church-link.utils.ts
+++ b/src/app/shared/utils/church-link.utils.ts
@@ -1,0 +1,11 @@
+// Usa a URL canônica nova (/paroquia/:uf/:cidadeSlug/:slug) se a igreja tiver slug+cidadeSlug;
+// senão cai na rota legada /igrejas/:nomeUnico. Sem esse fallback, igrejas sem slug geram
+// links quebrados (.../undefined) que nunca chegam a carregar a página de detalhes.
+export function linkParoquia(church: any): string[] {
+  const uf = church?.endereco?.uf;
+  const cidadeSlug = church?.endereco?.cidadeSlug;
+  if (uf && cidadeSlug && church?.slug) {
+    return ["/paroquia", uf.toLowerCase(), cidadeSlug, church.slug];
+  }
+  return ["/igrejas", church?.nomeUnico];
+}


### PR DESCRIPTION
## Resumo
Auditoria da coleta de indicadores identificou que igrejas sem `slug` preenchido tinham visualizações não contabilizadas: links de navegação (pesquisa, mapa, cidade, Próxima Missa, Favoritos) montavam `/paroquia/:uf/:cidade/:slug` sem fallback, gerando `.../undefined`, que nunca carrega a página de detalhes e portanto nunca dispara o evento de visualização.

Centralizei o fallback correto (que já existia isoladamente em `home.component.ts`) em `shared/utils/church-link.utils.ts` e apliquei em todos os pontos de navegação e no fluxo de favoritos (incluindo persistir `nomeUnico` nos favoritos salvos).

Complementa o [PR do backend](https://github.com/FabioVeiga/buscamissa-backend/pull/88), que corrige a causa raiz (igrejas nascendo sem slug).

## Test plan
- [x] `tsc --noEmit` sem erros
- [x] Build de produção sem erros
- [x] Testado no preview: igreja sem slug favoritada → navega para `/igrejas/:nomeUnico`; igreja com slug → navega para `/paroquia/...`