### PR TITLE
Melhorias no cadastro de igreja: horarios em lote + checagem de CEP duplicado

### DIFF
--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -60,6 +60,40 @@ export class ChurchesService {
     }>(`v2/Igreja/buscar-por-cep/${cep}`);
   }
 
+  /**
+   * Consulta única para o formulário de cadastro/edição: devolve todas as igrejas já
+   * cadastradas nesse CEP (para o usuário confirmar que a dele não é duplicata) e o
+   * endereço do CEP (para preencher o formulário), evitando uma segunda chamada à ViaCEP
+   * direto do frontend. `ignorarIgrejaId` exclui a própria igreja da lista (uso em edição).
+   */
+  consultarCep(cep: string, ignorarIgrejaId?: number) {
+    let params = new HttpParams();
+    if (ignorarIgrejaId != null) {
+      params = params.append("ignorarIgrejaId", ignorarIgrejaId);
+    }
+    return this.http.get<{
+      data: {
+        igrejas: {
+          id: number;
+          nome: string;
+          nomeUnico?: string;
+          slug?: string;
+          endereco: { uf: string; cidadeSlug?: string };
+        }[];
+        endereco: {
+          cep: string;
+          logradouro: string;
+          bairro?: string;
+          localidade: string;
+          uf: string;
+          estado: string;
+          regiao: string;
+          erro: boolean;
+        } | null;
+      };
+    }>(`v2/Igreja/consultar-cep/${cep}`, { params });
+  }
+
   /** Busca cidades e bairros através da UF, Localidade e Bairro */
   public addressRange(): Observable<any> {
     this.addressRange$ ??= this.http

--- a/src/app/modules/public/church/components/church-form/church-form.component.html
+++ b/src/app/modules/public/church/components/church-form/church-form.component.html
@@ -221,55 +221,184 @@
 
   
   <p-fieldset legend="Horários">
-    <div formArrayName="missas" class="w-full">
-      <div
-        *ngFor="let horarioCtrl of horarios.controls; let i = index"
-        [formGroupName]="i"
-        class="flex flex-col md:flex-row gap-4 pt-4 items-center"
-      >
+    <div class="flex flex-col gap-3 pb-4 mb-4 border-b border-surface-200">
+      <span class="font-medium">Adicionar horário</span>
+
+      <div class="flex flex-col md:flex-row gap-2 items-start md:items-center">
         <p-select
-          formControlName="diaSemana"
+          [(ngModel)]="diaUnico"
+          [ngModelOptions]="{ standalone: true }"
           [options]="diasSemana"
           optionLabel="label"
           optionValue="key"
           placeholder="Selecione o dia"
+          appendTo="body"
           class="w-full md:w-1/3"
         ></p-select>
-  
-        <div class="w-full md:w-1/3">
-          <p-datepicker
-            formControlName="horario"
-            [timeOnly]="true"
-            [showClear]="true"
-            inputId="Horario"
-            [readonlyInput]="false"
-            showIcon
-            fluid="true"
-            iconDisplay="input"
-            [stepMinute]="15"
-            (onFocus)="setDefaultTimeIfNull(horarioCtrl.get('horario'))"
-          />
-        </div>
-  
-        <input
-          pInputText
-          formControlName="observacao"
-          placeholder="Observação"
-          class="w-full md:w-1/3"
+
+        <p-datepicker
+          [(ngModel)]="horarioUnico"
+          [ngModelOptions]="{ standalone: true }"
+          [timeOnly]="true"
+          [showClear]="true"
+          inputId="horarioUnico"
+          [readonlyInput]="false"
+          showIcon
+          fluid="true"
+          iconDisplay="input"
+          [stepMinute]="15"
+          (onFocus)="setDefaultTimeIfNullUnico()"
+          class="w-full md:w-1/4"
         />
-  
-        <p-button icon="pi pi-trash" (click)="removerHorario(i)" class="w-full md:w-auto"></p-button>
+
+        <div class="w-full md:w-1/4">
+          <input
+            pInputText
+            [(ngModel)]="observacaoUnica"
+            [ngModelOptions]="{ standalone: true }"
+            placeholder="Observação"
+            maxlength="20"
+            class="w-full"
+          />
+          <small class="block text-right text-gray-400">{{ observacaoUnica.length }}/20</small>
+        </div>
+
+        <p-button
+          label="Adicionar"
+          icon="pi pi-plus"
+          size="small"
+          class="w-full md:w-auto"
+          [disabled]="diaUnico === null || !horarioUnico"
+          (click)="adicionarHorarioUnico()"
+        ></p-button>
       </div>
     </div>
-  
-    <div class="pt-4">
-      <p-button
-        label="Novo horário"
-        icon="pi pi-plus"
-        class="p-button-primary"
-        size="small"
-        (click)="adicionarHorario()"
-      ></p-button>
+
+    <p-panel header="Adicionar em lote" [toggleable]="true" [collapsed]="true" styleClass="mb-4">
+      <div class="flex flex-col gap-3">
+        <span class="text-sm text-gray-500">
+          Selecione um ou mais dias da semana e um ou mais horários, depois clique em "Adicionar" para
+          criar todas as combinações de uma vez na tabela abaixo.
+        </span>
+
+        <div class="flex flex-col md:flex-row gap-2 items-start md:items-center">
+          <p-multiselect
+            [(ngModel)]="diasSemanaLote"
+            [ngModelOptions]="{ standalone: true }"
+            [options]="diasSemana"
+            optionLabel="label"
+            optionValue="key"
+            placeholder="Selecione o(s) dia(s)"
+            display="chip"
+            class="w-full md:w-1/3"
+          ></p-multiselect>
+
+          <div class="flex gap-2 items-center w-full md:w-1/3">
+            <p-datepicker
+              [(ngModel)]="novoHorarioLote"
+              [ngModelOptions]="{ standalone: true }"
+              [timeOnly]="true"
+              [showClear]="true"
+              inputId="horarioLote"
+              [readonlyInput]="false"
+              showIcon
+              fluid="true"
+              iconDisplay="input"
+              [stepMinute]="15"
+              (onFocus)="setDefaultTimeIfNullLote()"
+              class="w-full"
+            />
+            <p-button
+              icon="pi pi-plus"
+              pTooltip="Adicionar horário à lista"
+              (click)="adicionarHorarioNaLista()"
+              [disabled]="!novoHorarioLote"
+            ></p-button>
+          </div>
+
+          <p-button
+            label="Adicionar"
+            icon="pi pi-check"
+            size="small"
+            class="w-full md:w-auto"
+            [disabled]="!diasSemanaLote.length || !horariosLote.length"
+            (click)="aplicarHorariosEmLote()"
+          ></p-button>
+        </div>
+
+        <div class="flex flex-wrap gap-2" *ngIf="horariosLote.length">
+          <p-chip
+            *ngFor="let h of horariosLote; let i = index"
+            [label]="(h | date: 'HH:mm') ?? ''"
+            [removable]="true"
+            (onRemove)="removerHorarioDaLista(i)"
+          ></p-chip>
+        </div>
+      </div>
+    </p-panel>
+
+    <div class="overflow-x-auto" formArrayName="missas">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="text-left text-sm text-gray-500">
+            <th class="font-medium pb-2 pr-2">Dia</th>
+            <th class="font-medium pb-2 pr-2">Horário</th>
+            <th class="font-medium pb-2 pr-2">Observação</th>
+            <th class="pb-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            *ngFor="let horarioCtrl of horarios.controls; let i = index"
+            [formGroupName]="i"
+            class="align-top"
+          >
+            <td class="pr-2 pb-2 w-1/3">
+              <p-select
+                formControlName="diaSemana"
+                [options]="diasSemana"
+                optionLabel="label"
+                optionValue="key"
+                placeholder="Selecione o dia"
+                appendTo="body"
+                class="w-full"
+              ></p-select>
+            </td>
+
+            <td class="pr-2 pb-2 w-1/4">
+              <p-datepicker
+                formControlName="horario"
+                [timeOnly]="true"
+                [showClear]="true"
+                inputId="Horario"
+                [readonlyInput]="false"
+                showIcon
+                fluid="true"
+                iconDisplay="input"
+                [stepMinute]="15"
+                (onFocus)="setDefaultTimeIfNull(horarioCtrl.get('horario'))"
+              />
+            </td>
+
+            <td class="pr-2 pb-2">
+              <input
+                pInputText
+                formControlName="observacao"
+                placeholder="Observação"
+                maxlength="20"
+                class="w-full"
+              />
+              <small class="block text-right text-gray-400">
+                {{ horarioCtrl.get('observacao')?.value?.length ?? 0 }}/20
+              </small>
+            </td>
+
+            <td class="pb-2 text-right">
+              <p-button icon="pi pi-trash" size="small" (click)="removerHorario(i)"></p-button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </p-fieldset>
   

--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -210,6 +210,7 @@ export class ChurchFormComponent implements OnInit, OnChanges {
     // Limpar e popular FormArray de Missas
     this.horarios.clear();
     data.missas?.forEach((missa) => this.addMissaControl(missa));
+    this.ordenarHorarios();
 
     // Resetar nome da imagem se não houver imagem nos dados iniciais
     this.imageName = data.imagem ? "imagem_carregada" : null; // Ou extrair nome se possível
@@ -323,6 +324,106 @@ export class ChurchFormComponent implements OnInit, OnChanges {
     return this.form.get("missas") as FormArray;
   }
 
+  // Estado do formulário de adição em lote (dias x horários)
+  diasSemanaLote: number[] = [];
+  horariosLote: Date[] = [];
+  novoHorarioLote: Date | null = null;
+
+  // Ajusta o horário digitado no seletor de lote para o passo de 15 min, igual à tabela principal
+  setDefaultTimeIfNullLote(): void {
+    const current = this.novoHorarioLote;
+    const d = current ? new Date(current) : new Date();
+    const snapped = Math.round(d.getMinutes() / 15) * 15;
+    d.setMinutes(snapped % 60, 0, 0);
+    if (snapped === 60) d.setHours(d.getHours() + 1);
+    this.novoHorarioLote = d;
+  }
+
+  private mesmoHorario(a: Date, b: Date): boolean {
+    return a.getHours() === b.getHours() && a.getMinutes() === b.getMinutes();
+  }
+
+  adicionarHorarioNaLista(): void {
+    if (!this.novoHorarioLote) return;
+    const jaExiste = this.horariosLote.some((h) => this.mesmoHorario(h, this.novoHorarioLote!));
+    if (!jaExiste) {
+      this.horariosLote.push(this.novoHorarioLote);
+      this.horariosLote.sort((a, b) => a.getTime() - b.getTime());
+    }
+    this.novoHorarioLote = null;
+  }
+
+  removerHorarioDaLista(index: number): void {
+    this.horariosLote.splice(index, 1);
+  }
+
+  // Gera o produto (dias selecionados x horários selecionados) e adiciona à tabela de horários,
+  // reaproveitando o mesmo FormArray/validações usados na edição linha a linha.
+  aplicarHorariosEmLote(): void {
+    if (!this.diasSemanaLote.length || !this.horariosLote.length) {
+      this.messageService.add({
+        severity: "warn",
+        summary: "Selecione os dados",
+        detail: "Escolha ao menos um dia da semana e um horário para adicionar.",
+      });
+      return;
+    }
+
+    let adicionados = 0;
+    this.diasSemanaLote.forEach((dia) => {
+      this.horariosLote.forEach((horario) => {
+        const jaExisteNoForm = this.horarios.controls.some((ctrl) => {
+          const v = ctrl.value;
+          return v.diaSemana === dia && v.horario instanceof Date && this.mesmoHorario(v.horario, horario);
+        });
+        if (!jaExisteNoForm) {
+          this.horarios.push(
+            this.fb.group({
+              id: [null],
+              diaSemana: [dia, Validators.required],
+              horario: [new Date(horario), [Validators.required, this.minutosValidos()]],
+              observacao: ["", Validators.maxLength(20)],
+            })
+          );
+          adicionados++;
+        }
+      });
+    });
+
+    if (adicionados > 0) {
+      this.messageService.add({
+        severity: "success",
+        summary: "Horários adicionados",
+        detail: `${adicionados} horário(s) adicionado(s) à tabela abaixo.`,
+      });
+    }
+
+    this.diasSemanaLote = [];
+    this.horariosLote = [];
+    this.novoHorarioLote = null;
+    this.ordenarHorarios();
+    this.cd.markForCheck();
+  }
+
+  // Reordena as linhas da tabela por dia da semana e depois por horário, sem recriar os
+  // FormGroups (setControl preserva estado/valor de cada linha, só muda a posição no array).
+  ordenarHorarios(): void {
+    const controlsOrdenados = [...this.horarios.controls].sort((a, b) => {
+      const va = a.value;
+      const vb = b.value;
+      const diaA = va.diaSemana ?? Number.MAX_SAFE_INTEGER;
+      const diaB = vb.diaSemana ?? Number.MAX_SAFE_INTEGER;
+      if (diaA !== diaB) return diaA - diaB;
+
+      const horaA = va.horario instanceof Date ? va.horario.getTime() : Number.MAX_SAFE_INTEGER;
+      const horaB = vb.horario instanceof Date ? vb.horario.getTime() : Number.MAX_SAFE_INTEGER;
+      return horaA - horaB;
+    });
+
+    controlsOrdenados.forEach((ctrl, index) => this.horarios.setControl(index, ctrl));
+    this.cd.markForCheck();
+  }
+
   // Adiciona um controle de grupo para uma missa ao FormArray
   private addMissaControl(missa?: Mass): void {
     this.horarios.push(
@@ -333,15 +434,53 @@ export class ChurchFormComponent implements OnInit, OnChanges {
           missa?.horario ? this.stringParaDate(missa.horario as string) : null,
           [Validators.required, this.minutosValidos()],
         ],
-        observacao: [missa?.observacao ?? "", Validators.maxLength(200)],
+        observacao: [missa?.observacao ?? "", Validators.maxLength(20)],
       })
     );
   }
   
 
-  // Adiciona um novo grupo de missa vazio
-  adicionarHorario(): void {
-    this.addMissaControl();
+  // Estado do formulário fixo de adição individual (dia + horário + observação).
+  // Fica fora do FormArray/tabela de propósito: assim o usuário preenche os campos
+  // com calma, sem a linha pular de posição a cada seleção, e só entra (já ordenada)
+  // na tabela quando ele clicar em "Adicionar".
+  diaUnico: number | null = null;
+  horarioUnico: Date | null = null;
+  observacaoUnica: string = "";
+
+  setDefaultTimeIfNullUnico(): void {
+    const current = this.horarioUnico;
+    const d = current ? new Date(current) : new Date();
+    const snapped = Math.round(d.getMinutes() / 15) * 15;
+    d.setMinutes(snapped % 60, 0, 0);
+    if (snapped === 60) d.setHours(d.getHours() + 1);
+    this.horarioUnico = d;
+  }
+
+  adicionarHorarioUnico(): void {
+    if (this.diaUnico === null || !this.horarioUnico) {
+      this.messageService.add({
+        severity: "warn",
+        summary: "Selecione os dados",
+        detail: "Escolha o dia da semana e o horário antes de adicionar.",
+      });
+      return;
+    }
+
+    this.horarios.push(
+      this.fb.group({
+        id: [null],
+        diaSemana: [this.diaUnico, Validators.required],
+        horario: [new Date(this.horarioUnico), [Validators.required, this.minutosValidos()]],
+        observacao: [this.observacaoUnica ?? "", Validators.maxLength(20)],
+      })
+    );
+    this.ordenarHorarios();
+
+    this.diaUnico = null;
+    this.horarioUnico = null;
+    this.observacaoUnica = "";
+    this.cd.markForCheck();
   }
 
   removerHorario(index: number): void {

--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -49,6 +49,9 @@ export class ChurchFormComponent implements OnInit, OnChanges {
   @Input() initialData: ChurchFormData | null = null;
   @Input() isSaving: boolean = false;
   @Input() isEditMode: boolean = false; // Para desabilitar CEP na edição
+  // Trava o formulário inteiro (exceto o campo CEP) enquanto o usuário não confirma,
+  // na tela pai, que nenhuma das igrejas já cadastradas nesse CEP é a dele.
+  @Input() bloqueadoPorCep: boolean = false;
   @Output() formSubmit = new EventEmitter<ChurchFormData>();
   @Output() formCancel = new EventEmitter<void>(); // Opcional: Para botão Cancelar
   @Output() cepLookup = new EventEmitter<string>(); // Emitir evento para busca de CEP
@@ -135,6 +138,11 @@ export class ChurchFormComponent implements OnInit, OnChanges {
       if (this.initialData) {
         this.populateForm(this.initialData);
       }
+      // Controles de rede social são adicionados de forma assíncrona (depois do
+      // disable-all abaixo); re-sincroniza para não deixá-los "escapar" do bloqueio.
+      if (this.bloqueadoPorCep) {
+        this.aplicarBloqueioPorCep();
+      }
     });
 
     if (this.initialData) {
@@ -144,6 +152,12 @@ export class ChurchFormComponent implements OnInit, OnChanges {
     if (this.isEditMode) {
       this.disableFields(); // Desabilita campos se necessário
       this.form.get("cep")?.disable(); // Desabilita CEP na edição
+    }
+
+    // Cobre o caso do componente já nascer bloqueado (o form ainda não existia
+    // quando o primeiro ngOnChanges rodou com bloqueadoPorCep=true).
+    if (this.bloqueadoPorCep) {
+      this.aplicarBloqueioPorCep();
     }
 
     if (this.isEditMode && this.form.value.imagem) {
@@ -178,6 +192,32 @@ export class ChurchFormComponent implements OnInit, OnChanges {
         this.form.get("cep")?.enable();
       }
     }
+    // Sem !firstChange aqui de propósito: a tela de cadastro esconde o
+    // <app-church-form> com *ngIf durante o loading do CEP, o que destrói e
+    // recria o componente a cada busca — então um bloqueio ativo pode chegar
+    // já na criação (firstChange: true), não só numa mudança posterior.
+    if (changes["bloqueadoPorCep"] && this.form) {
+      this.aplicarBloqueioPorCep();
+    }
+  }
+
+  // Trava/destrava o formulário inteiro (menos o CEP) quando a tela pai encontra
+  // igreja(s) já cadastradas no CEP informado. Ao destravar, reaplica as regras de
+  // edição (CEP sempre desabilitado); as regras de endereço (cidade/uf/etc.) voltam
+  // a ser aplicadas pela própria applyCepAddress logo em seguida, no fluxo do pai.
+  private aplicarBloqueioPorCep(): void {
+    if (this.bloqueadoPorCep) {
+      Object.keys(this.form.controls).forEach((key) => {
+        if (key !== "cep") this.form.get(key)?.disable({ emitEvent: false });
+      });
+    } else {
+      this.form.enable({ emitEvent: false });
+      if (this.isEditMode) {
+        this.disableFields();
+        this.form.get("cep")?.disable({ emitEvent: false });
+      }
+    }
+    this.cd.markForCheck();
   }
 
   constructor(private cd: ChangeDetectorRef) {}

--- a/src/app/modules/public/church/models/church.model.ts
+++ b/src/app/modules/public/church/models/church.model.ts
@@ -56,6 +56,9 @@ export interface ChurchApiData {
   endereco: Address;
   contato?: Contact;
   redesSociais?: SocialMedia[];
+  // Usuário confirmou, na tela de cadastro, que sua igreja não é nenhuma das que
+  // já existem no mesmo CEP (fluxo "Não é nenhuma destas - Informar uma Nova").
+  confirmouNovaIgreja?: boolean;
 }
 
 // Modelo da Igreja para o Formulário (pode ter tipos diferentes, ex: Date para horário)

--- a/src/app/modules/public/church/pages/church-edit-page/church-edit-page.component.ts
+++ b/src/app/modules/public/church/pages/church-edit-page/church-edit-page.component.ts
@@ -116,7 +116,7 @@ export class ChurchEditPageComponent implements OnInit {
         this.messageService.add({
           severity: "success",
           summary: "Sucesso",
-          detail: "Alteração de igreja em andamento! Verifique seu e-mail para validação.",
+          detail: "Alterada, vamos validar!",
         });
         if (controleId) {
           this.router.navigate(["/enviar-codigo", controleId]);

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
@@ -6,7 +6,6 @@
 </div>
 <div class="pt-2">
   <p-toast />
-  <p-confirmDialog></p-confirmDialog>
   <p-progressBar
     mode="indeterminate"
     *ngIf="isLoading"
@@ -18,10 +17,42 @@
     <p>Procurando informações do CEP...</p>
   </div>
 
+  <div *ngIf="!isCepLoading && igrejasDuplicadas.length" class="mb-4">
+    <p-message severity="warn" styleClass="w-full">
+      <div class="flex flex-col gap-3 py-1">
+        <span class="font-medium">Já encontramos igreja(s) cadastrada(s) para este CEP. Confira se alguma é a sua:</span>
+        <div class="flex flex-col gap-2">
+          <a
+            *ngFor="let igreja of igrejasDuplicadas"
+            [routerLink]="linkParoquia(igreja)"
+            target="_blank"
+            class="flex items-center justify-between gap-3 bg-white border border-surface-200 rounded-lg px-4 py-3 shadow-sm hover:shadow-md hover:border-primary transition-all no-underline"
+          >
+            <span class="flex items-center gap-2">
+              <i class="pi pi-map-marker text-primary"></i>
+              <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
+            </span>
+            <span class="flex items-center gap-1 text-sm text-primary font-medium shrink-0">
+              Ver detalhes <i class="pi pi-external-link text-xs"></i>
+            </span>
+          </a>
+        </div>
+        <p-button
+          label="Não é nenhuma destas - Informar uma Nova"
+          icon="pi pi-plus"
+          size="small"
+          styleClass="w-fit"
+          (click)="confirmarNovaIgreja()"
+        ></p-button>
+      </div>
+    </p-message>
+  </div>
+
   <p-panel header="Formulário de Cadastro" class="mb-4" *ngIf="!isCepLoading">
     <app-church-form
       [isSaving]="isLoading"
       [isEditMode]="false"
+      [bloqueadoPorCep]="igrejasDuplicadas.length > 0"
       (formSubmit)="handleFormSubmit($event)"
       (formCancel)="cancel()"
       (cepLookup)="handleCepLookup($event)"

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -9,7 +9,7 @@ import {
 import { Router, RouterLink } from "@angular/router";
 import { CommonModule, DatePipe } from "@angular/common";
 import { HttpErrorResponse } from "@angular/common/http";
-import { ConfirmationService, MessageService } from "primeng/api";
+import { MessageService } from "primeng/api";
 
 import {
   ChurchFormData,
@@ -21,12 +21,13 @@ import { ChurchesService } from "../../../../../core/services/churches.service";
 import { ClarityService } from "../../../../../core/services/clarity.service";
 import { RedesSociaisService, TipoRedeSocial } from "../../../../../core/services/redes-sociais.service";
 import { LoggerService } from "../../../../../core/services/logger.service";
+import { linkParoquia } from "../../../../../shared/utils/church-link.utils";
 
 @Component({
   selector: "app-church-registration-page",
   standalone: true,
   imports: [CommonModule, RouterLink, ChurchFormComponent, PrimeNgModule],
-  providers: [MessageService, DatePipe, ConfirmationService],
+  providers: [MessageService, DatePipe],
   templateUrl: "./church-registration-page.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -36,7 +37,6 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   private churchService = inject(ChurchesService);
   private router = inject(Router);
   private messageService = inject(MessageService);
-  private confirmationService = inject(ConfirmationService);
   private datePipe = inject(DatePipe);
   private cd = inject(ChangeDetectorRef);
   private _clarity = inject(ClarityService);
@@ -46,6 +46,19 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   private tiposRedeSocial: TipoRedeSocial[] = [];
   isLoading = false;
   isCepLoading = false;
+  readonly linkParoquia = linkParoquia;
+
+  // Igrejas já cadastradas no CEP informado — enquanto a lista não estiver vazia,
+  // o restante do formulário fica travado até o usuário confirmar que nenhuma delas
+  // é a sua (botão "Não é nenhuma destas").
+  igrejasDuplicadas: {
+    id: number;
+    nome: string;
+    nomeUnico?: string;
+    slug?: string;
+    endereco: { uf: string; cidadeSlug?: string };
+  }[] = [];
+  private enderecoPendente: any = null;
 
   ngAfterViewInit(): void {
     this.redesSociaisService.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
@@ -86,73 +99,73 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     });
   }
 
-  // Lida com a busca de CEP vinda do form filho
+  // Lida com a busca de CEP vinda do form filho: numa única consulta, verifica se já
+  // existem igrejas cadastradas nesse CEP (bloqueia o restante do form até o usuário
+  // confirmar que não é nenhuma delas) e traz o endereço para preencher o formulário.
   handleCepLookup(cep: string): void {
     if (!this.churchFormComponent) return;
     this.isCepLoading = true;
+    this.igrejasDuplicadas = [];
+    this.enderecoPendente = null;
     this.cd.markForCheck();
-    this.churchService.searchByCEP(cep).subscribe({
-      next: (response: any) => {
-        this.isCepLoading = false;
-        // Se encontrou uma IGREJA existente (inesperado no cadastro, mas tratar)
-        if (response?.data?.response?.id) {
 
-          this.confirmationService.confirm({
-            header: "Igreja já cadastrada",
-            message:
-              "Já existe uma igreja com este CEP. Deseja editar o cadastro existente?",
-            icon: "pi pi-exclamation-triangle",
-            acceptLabel: "Sim",
-            rejectLabel: "Não",
-            accept: () => {
-              this.router.navigate(["/editar", response?.data?.response?.id]);
-            },
-            reject: () => {
-              this.churchFormComponent.form.reset(); // limpa o formulário
-              this.churchFormComponent.updateAddressFieldsState(false); // reabilita os campos
-              this.cd.markForCheck();
-            },
-          });
+    this.churchService.consultarCep(cep).subscribe({
+      next: (response) => {
+        this.isCepLoading = false;
+        const { igrejas, endereco } = response.data;
+
+        if (igrejas?.length) {
+          // Trava o restante do form (via binding [bloqueadoPorCep] no template)
+          // até o usuário confirmar que a igreja dele não está na lista.
+          this.igrejasDuplicadas = igrejas;
+          this.enderecoPendente = endereco;
+          this.cd.markForCheck();
+          return;
         }
+
+        this.aplicarEnderecoOuErro(endereco);
         this.cd.markForCheck();
       },
       error: (error: HttpErrorResponse) => {
         this.isCepLoading = false;
-        // Tratamento específico para 404 que RETORNA endereço (como no seu código original)
-        if (error.status === 404 && error.error?.data?.endereco) {
-          const address = error.error.data.endereco;
-          const isAddressEmpty = Object.values(address).every(
-            (v) => v === null || v === undefined || v === ""
-          );
-
-          if (isAddressEmpty) {
-            this.messageService.add({
-              severity: "error",
-              summary: "Erro",
-              detail: "CEP não encontrado.",
-            });
-            this.churchFormComponent?.form
-              .get("cep")
-              ?.setErrors({ notFound: true });
-          } else {
-            this.messageService.add({
-              severity: "info",
-              summary: "Endereço Encontrado",
-              detail: "Endereço preenchido automaticamente.",
-            });
-            this.cd.detectChanges();
-            // Trava só o que veio preenchido; campos vazios ficam liberados e
-            // cidade/UF ausentes viram seleção padronizada (ver ChurchFormComponent).
-            this.churchFormComponent?.applyCepAddress(address);
-            setTimeout(() => document.getElementById("numero")?.focus(), 0);
-          }
-        } else {
-          // Outro erro na busca de CEP
-          this.showErrorToast(error, "Erro ao buscar CEP");
-        }
+        this.showErrorToast(error, "Erro ao buscar CEP");
         this.cd.markForCheck();
       },
     });
+  }
+
+  // Usuário confirmou, na lista de igrejas do CEP, que nenhuma delas é a sua —
+  // libera o restante do formulário e aplica o endereço que já veio na consulta.
+  confirmarNovaIgreja(): void {
+    this.igrejasDuplicadas = [];
+    this.aplicarEnderecoOuErro(this.enderecoPendente);
+    this.enderecoPendente = null;
+    this.cd.markForCheck();
+  }
+
+  private aplicarEnderecoOuErro(address: any): void {
+    const isAddressEmpty = !address || address.erro;
+
+    if (isAddressEmpty) {
+      this.messageService.add({
+        severity: "error",
+        summary: "Erro",
+        detail: "CEP não encontrado.",
+      });
+      this.churchFormComponent?.form.get("cep")?.setErrors({ notFound: true });
+      return;
+    }
+
+    this.messageService.add({
+      severity: "info",
+      summary: "Endereço Encontrado",
+      detail: "Endereço preenchido automaticamente.",
+    });
+    this.cd.detectChanges();
+    // Trava só o que veio preenchido; campos vazios ficam liberados e
+    // cidade/UF ausentes viram seleção padronizada (ver ChurchFormComponent).
+    this.churchFormComponent?.applyCepAddress(address);
+    setTimeout(() => document.getElementById("numero")?.focus(), 0);
   }
 
   // Mapeia os dados do formulário para o formato esperado pela API de CRIAÇÃO

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -59,6 +59,10 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     endereco: { uf: string; cidadeSlug?: string };
   }[] = [];
   private enderecoPendente: any = null;
+  // true depois que o usuário clica em "Não é nenhuma destas": vai no payload de
+  // criação para o backend não bloquear a igreja só por já existir outra no CEP
+  // (várias igrejas legitimamente compartilham o mesmo CEP).
+  private cepDuplicataConfirmada = false;
 
   ngAfterViewInit(): void {
     this.redesSociaisService.obterTipos().subscribe((tipos) => (this.tiposRedeSocial = tipos));
@@ -107,6 +111,7 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     this.isCepLoading = true;
     this.igrejasDuplicadas = [];
     this.enderecoPendente = null;
+    this.cepDuplicataConfirmada = false;
     this.cd.markForCheck();
 
     this.churchService.consultarCep(cep).subscribe({
@@ -138,6 +143,7 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   // libera o restante do formulário e aplica o endereço que já veio na consulta.
   confirmarNovaIgreja(): void {
     this.igrejasDuplicadas = [];
+    this.cepDuplicataConfirmada = true;
     this.aplicarEnderecoOuErro(this.enderecoPendente);
     this.enderecoPendente = null;
     this.cd.markForCheck();
@@ -206,6 +212,7 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
         emailContato: formData.emailContato,
       },
       redesSociais: this._mapearRedesSociais(formData),
+      confirmouNovaIgreja: this.cepDuplicataConfirmada,
     };
     return payload;
   }

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -83,7 +83,7 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
         this.messageService.add({
           severity: "success",
           summary: "Sucesso",
-          detail: "Cadastro iniciado! Verifique seu e-mail para validação.",
+          detail: "Cadastrada, vamos validar!",
         });
         if (controleId) {
           // Navega para a página de validação

--- a/src/app/shared/primeng.module.ts
+++ b/src/app/shared/primeng.module.ts
@@ -37,6 +37,8 @@ import { TableModule } from "primeng/table";
 import { PaginatorModule } from "primeng/paginator";
 import { ProgressSpinnerModule } from "primeng/progressspinner";
 import { TextareaModule } from "primeng/textarea";
+import { MultiSelectModule } from "primeng/multiselect";
+import { ChipModule } from "primeng/chip";
 @NgModule({
   imports: [
     CommonModule,
@@ -74,7 +76,9 @@ import { TextareaModule } from "primeng/textarea";
     TableModule,
     PaginatorModule,
     ProgressSpinnerModule,
-    TextareaModule
+    TextareaModule,
+    MultiSelectModule,
+    ChipModule
   ],
   exports: [
     FieldsetModule,
@@ -111,7 +115,9 @@ import { TextareaModule } from "primeng/textarea";
     TableModule,
     PaginatorModule,
     ProgressSpinnerModule,
-    TextareaModule
+    TextareaModule,
+    MultiSelectModule,
+    ChipModule
   ],
 })
 export class PrimeNgModule {}


### PR DESCRIPTION
## Summary

### Horários de missa (commit 7dbf0bf)
- Formulário fixo "Adicionar horário" (dia + horário + observação) que só entra na tabela após confirmar, evitando que a linha pule de posição durante o preenchimento.
- Seção retrátil "Adicionar em lote": seleciona múltiplos dias da semana e múltiplos horários de uma vez, gerando o produto cartesiano das combinações (evitando duplicatas).
- Tabela de horários reordenada automaticamente por dia da semana e horário após cada inserção.
- Tabela compactada (layout em `<table>`) para reduzir a altura da tela.
- Campo "Observação" limitado a 20 caracteres, com contador visual (`x/20`).

### Checagem de CEP duplicado no cadastro (commit 56c026b)
- Ao informar o CEP no cadastro (`/nova`), uma única consulta ao novo endpoint `v2/Igreja/consultar-cep/{cep}` retorna as igrejas já cadastradas naquele CEP e os dados do endereço.
- Se houver igrejas, o formulário fica travado e uma lista estilizada (cards com link para os detalhes) é exibida.
- Botão "Não é nenhuma destas - Informar uma Nova" libera o cadastro e aplica o endereço retornado.
- Cidade/Estado/UF/Região continuam sempre travados; os demais campos só liberam se não vierem da API.
- Depende do endpoint novo no `buscamissa-api-public` (commit `4fa6ec5` na branch `dev` de lá, deploy automático no Azure dev).

## Test plan
- [x] Horários: lote, adição individual, reordenação e limite de observação testados no navegador.
- [x] CEP com igreja cadastrada (12460000): alerta com card estilizado + formulário travado + botão libera cadastro.
- [x] CEP sem igreja (01310-200): cadastro libera direto com endereço preenchido e Cidade/Estado travados.
- [x] Backend testado localmente (endpoint retorna igrejas + endereço; `ignorarIgrejaId` funciona).
- [x] Validar em dev após deploy do api-public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)