### PR TITLE
fix: valida-code decide desafio x código por e-mail pela resposta da …

### DIFF
--- a/src/app/modules/public/register-church/send-code/send-code.component.html
+++ b/src/app/modules/public/register-church/send-code/send-code.component.html
@@ -6,22 +6,18 @@
 <div class="container text-center">
   <p-toast position="top-right"></p-toast>
   <h3>Validação de usuário</h3>
-  <div *ngIf="!validacaoSemEmail">
-    Para prosseguir com a alteração ou criação da Igreja, precisamos confirmar o
-    seu e-mail, preencha os campos abaixo e você receberá um código.
+  <div>
+    Para prosseguir com a alteração ou criação da Igreja, precisamos dos seus
+    dados. Preencha os campos abaixo para confirmar sua contribuição na
+    próxima etapa.
     <div class="mt-4">
       <small>
         <strong
-          >Lembre-se de verificar a caixa de spam ou lixo eletrônico do seu
-          e-mail.</strong
+          >Caso receba um código por e-mail, lembre-se de verificar também a
+          caixa de spam ou lixo eletrônico.</strong
         >
       </small>
     </div>
-  </div>
-  <div *ngIf="validacaoSemEmail">
-    Para prosseguir com a alteração ou criação da Igreja, precisamos dos seus
-    dados. Preencha os campos abaixo e confirme respondendo uma pergunta rápida
-    na próxima etapa.
   </div>
   <form [formGroup]="form" class="flex flex-wrap gap-4">
     <p-inputgroup>

--- a/src/app/modules/public/register-church/send-code/send-code.component.ts
+++ b/src/app/modules/public/register-church/send-code/send-code.component.ts
@@ -13,7 +13,6 @@ import { MessageService } from "primeng/api";
 import { PrimeNgModule } from "../../../../shared/primeng.module";
 import { LoadingComponent } from "../../../../core/components/loading/loading.component";
 import { LoggerService } from "../../../../core/services/logger.service";
-import { environment } from "../../../../../environments/environment";
 
 @Component({
   selector: "app-send-code",
@@ -42,10 +41,6 @@ export class SendCodeComponent implements OnInit {
   form!: FormGroup;
   showPromocaoModal = false;
   showTermosModal = false;
-
-  // Validação por desafio matemático (MailerSend indisponível) — muda só o
-  // texto da tela; o fluxo de navegação para /validar é o mesmo.
-  validacaoSemEmail = (environment as any).features?.validacaoSemEmail === true;
 
   ngOnInit(): void {
     this.controleId = Number(this._route.snapshot.paramMap.get("controleId"));

--- a/src/app/modules/public/register-church/validate-code/validate-code.component.html
+++ b/src/app/modules/public/register-church/validate-code/validate-code.component.html
@@ -6,8 +6,8 @@
 <div class="auth-container text-center">
   <p-toast position="top-right"></p-toast>
 
-  <!-- Validação por desafio matemático (validacaoSemEmail) -->
-  <form *ngIf="validacaoSemEmail" [formGroup]="formDesafio">
+  <!-- Validação por desafio matemático -->
+  <form *ngIf="mostrarDesafio === true" [formGroup]="formDesafio">
     <div class="flex flex-col items-center">
       <h3>Confirmação rápida</h3>
       <p class="text-muted-color block mb-8">
@@ -33,7 +33,7 @@
   </form>
 
   <!-- Validação por código enviado por e-mail (fluxo original) -->
-  <form *ngIf="!validacaoSemEmail" [formGroup]="form">
+  <form *ngIf="mostrarDesafio === false" [formGroup]="form">
     <div class="flex flex-col items-center">
       <h3>Confirmação de usuário</h3>
       <p class="text-muted-color block mb-8">

--- a/src/app/modules/public/register-church/validate-code/validate-code.component.ts
+++ b/src/app/modules/public/register-church/validate-code/validate-code.component.ts
@@ -14,7 +14,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { PrimeNgModule } from "../../../../shared/primeng.module";
 import { LoadingComponent } from "../../../../core/components/loading/loading.component";
 import { MessageService } from "primeng/api";
-import { environment } from "../../../../../environments/environment";
 
 @Component({
   selector: "app-validate-code",
@@ -43,9 +42,10 @@ export class ValidateCodeComponent {
   email: string = "";
   controleId: number = 0;
 
-  // Validação por desafio matemático (MailerSend indisponível) — ver
-  // environment.features.validacaoSemEmail.
-  validacaoSemEmail = (environment as any).features?.validacaoSemEmail === true;
+  // Qual método de validação mostrar (desafio matemático x código por e-mail)
+  // é decidido pelo backend, não por uma flag estática do frontend — cada FT
+  // pode mudar em runtime pelo admin. null = ainda não sabemos, mostra loading.
+  mostrarDesafio: boolean | null = null;
   perguntaDesafio = "";
   formDesafio: FormGroup;
 
@@ -67,19 +67,31 @@ export class ValidateCodeComponent {
       this.controleId = params["controleId"];
     });
     this._clarity.track('contrib_tela_confirmacao');
-    if (this.validacaoSemEmail) this.carregarDesafio();
+    this.carregarDesafio();
   }
 
+  // Sempre tenta carregar o desafio primeiro; se o backend responder que ele
+  // não está habilitado (FT validacao-sem-email OFF, ou sem credencial de
+  // e-mail), cai pro formulário de código por e-mail. Isso reflete o estado
+  // real das feature toggles no momento da requisição, sem depender de nada
+  // fixado no build do frontend.
   carregarDesafio(): void {
     this.isLoading = true;
     this._service.getDesafio(this.controleId).subscribe({
       next: (response: any) => {
+        this.mostrarDesafio = true;
         this.perguntaDesafio = response?.data?.pergunta ?? "";
         this.formDesafio.reset();
         this.isLoading = false;
       },
       error: (error) => {
         this.isLoading = false;
+        const desafioIndisponivel = error?.status === 404;
+        if (desafioIndisponivel) {
+          this.mostrarDesafio = false;
+          return;
+        }
+        this.mostrarDesafio = false;
         this._toast.add({
           severity: "info",
           summary: "Aviso!",

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -11,8 +11,4 @@ export const environment = {
     apiURL: "https://app-buscamissa-prod-api-public.azurewebsites.net/api/",
     token:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImRyb2lkYmluaG9AZ21haWwuY29tIiwicm9sZSI6IkFwcCIsIm5iZiI6MTc4MzE3NDg2NSwiZXhwIjoyMDk4NTM0ODY1LCJpYXQiOjE3ODMxNzQ4NjUsImlzcyI6IkJ1c2NhTWlzc2EiLCJhdWQiOiJCdXNjYU1pc3NhQXBpIn0.ahJduNioP3xj0dsub4r2ZX_sGUpVcfaiJLVITQfY7x4",
   },
-  // Validação por desafio matemático (api-public tem os endpoints de desafio)
-  features: {
-    validacaoSemEmail: true,
-  },
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -12,8 +12,4 @@ export const environment = {
     // Token App (SecretApp do Key Vault de dev), já com claims iss/aud.
     token:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImRyb2lkYmluaG9AZ21haWwuY29tIiwicm9sZSI6IkFwcCIsIm5iZiI6MTc4MzE2NTczOCwiZXhwIjoyMDk4Nzg0OTM4LCJpYXQiOjE3ODMxNjU3MzgsImlzcyI6IkJ1c2NhTWlzc2EiLCJhdWQiOiJCdXNjYU1pc3NhQXBpIn0.OrQTwTkloZMHvRk-C4IcAZ5I6M3gtWXmv3uGksTrmD4",
   },
-  // Validação por desafio matemático (api-public tem os endpoints de desafio)
-  features: {
-    validacaoSemEmail: true,
-  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,10 +12,4 @@ export const environment = {
     // Token App rotacionado (SecretApp novo do Key Vault de dev), já com claims iss/aud.
     token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImRyb2lkYmluaG9AZ21haWwuY29tIiwicm9sZSI6IkFwcCIsIm5iZiI6MTc4MzE2NTczOCwiZXhwIjoyMDk4Nzg0OTM4LCJpYXQiOjE3ODMxNjU3MzgsImlzcyI6IkJ1c2NhTWlzc2EiLCJhdWQiOiJCdXNjYU1pc3NhQXBpIn0.OrQTwTkloZMHvRk-C4IcAZ5I6M3gtWXmv3uGksTrmD4",
   },
-  // Validação da contribuição por desafio matemático em vez de código por
-  // e-mail (MailerSend indisponível). Requer o toggle equivalente
-  // (Features:ValidacaoSemEmail) ligado na API.
-  features: {
-    validacaoSemEmail: true,
-  },
 };


### PR DESCRIPTION
…API, não por flag estática

O componente usava environment.features.validacaoSemEmail, hardcoded true em dev/staging/prod, pra escolher a tela — ignorando completamente a FT validacao-sem-email do backend (que já manda essa decisão via validacaoPorDesafio na resposta de gerar-codigo-validador). Resultado: sempre mostrava o desafio matemático, mesmo com a FT desligada e o e-mail sendo enviado de verdade.

Agora o componente sempre tenta carregar o desafio primeiro; se o backend responder que não está habilitado (404), cai pro formulário de código por e-mail. Reflete o estado real da FT em runtime, sobrevive a refresh de página e não depende de nada fixado no build.

Testado localmente nos dois cenários (FT ON e OFF) contra a API de dev.