### PR TITLE
feat: contratos de hierarquia de igreja (Fase 2 — Responsável Verificado)

### DIFF
--- a/src/app/core/interfaces/church.interface.ts
+++ b/src/app/core/interfaces/church.interface.ts
@@ -14,6 +14,15 @@ export interface FilterSearchChurch {
 
 export type StatusConfianca = 'Alta' | 'Media' | 'Baixa' | 'Desconhecida';
 
+// Espelha Enums/TipoIgrejaEnum.cs do backend (int cru no banco — não renumerar).
+export enum TipoIgreja {
+  Paroquia = 1,
+  Capela = 2,
+  Comunidade = 3,
+  Santuario = 4,
+  Outro = 99,
+}
+
 export interface Church {
   id?: number;
   nomeUnico?: string;
@@ -23,6 +32,10 @@ export interface Church {
   missas: Mass[];
   endereco: Address;
   statusConfianca?: StatusConfianca;
+  /** Tipo da unidade (Paróquia, Capela...). Ausente em respostas antigas = Paróquia. */
+  tipoIgreja?: TipoIgreja;
+  /** Paróquia-sede quando esta unidade é capela/comunidade; null para paróquias. */
+  igrejaPaiId?: number | null;
 }
 
 export interface UpdateChurch {

--- a/src/app/modules/public/church/models/church.model.ts
+++ b/src/app/modules/public/church/models/church.model.ts
@@ -59,6 +59,10 @@ export interface ChurchApiData {
   // Usuário confirmou, na tela de cadastro, que sua igreja não é nenhuma das que
   // já existem no mesmo CEP (fluxo "Não é nenhuma destas - Informar uma Nova").
   confirmouNovaIgreja?: boolean;
+  /** Tipo da unidade (TipoIgreja em core/interfaces). Ausente = Paróquia. */
+  tipoIgreja?: number;
+  /** Paróquia-sede quando capela/comunidade; null para paróquias. */
+  igrejaPaiId?: number | null;
 }
 
 // Modelo da Igreja para o Formulário (pode ter tipos diferentes, ex: Date para horário)


### PR DESCRIPTION
## Resumo
Fase 2 do plano **Responsável Verificado** (front público): espelha o `TipoIgrejaEnum` e os novos campos de `Igreja` do backend nas interfaces TS.

Backend correspondente: buscamissa/buscamissa-api-admin#12

## Mudanças
- `core/interfaces/church.interface.ts`: enum `TipoIgreja` + campos opcionais `tipoIgreja`/`igrejaPaiId` em `Church`
- `modules/public/church/models/church.model.ts`: mesmos campos em `ChurchApiData`

Campos opcionais — compatível com respostas da API que ainda não os expõem. Nenhuma mudança de UI/comportamento. `tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)