### PR TITLE
feat(auditoria 5): foco visível, foco SPA no main e Instagram (sameAs…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -49,6 +49,9 @@ export class AppComponent implements OnInit {
           canonical: data['canonical'],
         });
       }
+      // A11y: move o foco para o <main> a cada navegação SPA, para que leitores
+      // de tela anunciem a nova página. preventScroll não interfere no scroll.
+      document.getElementById('conteudo')?.focus({ preventScroll: true });
     });
   }
 

--- a/src/app/core/layout/home/footer/footer.component.html
+++ b/src/app/core/layout/home/footer/footer.component.html
@@ -30,9 +30,17 @@
     </nav>
     
 
-    <!-- Créditos -->
-    <div class="text-xs text-gray-400 mt-4 md:mt-0 text-center md:text-right">
-      © {{ currentYear }} BuscaMissa. Todos os direitos reservados.
+    <!-- Redes sociais + Créditos -->
+    <div class="flex flex-col items-center md:items-end gap-2 mt-4 md:mt-0">
+      <a href="https://www.instagram.com/buscamissa/" target="_blank" rel="noopener noreferrer"
+        aria-label="Instagram do BuscaMissa"
+        class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 transition">
+        <i class="pi pi-instagram" aria-hidden="true"></i>
+        <span>&#64;buscamissa</span>
+      </a>
+      <div class="text-xs text-gray-400 text-center md:text-right">
+        © {{ currentYear }} BuscaMissa. Todos os direitos reservados.
+      </div>
     </div>
     
   </div>

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -429,7 +429,6 @@ export class HomeComponent {
    * WebSite/SearchAction (habilita a sitelinks searchbox do Google).
    * title/description/canonical são aplicados centralmente pelo AppComponent via
    * route.data — não repetir aqui (a home também serve /buscar).
-   * O `sameAs` (Instagram/Facebook oficiais) pode ser adicionado quando disponível.
    */
   private _setSeo(): void {
     const base = "https://buscamissa.com.br";
@@ -440,6 +439,7 @@ export class HomeComponent {
       name: "BuscaMissa",
       url: base,
       logo: `${base}/android-chrome-512x512.png`,
+      sameAs: ["https://www.instagram.com/buscamissa/"],
     });
 
     this._seo.setJsonLd("website", {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -33,6 +33,21 @@
   line-gap-override: 8.92%;
 }
 
+/* ── A11y: foco visível por teclado (5.1.e) ─────────────────────────────────
+   Só dispara na navegação por teclado (:focus-visible), não no clique de mouse.
+   Cobre links e elementos custom que não tinham indicador de foco. */
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible,
+.search-tab:focus-visible,
+.city-card__favoritar:focus-visible,
+.city-card__btn:focus-visible,
+.city-card__nome:focus-visible {
+  outline: 2px solid #bc5d10;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* Estas páginas usam layout largo (alinhado ao header). Demais mantêm 640px de leitura. */
 .layout-main > .card:has(app-home),
 .layout-main > .card:has(app-missa-agora),


### PR DESCRIPTION
… + footer)

- styles: :focus-visible global (só teclado) com a cor da marca #bc5d10 (5.1.e)
- app.component: foco move para <main id=conteudo> a cada navegação SPA, para leitores de tela anunciarem a nova página (5.3)
- home: sameAs (Instagram) na Organization JSON-LD (reforça Etapa 4)
- footer: link do Instagram oficial (@buscamissa) com aria-label