### PR TITLE
feat(auditoria 5): estados de erro com "Tentar novamente" em city/det…

### DIFF
--- a/src/app/modules/public/home/city/city.component.html
+++ b/src/app/modules/public/home/city/city.component.html
@@ -105,8 +105,15 @@
           <button (click)="limparFiltros()">Limpar filtros</button>
         </div>
 
+        <!-- Erro de carregamento (rede/API) -->
+        <div *ngIf="erroCarregar" class="city-vazio">
+          <i class="pi pi-wifi"></i>
+          <p>Não foi possível carregar as paróquias. Verifique sua conexão.</p>
+          <button type="button" (click)="carregar()">Tentar novamente</button>
+        </div>
+
         <!-- Vazio geral -->
-        <div *ngIf="naoEncontrado && !igrejas.length" class="city-vazio">
+        <div *ngIf="naoEncontrado && !igrejas.length && !erroCarregar" class="city-vazio">
           <i class="pi pi-search"></i>
           <p>Nenhuma paróquia cadastrada em {{ cidadeNome }} ainda.</p>
           <a routerLink="/nova">Cadastrar paróquia</a>

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -57,6 +57,8 @@ export class CityComponent implements OnInit, OnDestroy {
   igrejasFiltradas: any[] = [];
   trackByIgrejaId = (_: number, igreja: any): number => igreja.id;
   naoEncontrado = false;
+  /** Erro de rede/API ao carregar — mostra estado com "Tentar novamente" (≠ cidade sem paróquias) */
+  erroCarregar = false;
   faqs: { pergunta: string; resposta: string }[] = [];
 
   favoritasIds: number[] = [];
@@ -119,6 +121,7 @@ export class CityComponent implements OnInit, OnDestroy {
   carregar(): void {
     this.isLoading = true;
     this.naoEncontrado = false;
+    this.erroCarregar = false;
     this._church.getByCidade(this.uf, this.cidade).pipe(
       finalize(() => { this.isLoading = false; })
     ).subscribe({
@@ -165,7 +168,8 @@ export class CityComponent implements OnInit, OnDestroy {
         }
       },
       error: () => {
-        this.naoEncontrado = true;
+        // Erro de rede/API ≠ "cidade sem paróquias": estado próprio com retry
+        this.erroCarregar = true;
         this._seo.update({ title: `Missas em ${this.cidade}/${this.uf?.toUpperCase()} | BuscaMissa` });
       },
     });

--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -10,6 +10,14 @@
     <p-skeleton height="1rem" *ngFor="let i of [1,2,3,4]" width="80%"></p-skeleton>
   </div>
 
+  <!-- Erro de carregamento (rede/API) -->
+  <div *ngIf="!isLoading && erroCarregar" class="flex flex-col items-center gap-2 py-16 text-center">
+    <i class="pi pi-wifi text-4xl text-gray-300"></i>
+    <p class="text-sm text-gray-500 m-0">Não foi possível carregar os dados da igreja. Verifique sua conexão.</p>
+    <button type="button" pButton label="Tentar novamente" icon="pi pi-refresh"
+      class="p-button-sm p-button-outlined mt-2" (click)="tentarNovamente()"></button>
+  </div>
+
   <ng-container *ngIf="!isLoading && churchInfo">
 
     <!-- Breadcrumb -->

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -65,6 +65,10 @@ export class DetailsComponent implements OnInit {
   isLoading = false;
   nomeUnico: string | null = null;
   churchInfo: any;
+  /** Erro de rede/API ao carregar — mostra estado com "Tentar novamente" */
+  erroCarregar = false;
+  /** Última requisição (cold observable do HttpClient) — reusada pelo retry */
+  private _reqAtual: import("rxjs").Observable<any> | null = null;
 
   // Favorito
   isFavorita = false;
@@ -91,8 +95,15 @@ export class DetailsComponent implements OnInit {
     });
   }
 
+  /** Refaz a última requisição após um erro de carregamento. */
+  tentarNovamente(): void {
+    if (this._reqAtual) this.carregar(this._reqAtual);
+  }
+
   private carregar(req: import("rxjs").Observable<any>): void {
+    this._reqAtual = req;
     this.isLoading = true;
+    this.erroCarregar = false;
     req.pipe(
       finalize(() => { this.isLoading = false; })
     ).subscribe({
@@ -126,8 +137,9 @@ export class DetailsComponent implements OnInit {
         this.aplicarBreadcrumbSchema(igreja);
         this.aplicarPlaceSchema(igreja);
       },
-      error: (error) => {
-        this._toast.add({ severity: "error", summary: "Erro", detail: "Erro ao carregar dados da igreja." });
+      error: () => {
+        // Estado de erro na página (com retry) — toast some e deixava a tela em branco
+        this.erroCarregar = true;
       },
     });
   }

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -202,7 +202,15 @@
     <i class="pi pi-spin pi-spinner"></i>
     <span>Buscando igrejas…</span>
   </div>
-  <div *ngIf="resultsMode && !isLoading && churchInfo.length === 0" class="resultados-feedback resultados-feedback--vazio">
+  <div *ngIf="resultsMode && !isLoading && erroBusca" class="resultados-feedback resultados-feedback--vazio">
+    <i class="pi pi-wifi"></i>
+    <p class="resultados-feedback__titulo">Não foi possível buscar as igrejas.</p>
+    <p class="resultados-feedback__sub">Verifique sua conexão e tente novamente.</p>
+    <button type="button" class="btn-primary resultados-feedback__cadastro-btn" (click)="searchFilter(false)">
+      <i class="pi pi-refresh"></i> Tentar novamente
+    </button>
+  </div>
+  <div *ngIf="resultsMode && !isLoading && !erroBusca && churchInfo.length === 0" class="resultados-feedback resultados-feedback--vazio">
     <i class="pi pi-search"></i>
     <p class="resultados-feedback__titulo">Nenhuma igreja encontrada para os filtros aplicados.</p>
     <p class="resultados-feedback__sub">Tente ampliar a busca — remova o bairro, o dia ou o horário.</p>

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component, DestroyRef, inject } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { finalize } from "rxjs/operators";
 import { CommonModule, DatePipe } from "@angular/common";
 import {
   FormGroup,
@@ -257,6 +258,8 @@ export class HomeComponent {
   public isLoadingCities = false;
   public isLoadingDistricts = false;
   public showNoChurchCard = false;
+  /** Erro de rede/API na busca — mostra estado com "Tentar novamente" (≠ busca sem resultados) */
+  public erroBusca = false;
 
   public totalRecords: any;
 
@@ -485,7 +488,19 @@ export class HomeComponent {
   public getAddress(): void {
     this.isLoadingAddress = true;
 
-    this._churchService.addressRange().subscribe({
+    // finalize (não complete): se o addressRange falhar, a continuação PRECISA rodar
+    // mesmo assim — senão a busca da URL (/buscar?uf=...) nunca dispara e o usuário
+    // vê o vazio enganoso "Nenhuma igreja encontrada" em vez do estado de erro.
+    this._churchService.addressRange().pipe(
+      finalize(() => {
+        this.isLoadingAddress = false;
+        this._restoreFromQueryParams();
+        if (!this.resultsMode) {
+          this._loadProximasMissas();
+          this._requestGeolocation();
+        }
+      })
+    ).subscribe({
       next: ({ data }: { data: AddressData }) => {
         this.fullAddressData = data;
         this.statesList = Object.keys(data).map((sigla) => {
@@ -502,14 +517,6 @@ export class HomeComponent {
           summary: "Erro ao carregar dados",
           detail: "Não foi possível carregar as cidades e bairros.",
         });
-      },
-      complete: () => {
-        this.isLoadingAddress = false;
-        this._restoreFromQueryParams();
-        if (!this.resultsMode) {
-          this._loadProximasMissas();
-          this._requestGeolocation();
-        }
       },
     });
   }
@@ -791,7 +798,9 @@ export class HomeComponent {
   public onStateChange(event: any): void {
     this.selectedState = event.value;
     if (this.selectedState) {
-      const cities = Object.keys(this.fullAddressData[this.selectedState]);
+      // Guarda: se o addressRange falhou, fullAddressData é undefined — não pode
+      // derrubar o fluxo (a busca da URL ainda precisa rodar e mostrar o erro dela)
+      const cities = Object.keys(this.fullAddressData?.[this.selectedState] ?? {});
       this.citiesList = cities.map((city) => ({
         label: city,
         value: city,
@@ -809,7 +818,7 @@ export class HomeComponent {
     this.selectedCity = event.value;
     if (this.selectedState && this.selectedCity) {
       const districts =
-        this.fullAddressData[this.selectedState][this.selectedCity];
+        this.fullAddressData?.[this.selectedState]?.[this.selectedCity] ?? [];
       this.districtsList = districts.map((district) => ({
         label: district,
         value: district,
@@ -875,6 +884,7 @@ export class HomeComponent {
     if (resetPage) this.pageIndex = 1;
 
     this.isLoading = true;
+    this.erroBusca = false;
     this.churchInfo = [];
 
     const params = this._buildFilterQueryParams();
@@ -914,7 +924,8 @@ export class HomeComponent {
       },
       error: (err: HttpErrorResponse) => {
         this.isLoading = false;
-        if (err.error.status === 404) {
+        // Acesso seguro: em erro de rede err.error é ProgressEvent/null (sem .status)
+        if (err?.error?.status === 404 || err?.status === 404) {
           this._toast.add({
             severity: "warn",
             summary: "Nenhuma igreja encontrada",
@@ -922,11 +933,8 @@ export class HomeComponent {
           });
           this.showNoChurchCard = true;
         } else {
-          this._toast.add({
-            severity: "error",
-            summary: "Erro na busca",
-            detail: "Não foi possível buscar igrejas.",
-          });
+          // Estado de erro persistente na página (com retry) — toast some
+          this.erroBusca = true;
           this.showNoChurchCard = false;
         }
       },


### PR DESCRIPTION
…ails/buscar

Antes, erro de rede/API mostrava só um toast que some (details/buscar) ou o estado vazio enganoso "Nenhuma paróquia cadastrada" (city). Agora cada página tem estado de erro persistente com botão de retry.

- city: flag erroCarregar + bloco .city-vazio com retry -> carregar()
- details: erroCarregar + _reqAtual (cold observable reusado) + tentarNovamente()
- home/buscar: erroBusca + painel resultados-feedback com retry -> searchFilter(false)

Bugs de fluxo corrigidos no caminho:
- getAddress: continuação movida de complete: para finalize() — se o addressRange falhar, complete não dispara e a busca da URL (/buscar?uf=...) nunca rodava
- onStateChange/onCityChange: optional chaining em fullAddressData (TypeError quando o addressRange falhou abortava _restoreFromQueryParams)
- searchFilter: acesso seguro a err.error.status (erro de rede não tem body)

Validado com backend desligado: os 3 estados aparecem e o retry refaz a chamada.