### PR TITLE
fix(seo): remove canonical/og:url estáticos do index.html (deduplicaç…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,8 @@
       content="Plataforma para encontrar igrejas católicas e horários de missa. Cadastre uma nova igreja se não encontrar a sua!"
     />
     <meta property="og:image" content="/assets/images/og-image.jpg" />
-    <meta property="og:url" content="https://buscamissa.com.br" />
+    <!-- og:url é definido por rota pelo SeoService (= canonical da página).
+         Não declarar estático aqui: no HTML inicial (SPA sem SSR) apontaria a home em toda URL. -->
     <meta property="og:type" content="website" />
 
     <!-- Twitter Card -->
@@ -91,8 +92,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!-- Canonical -->
-    <link rel="canonical" href="https://buscamissa.com.br/" />
+    <!-- Canonical definido por rota pelo SeoService (self-referente por URL).
+         Sem canonical estático: no HTML inicial (SPA sem SSR) declararia a home
+         para TODA página, causando "Duplicate, Google chose different canonical". -->
+
 
     <!-- Fonte da aplicação: Poppins (pesos utilizados, sem itálico) -->
     <!-- Carregada fora do caminho crítico de render: preload + troca p/ stylesheet no onload -->


### PR DESCRIPTION
…ão GSC)

O HTML inicial (SPA sem SSR) declarava canonical=home e og:url=home para TODA página, contribuindo para o "Duplicate, Google chose different canonical than user" nas ~391 URLs /paroquia. Sem o estático, cada URL se auto-canonicaliza no HTML bruto; o SeoService segue setando canonical/og:url corretos por rota no render (validado: /home -> canonical e og:url = /home).

Fase 1 do plano de correção da deduplicação; SSG (prerender) fica como solução arquitetural para a Fase 3.