### PR TITLE
feat: login do Responsável Verificado — tela /entrar + sessão (Fase 3)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,5 @@
-import { ApplicationConfig, ErrorHandler, provideZoneChangeDetection } from "@angular/core";
+import { ApplicationConfig, ErrorHandler, inject, provideAppInitializer, provideZoneChangeDetection } from "@angular/core";
+import { AuthService } from "./core/services/auth.service";
 import { GlobalErrorHandler } from "./core/error/global-error-handler";
 import { provideRouter } from "@angular/router";
 import { routes } from "./app.routes";
@@ -21,6 +22,8 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     provideHttpClient(withInterceptorsFromDi()),
     provideEnvironmentNgxMask(),
+    // Restaura/renova a sessão do Responsável Verificado ao abrir o app
+    provideAppInitializer(() => inject(AuthService).restaurarSessao()),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
     {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -195,6 +195,18 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "entrar",
+        data: {
+          title: 'Entrar | BuscaMissa',
+          description: 'Área do responsável pela paróquia: entre para gerenciar as informações da sua igreja no BuscaMissa.',
+          canonical: 'https://buscamissa.com.br/entrar',
+        },
+        loadComponent: () =>
+          import("./modules/public/entrar/entrar.component").then(
+            (m) => m.EntrarComponent
+          ),
+      },
+      {
         path: "solicitar",
         data: {
           title: 'Fale Conosco | BuscaMissa',

--- a/src/app/core/interfaces/user.interface.ts
+++ b/src/app/core/interfaces/user.interface.ts
@@ -12,6 +12,31 @@ export interface AuthRequest {
   senha: string;
 }
 
+// ---- Auth do usuário público (fluxo Responsável Verificado) ----
+// Espelha Dtos/AuthDtos.cs do api-public.
+
+export interface SolicitarCodigoSenhaRequest {
+  email: string;
+  nome?: string;
+}
+
+export interface DefinirSenhaRequest {
+  email: string;
+  codigo: number;
+  novaSenha: string;
+}
+
+export interface AuthResponse {
+  id: number;
+  nome: string;
+  email: string;
+  perfil: string;
+  token: string;
+  tokenExpira: string;
+  refreshToken: string;
+  refreshTokenExpira: string;
+}
+
 export interface ValidatorCodeRequest {
   email: string;
   nome: string;

--- a/src/app/core/middleware/auth.interceptor.ts
+++ b/src/app/core/middleware/auth.interceptor.ts
@@ -1,12 +1,17 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { AuthService } from '../services/auth.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  private authService = inject(AuthService);
+
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    const token = environment.config.token;
+    // Sessão de usuário logado (Responsável Verificado) tem prioridade;
+    // chamadas anônimas seguem com o token estático de app, como sempre.
+    const token = this.authService.accessToken ?? environment.config.token;
     if (token) {
       const clonedReq = req.clone({
         setHeaders: {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,112 @@
+import { HttpClient } from "@angular/common/http";
+import { inject, Injectable } from "@angular/core";
+import { BehaviorSubject, Observable, map, tap } from "rxjs";
+import {
+  AuthResponse,
+  DefinirSenhaRequest,
+  SolicitarCodigoSenhaRequest,
+} from "../interfaces/user.interface";
+
+const STORAGE_KEY = "bm_sessao";
+
+/**
+ * Sessão do usuário público (fluxo Responsável Verificado).
+ * Login com senha + refresh token emitidos pelo api-public (api/v1/auth).
+ * O token de sessão convive com o token estático de app: o AuthInterceptor
+ * usa o de sessão quando válido e cai para o estático nas chamadas anônimas.
+ */
+@Injectable({ providedIn: "root" })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  private sessaoSubject = new BehaviorSubject<AuthResponse | null>(this.carregarSessao());
+  /** Sessão atual (null = anônimo). */
+  readonly sessao$ = this.sessaoSubject.asObservable();
+
+  get sessao(): AuthResponse | null {
+    return this.sessaoSubject.value;
+  }
+
+  get estaLogado(): boolean {
+    return this.tokenValido(this.sessao);
+  }
+
+  /** Token de acesso válido (não expirado), ou null. */
+  get accessToken(): string | null {
+    const sessao = this.sessao;
+    return this.tokenValido(sessao) ? sessao!.token : null;
+  }
+
+  /** Serve para cadastro de senha E "esqueci minha senha". */
+  solicitarCodigoSenha(request: SolicitarCodigoSenhaRequest): Observable<string> {
+    return this.http
+      .post<{ data: { mensagemTela: string } }>("v1/auth/solicitar-codigo-senha", request)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  definirSenha(request: DefinirSenhaRequest): Observable<string> {
+    return this.http
+      .post<{ data: { mensagemTela: string } }>("v1/auth/definir-senha", request)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  login(email: string, senha: string): Observable<AuthResponse> {
+    return this.http
+      .post<{ data: AuthResponse }>("v1/auth/login", { email, senha })
+      .pipe(
+        map((r) => r.data),
+        tap((sessao) => this.salvarSessao(sessao))
+      );
+  }
+
+  /** Rotaciona o refresh token; sessão cai se o backend rejeitar. */
+  refresh(): Observable<AuthResponse> {
+    const refreshToken = this.sessao?.refreshToken;
+    return this.http
+      .post<{ data: AuthResponse }>("v1/auth/refresh", { refreshToken })
+      .pipe(
+        map((r) => r.data),
+        tap({
+          next: (sessao) => this.salvarSessao(sessao),
+          error: () => this.logout(),
+        })
+      );
+  }
+
+  logout(): void {
+    localStorage.removeItem(STORAGE_KEY);
+    this.sessaoSubject.next(null);
+  }
+
+  /** Restaura a sessão ao abrir o app: renova se o access token venceu mas o refresh ainda vale. */
+  restaurarSessao(): void {
+    const sessao = this.sessao;
+    if (!sessao) return;
+    if (this.tokenValido(sessao)) return;
+    if (new Date(sessao.refreshTokenExpira) > new Date()) {
+      this.refresh().subscribe({ error: () => {} });
+    } else {
+      this.logout();
+    }
+  }
+
+  private tokenValido(sessao: AuthResponse | null): boolean {
+    if (!sessao?.token) return false;
+    // 30s de folga para não usar token à beira de expirar
+    return new Date(sessao.tokenExpira).getTime() - 30_000 > Date.now();
+  }
+
+  private salvarSessao(sessao: AuthResponse): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessao));
+    this.sessaoSubject.next(sessao);
+  }
+
+  private carregarSessao(): AuthResponse | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as AuthResponse) : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/app/modules/public/entrar/entrar.component.html
+++ b/src/app/modules/public/entrar/entrar.component.html
@@ -1,0 +1,163 @@
+<p-toast></p-toast>
+
+<div class="entrar-wrapper">
+  <p-panel [header]="modo === 'login' ? 'Entrar' : 'Criar ou recuperar senha'" class="container">
+    <!-- LOGIN -->
+    <ng-container *ngIf="modo === 'login'">
+      <p>
+        Área do responsável pela paróquia. Entre com seu e-mail e senha para
+        gerenciar as informações da sua igreja.
+      </p>
+      <form [formGroup]="formLogin" (ngSubmit)="entrar()">
+        <div class="p-fluid">
+          <div class="field">
+            <p-iftalabel>
+              <input pInputText id="email" type="email" formControlName="email" autocomplete="email" />
+              <label htmlFor="email">E-mail</label>
+            </p-iftalabel>
+            <small
+              class="p-error block"
+              *ngIf="formLogin.controls['email'].invalid && formLogin.controls['email'].touched"
+              >Informe um e-mail válido.</small
+            >
+          </div>
+          <div class="field">
+            <p-iftalabel>
+              <p-password
+                id="senha"
+                formControlName="senha"
+                [feedback]="false"
+                [toggleMask]="true"
+                autocomplete="current-password"
+              ></p-password>
+              <label htmlFor="senha">Senha</label>
+            </p-iftalabel>
+            <small
+              class="p-error block"
+              *ngIf="formLogin.controls['senha'].invalid && formLogin.controls['senha'].touched"
+              >Informe sua senha.</small
+            >
+          </div>
+          <p-button
+            type="submit"
+            label="Entrar"
+            [loading]="isLoading"
+            styleClass="w-full"
+          ></p-button>
+        </div>
+      </form>
+      <div class="links">
+        <a (click)="trocarModo('solicitar-codigo')"
+          >Primeiro acesso ou esqueceu a senha?</a
+        >
+      </div>
+    </ng-container>
+
+    <!-- SOLICITAR CÓDIGO -->
+    <ng-container *ngIf="modo === 'solicitar-codigo'">
+      <p>
+        Informe seu e-mail e enviaremos um código de 6 dígitos para você criar
+        (ou redefinir) sua senha.
+      </p>
+      <form [formGroup]="formSolicitar" (ngSubmit)="solicitarCodigo()">
+        <div class="p-fluid">
+          <div class="field">
+            <p-iftalabel>
+              <input pInputText id="emailSolicitar" type="email" formControlName="email" autocomplete="email" />
+              <label htmlFor="emailSolicitar">E-mail</label>
+            </p-iftalabel>
+            <small
+              class="p-error block"
+              *ngIf="formSolicitar.controls['email'].invalid && formSolicitar.controls['email'].touched"
+              >Informe um e-mail válido.</small
+            >
+          </div>
+          <div class="field">
+            <p-iftalabel>
+              <input pInputText id="nome" type="text" formControlName="nome" autocomplete="name" />
+              <label htmlFor="nome">Nome (opcional)</label>
+            </p-iftalabel>
+          </div>
+          <p-button
+            type="submit"
+            label="Enviar código"
+            [loading]="isLoading"
+            styleClass="w-full"
+          ></p-button>
+        </div>
+      </form>
+      <div class="links">
+        <a (click)="trocarModo('login')">Voltar para o login</a>
+        <a (click)="trocarModo('definir-senha')">Já tenho um código</a>
+      </div>
+    </ng-container>
+
+    <!-- DEFINIR SENHA -->
+    <ng-container *ngIf="modo === 'definir-senha'">
+      <p>
+        Digite o código de 6 dígitos que enviamos para
+        <strong>{{ formSolicitar.value.email || "seu e-mail" }}</strong> e
+        escolha sua nova senha.
+      </p>
+      <form [formGroup]="formDefinir" (ngSubmit)="definirSenha()">
+        <div class="p-fluid">
+          <div class="field" *ngIf="!formSolicitar.value.email">
+            <p-iftalabel>
+              <input
+                pInputText
+                id="emailDefinir"
+                type="email"
+                [formControl]="$any(formSolicitar.controls['email'])"
+                autocomplete="email"
+              />
+              <label htmlFor="emailDefinir">E-mail</label>
+            </p-iftalabel>
+          </div>
+          <div class="field">
+            <p-iftalabel>
+              <input
+                pInputText
+                id="codigo"
+                type="number"
+                formControlName="codigo"
+                inputmode="numeric"
+              />
+              <label htmlFor="codigo">Código (6 dígitos)</label>
+            </p-iftalabel>
+            <small
+              class="p-error block"
+              *ngIf="formDefinir.controls['codigo'].invalid && formDefinir.controls['codigo'].touched"
+              >Informe o código de 6 dígitos recebido por e-mail.</small
+            >
+          </div>
+          <div class="field">
+            <p-iftalabel>
+              <p-password
+                id="novaSenha"
+                formControlName="novaSenha"
+                [toggleMask]="true"
+                autocomplete="new-password"
+              ></p-password>
+              <label htmlFor="novaSenha">Nova senha (mínimo 8 caracteres)</label>
+            </p-iftalabel>
+            <small
+              class="p-error block"
+              *ngIf="formDefinir.controls['novaSenha'].invalid && formDefinir.controls['novaSenha'].touched"
+              >A senha precisa ter pelo menos 8 caracteres.</small
+            >
+          </div>
+          <p-button
+            type="submit"
+            label="Definir senha"
+            [loading]="isLoading"
+            styleClass="w-full"
+          ></p-button>
+        </div>
+      </form>
+      <div class="links">
+        <a (click)="trocarModo('solicitar-codigo')">Reenviar código</a>
+        <a (click)="trocarModo('login')">Voltar para o login</a>
+      </div>
+    </ng-container>
+  </p-panel>
+</div>

--- a/src/app/modules/public/entrar/entrar.component.scss
+++ b/src/app/modules/public/entrar/entrar.component.scss
@@ -1,0 +1,33 @@
+.entrar-wrapper {
+  max-width: 480px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.field {
+  margin-bottom: 1rem;
+}
+
+.field input,
+.field .p-password {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.links {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  a {
+    color: var(--p-primary-color, #2563eb);
+    cursor: pointer;
+    font-size: 0.9rem;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/app/modules/public/entrar/entrar.component.ts
+++ b/src/app/modules/public/entrar/entrar.component.ts
@@ -1,0 +1,147 @@
+import { Component, inject, OnInit } from "@angular/core";
+import { NgIf } from "@angular/common";
+import {
+  FormBuilder,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { Router } from "@angular/router";
+import { MessageService } from "primeng/api";
+import { PrimeNgModule } from "../../../shared/primeng.module";
+import { AuthService } from "../../../core/services/auth.service";
+import { LoggerService } from "../../../core/services/logger.service";
+
+type Modo = "login" | "solicitar-codigo" | "definir-senha";
+
+/**
+ * Login do Responsável Verificado: entrar com e-mail/senha, criar senha
+ * (primeiro acesso) e recuperar senha — os dois últimos usam o mesmo fluxo
+ * de código por e-mail do backend.
+ */
+@Component({
+  selector: "app-entrar",
+  imports: [PrimeNgModule, FormsModule, ReactiveFormsModule, NgIf],
+  providers: [MessageService],
+  templateUrl: "./entrar.component.html",
+  styleUrl: "./entrar.component.scss",
+})
+export class EntrarComponent implements OnInit {
+  private _auth = inject(AuthService);
+  private _message = inject(MessageService);
+  private _fb = inject(FormBuilder);
+  private _logger = inject(LoggerService);
+  private _router = inject(Router);
+
+  public modo: Modo = "login";
+  public isLoading = false;
+  public formLogin!: FormGroup;
+  public formSolicitar!: FormGroup;
+  public formDefinir!: FormGroup;
+
+  ngOnInit(): void {
+    // Forms antes do redirect: o template renderiza uma vez mesmo quando
+    // vamos navegar embora — sem os forms criados isso estoura NG01052.
+    this.formLogin = this._fb.group({
+      email: ["", [Validators.required, Validators.email]],
+      senha: ["", Validators.required],
+    });
+    this.formSolicitar = this._fb.group({
+      email: ["", [Validators.required, Validators.email]],
+      nome: [""],
+    });
+    this.formDefinir = this._fb.group({
+      codigo: [null, [Validators.required, Validators.min(100000), Validators.max(999999)]],
+      novaSenha: ["", [Validators.required, Validators.minLength(8)]],
+    });
+
+    if (this._auth.estaLogado) {
+      this._router.navigate(["/home"]);
+    }
+  }
+
+  trocarModo(modo: Modo): void {
+    this.modo = modo;
+  }
+
+  entrar(): void {
+    if (this.formLogin.invalid) {
+      this.formLogin.markAllAsTouched();
+      return;
+    }
+    this.isLoading = true;
+    const { email, senha } = this.formLogin.value;
+    this._auth.login(email, senha).subscribe({
+      next: (sessao) => {
+        this._message.add({
+          severity: "success",
+          summary: "Bem-vindo",
+          detail: `Olá, ${sessao.nome}!`,
+        });
+        this._router.navigate(["/home"]);
+      },
+      error: (error) => {
+        this.isLoading = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível entrar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "entrar:login");
+      },
+      complete: () => (this.isLoading = false),
+    });
+  }
+
+  solicitarCodigo(): void {
+    if (this.formSolicitar.invalid) {
+      this.formSolicitar.markAllAsTouched();
+      return;
+    }
+    this.isLoading = true;
+    this._auth.solicitarCodigoSenha(this.formSolicitar.value).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Código enviado", detail: mensagem });
+        this.modo = "definir-senha";
+      },
+      error: (error) => {
+        this.isLoading = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível enviar o código",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "entrar:solicitar-codigo");
+      },
+      complete: () => (this.isLoading = false),
+    });
+  }
+
+  definirSenha(): void {
+    if (this.formDefinir.invalid) {
+      this.formDefinir.markAllAsTouched();
+      return;
+    }
+    this.isLoading = true;
+    const email = this.formSolicitar.value.email;
+    const { codigo, novaSenha } = this.formDefinir.value;
+    this._auth.definirSenha({ email, codigo, novaSenha }).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Senha definida", detail: mensagem });
+        this.formLogin.patchValue({ email });
+        this.modo = "login";
+      },
+      error: (error) => {
+        this.isLoading = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível definir a senha",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "entrar:definir-senha");
+      },
+      complete: () => (this.isLoading = false),
+    });
+  }
+}

--- a/src/app/shared/primeng.module.ts
+++ b/src/app/shared/primeng.module.ts
@@ -39,6 +39,7 @@ import { ProgressSpinnerModule } from "primeng/progressspinner";
 import { TextareaModule } from "primeng/textarea";
 import { MultiSelectModule } from "primeng/multiselect";
 import { ChipModule } from "primeng/chip";
+import { PasswordModule } from "primeng/password";
 @NgModule({
   imports: [
     CommonModule,
@@ -78,7 +79,8 @@ import { ChipModule } from "primeng/chip";
     ProgressSpinnerModule,
     TextareaModule,
     MultiSelectModule,
-    ChipModule
+    ChipModule,
+    PasswordModule
   ],
   exports: [
     FieldsetModule,
@@ -117,7 +119,8 @@ import { ChipModule } from "primeng/chip";
     ProgressSpinnerModule,
     TextareaModule,
     MultiSelectModule,
-    ChipModule
+    ChipModule,
+    PasswordModule
   ],
 })
 export class PrimeNgModule {}


### PR DESCRIPTION
## Resumo
Fase 3 do plano **Responsável Verificado** (front público): tela de login e gestão de sessão do usuário.

Depende dos backends (deploy antes): buscamissa/buscamissa-api-admin#13 e buscamissa/buscamissa-api-public#6

## Mudanças
- **`core/services/auth.service.ts`**: sessão em localStorage exposta como Observable; login, solicitar código (cadastro E esqueci-senha), definir senha, refresh com rotação; restauração/renovação de sessão no boot via `provideAppInitializer`
- **`AuthInterceptor`**: token de sessão do usuário logado tem prioridade; chamadas anônimas seguem com o token estático de app (comportamento atual preservado)
- **`modules/public/entrar/`**: tela única com 3 modos — login, solicitar código, definir senha — PrimeNG, rota `/entrar` com metadata SEO
- `PasswordModule` adicionado ao agregador PrimeNG
- Interfaces `AuthResponse`/`SolicitarCodigoSenhaRequest`/`DefinirSenhaRequest` em `core/interfaces/user.interface.ts` (espelham `AuthDtos.cs`)

## Testes (ponta a ponta local: site + api-public local + banco de teste)
- Login pela UI → toast de boas-vindas → sessão persistida no localStorage
- `/entrar` com usuário logado → redirect para /home (bug de FormGroup no primeiro render encontrado e corrigido)
- Modos de criar/recuperar senha renderizando e navegando entre si
- Console sem erros; `tsc --noEmit` limpo

Nenhuma mudança de comportamento para usuários anônimos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)