### PR TITLE
feat: edição direta no painel do responsável (Fase 8)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -219,6 +219,18 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "meu-painel/editar/:igrejaId",
+        data: {
+          title: 'Editar igreja | BuscaMissa',
+          description: 'Edite as informações da sua igreja no BuscaMissa.',
+          noindex: true,
+        },
+        loadComponent: () =>
+          import("./modules/public/meu-painel/editar-igreja/editar-igreja.component").then(
+            (m) => m.EditarIgrejaComponent
+          ),
+      },
+      {
         path: "solicitar",
         data: {
           title: 'Fale Conosco | BuscaMissa',

--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -25,3 +25,39 @@ export interface MinhaResponsabilidade {
   /** True quando o acesso veio por herança da paróquia-pai (não é vínculo direto). */
   porHeranca: boolean;
 }
+
+// ---- Edição direta (Fase 8): contato + redes + horários ----
+
+export interface ContatoEdicao {
+  emailContato?: string | null;
+  ddd?: string | null;
+  telefone?: string | null;
+  dddWhatsApp?: string | null;
+  telefoneWhatsApp?: string | null;
+  website?: string | null;
+}
+
+export interface RedeSocialEdicao {
+  tipoRedeSocial: number; // 1=Facebook,2=Instagram,3=YouTube,4=TikTok,5=Twitter
+  nomeDoPerfil: string;
+}
+
+export interface MissaEdicao {
+  diaSemana: number; // 0=Domingo ... 6=Sábado
+  horario: string; // "HH:mm"
+  observacao?: string | null;
+}
+
+export interface DadosEdicao {
+  igrejaId: number;
+  igrejaNome: string;
+  contato: ContatoEdicao;
+  redesSociais: RedeSocialEdicao[];
+  missas: MissaEdicao[];
+}
+
+export interface EditarDadosRequest {
+  contato?: ContatoEdicao | null;
+  redesSociais?: RedeSocialEdicao[] | null;
+  missas?: MissaEdicao[] | null;
+}

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -2,6 +2,8 @@ import { HttpClient } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
 import { map, Observable } from "rxjs";
 import {
+  DadosEdicao,
+  EditarDadosRequest,
   MinhaResponsabilidade,
   SolicitarResponsabilidadeRequest,
 } from "../interfaces/responsavel.interface";
@@ -37,5 +39,19 @@ export class ResponsavelService {
     return this.http
       .get<{ data: { podeEditar: boolean } }>(`v1/responsavel/igreja/${igrejaId}/pode-editar`)
       .pipe(map((r) => r.data.podeEditar));
+  }
+
+  /** Dados atuais editáveis (contato/redes/horários) para o formulário. */
+  obterDados(igrejaId: number): Observable<DadosEdicao> {
+    return this.http
+      .get<{ data: DadosEdicao }>(`v1/responsavel/igreja/${igrejaId}/dados`)
+      .pipe(map((r) => r.data));
+  }
+
+  /** Aplica a edição direta na igreja real. */
+  editarDados(igrejaId: number, request: EditarDadosRequest): Observable<string> {
+    return this.http
+      .put<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${igrejaId}/dados`, request)
+      .pipe(map((r) => r.data.mensagemTela));
   }
 }

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -1,0 +1,103 @@
+<p-toast></p-toast>
+
+<div class="editar-wrapper">
+  <a routerLink="/meu-painel" class="voltar">
+    <i class="pi pi-arrow-left"></i> Voltar para minhas igrejas
+  </a>
+
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="flex flex-col gap-3 mt-3">
+    <p-skeleton height="3rem" borderRadius="10px"></p-skeleton>
+    <p-skeleton height="10rem" borderRadius="12px"></p-skeleton>
+    <p-skeleton height="8rem" borderRadius="12px"></p-skeleton>
+  </div>
+
+  <!-- Erro -->
+  <div *ngIf="!isLoading && erroCarregar" class="estado-vazio">
+    <i class="pi pi-wifi"></i>
+    <p>Não foi possível carregar os dados desta igreja.</p>
+    <button pButton type="button" label="Tentar novamente" icon="pi pi-refresh"
+            class="p-button-sm p-button-outlined" (click)="carregar()"></button>
+  </div>
+
+  <form *ngIf="!isLoading && !erroCarregar" [formGroup]="form" (ngSubmit)="salvar()">
+    <h1>{{ igrejaNome }}</h1>
+    <p class="subtitulo">Suas alterações são aplicadas imediatamente na página da igreja.</p>
+
+    <!-- CONTATO -->
+    <section class="bloco" formGroupName="contato">
+      <h2><i class="pi pi-phone"></i> Contato</h2>
+      <div class="grid-contato">
+        <div class="campo campo--ddd">
+          <label>DDD</label>
+          <input pInputText formControlName="ddd" maxlength="3" inputmode="numeric" />
+        </div>
+        <div class="campo">
+          <label>Telefone</label>
+          <input pInputText formControlName="telefone" maxlength="20" inputmode="numeric" />
+        </div>
+        <div class="campo campo--ddd">
+          <label>DDD WhatsApp</label>
+          <input pInputText formControlName="dddWhatsApp" maxlength="3" inputmode="numeric" />
+        </div>
+        <div class="campo">
+          <label>WhatsApp</label>
+          <input pInputText formControlName="telefoneWhatsApp" maxlength="20" inputmode="numeric" />
+        </div>
+        <div class="campo campo--full">
+          <label>Site</label>
+          <input pInputText formControlName="website" placeholder="https://..." maxlength="255" />
+        </div>
+        <div class="campo campo--full">
+          <label>E-mail de contato</label>
+          <input pInputText formControlName="emailContato" type="email" maxlength="100" />
+          <small class="erro" *ngIf="form.get('contato.emailContato')?.invalid && form.get('contato.emailContato')?.touched">
+            E-mail inválido.
+          </small>
+        </div>
+      </div>
+    </section>
+
+    <!-- REDES SOCIAIS -->
+    <section class="bloco">
+      <h2><i class="pi pi-share-alt"></i> Redes sociais</h2>
+      <div formArrayName="redesSociais">
+        <div *ngFor="let rede of redesSociais.controls; let i = index" [formGroupName]="i" class="linha-dinamica">
+          <p-select formControlName="tipoRedeSocial" [options]="redes" optionLabel="nome" optionValue="tipo"
+                    styleClass="w-full" appendTo="body"></p-select>
+          <input pInputText formControlName="nomeDoPerfil" placeholder="@perfil ou nome" maxlength="150" />
+          <button pButton type="button" icon="pi pi-trash" class="p-button-text p-button-danger p-button-sm"
+                  (click)="removerRede(i)" aria-label="Remover rede"></button>
+        </div>
+      </div>
+      <button pButton type="button" icon="pi pi-plus" label="Adicionar rede social"
+              class="p-button-text p-button-sm mt-1" (click)="adicionarRede()"></button>
+    </section>
+
+    <!-- HORÁRIOS -->
+    <section class="bloco">
+      <h2><i class="pi pi-clock"></i> Horários de missa</h2>
+      <div formArrayName="missas">
+        <div *ngFor="let missa of missas.controls; let i = index" [formGroupName]="i" class="linha-missa">
+          <p-select formControlName="diaSemana" [options]="dias" optionLabel="nome" optionValue="valor"
+                    styleClass="w-full" appendTo="body"></p-select>
+          <input pInputText formControlName="horario" placeholder="HH:mm" maxlength="5" class="input-hora"
+                 [class.ng-invalid-visual]="missas.at(i).get('horario')?.invalid && missas.at(i).get('horario')?.touched" />
+          <input pInputText formControlName="observacao" placeholder="Observação (opcional)" maxlength="255" />
+          <button pButton type="button" icon="pi pi-trash" class="p-button-text p-button-danger p-button-sm"
+                  (click)="removerMissa(i)" aria-label="Remover horário"></button>
+        </div>
+      </div>
+      <button pButton type="button" icon="pi pi-plus" label="Adicionar horário"
+              class="p-button-text p-button-sm mt-1" (click)="adicionarMissa()"></button>
+      <p class="dica-hora">Use o formato 24h, ex.: 07:30, 19:00.</p>
+    </section>
+
+    <div class="acoes">
+      <a routerLink="/meu-painel">
+        <button pButton type="button" label="Cancelar" class="p-button-text" [disabled]="salvando"></button>
+      </a>
+      <button pButton type="submit" label="Salvar alterações" icon="pi pi-check" [loading]="salvando"></button>
+    </div>
+  </form>
+</div>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -1,0 +1,149 @@
+.editar-wrapper {
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.voltar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--p-primary-color, #2563eb);
+  }
+}
+
+h1 {
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 1rem 0 0.25rem;
+}
+
+.subtitulo {
+  margin: 0 0 1.25rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.bloco {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+
+  h2 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 1rem;
+  }
+}
+
+.grid-contato {
+  display: grid;
+  grid-template-columns: 90px 1fr 90px 1fr;
+  gap: 0.75rem;
+
+  .campo--ddd {
+    grid-column: span 1;
+  }
+  .campo--full {
+    grid-column: 1 / -1;
+  }
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #4b5563;
+  }
+
+  input {
+    width: 100%;
+  }
+
+  .erro {
+    color: #b91c1c;
+    font-size: 0.72rem;
+  }
+}
+
+.linha-dinamica {
+  display: grid;
+  grid-template-columns: 150px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.linha-missa {
+  display: grid;
+  grid-template-columns: 160px 90px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+
+  .input-hora {
+    text-align: center;
+  }
+}
+
+.ng-invalid-visual {
+  border-color: #ef4444 !important;
+}
+
+.dica-hora {
+  font-size: 0.72rem;
+  color: #9ca3af;
+  margin: 0.5rem 0 0;
+}
+
+.acoes {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.estado-vazio {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 3rem 1rem;
+  text-align: center;
+  color: #6b7280;
+
+  .pi {
+    font-size: 2.25rem;
+    color: #d1d5db;
+  }
+}
+
+@media (max-width: 640px) {
+  .grid-contato {
+    grid-template-columns: 70px 1fr;
+  }
+  .linha-dinamica {
+    grid-template-columns: 1fr auto;
+  }
+  .linha-missa {
+    grid-template-columns: 1fr 80px auto;
+
+    input[formcontrolname="observacao"],
+    input[placeholder*="Observação"] {
+      grid-column: 1 / -1;
+    }
+  }
+}

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -1,0 +1,199 @@
+import { Component, inject, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { MessageService } from "primeng/api";
+import { SkeletonModule } from "primeng/skeleton";
+import { PrimeNgModule } from "../../../../shared/primeng.module";
+import { AuthService } from "../../../../core/services/auth.service";
+import { ResponsavelService } from "../../../../core/services/responsavel.service";
+import { LoggerService } from "../../../../core/services/logger.service";
+
+const REDES = [
+  { tipo: 1, nome: "Facebook" },
+  { tipo: 2, nome: "Instagram" },
+  { tipo: 3, nome: "YouTube" },
+  { tipo: 4, nome: "TikTok" },
+  { tipo: 5, nome: "Twitter/X" },
+];
+
+const DIAS = [
+  { valor: 0, nome: "Domingo" },
+  { valor: 1, nome: "Segunda-feira" },
+  { valor: 2, nome: "Terça-feira" },
+  { valor: 3, nome: "Quarta-feira" },
+  { valor: 4, nome: "Quinta-feira" },
+  { valor: 5, nome: "Sexta-feira" },
+  { valor: 6, nome: "Sábado" },
+];
+
+/**
+ * Edição direta (Fase 8) de contato + redes sociais + horários pelo
+ * responsável verificado. Grava direto na igreja real (sem código).
+ */
+@Component({
+  selector: "app-editar-igreja",
+  imports: [PrimeNgModule, CommonModule, FormsModule, ReactiveFormsModule, RouterLink, SkeletonModule],
+  providers: [MessageService],
+  templateUrl: "./editar-igreja.component.html",
+  styleUrl: "./editar-igreja.component.scss",
+})
+export class EditarIgrejaComponent implements OnInit {
+  private _fb = inject(FormBuilder);
+  private _route = inject(ActivatedRoute);
+  private _router = inject(Router);
+  private _auth = inject(AuthService);
+  private _responsavel = inject(ResponsavelService);
+  private _message = inject(MessageService);
+  private _logger = inject(LoggerService);
+
+  readonly redes = REDES;
+  readonly dias = DIAS;
+
+  igrejaId!: number;
+  igrejaNome = "";
+  isLoading = true;
+  erroCarregar = false;
+  salvando = false;
+  form!: FormGroup;
+
+  get redesSociais(): FormArray {
+    return this.form.get("redesSociais") as FormArray;
+  }
+  get missas(): FormArray {
+    return this.form.get("missas") as FormArray;
+  }
+
+  ngOnInit(): void {
+    if (!this._auth.estaLogado) {
+      this._router.navigate(["/entrar"]);
+      return;
+    }
+    this.igrejaId = Number(this._route.snapshot.paramMap.get("igrejaId"));
+    this.form = this._fb.group({
+      contato: this._fb.group({
+        ddd: [""],
+        telefone: [""],
+        dddWhatsApp: [""],
+        telefoneWhatsApp: [""],
+        website: [""],
+        emailContato: ["", [Validators.email]],
+      }),
+      redesSociais: this._fb.array([]),
+      missas: this._fb.array([]),
+    });
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.isLoading = true;
+    this.erroCarregar = false;
+    this._responsavel.obterDados(this.igrejaId).subscribe({
+      next: (dados) => {
+        this.igrejaNome = dados.igrejaNome;
+        this.form.get("contato")!.patchValue({
+          ddd: dados.contato.ddd ?? "",
+          telefone: dados.contato.telefone ?? "",
+          dddWhatsApp: dados.contato.dddWhatsApp ?? "",
+          telefoneWhatsApp: dados.contato.telefoneWhatsApp ?? "",
+          website: dados.contato.website ?? "",
+          emailContato: dados.contato.emailContato ?? "",
+        });
+        dados.redesSociais.forEach((r) => this.adicionarRede(r.tipoRedeSocial, r.nomeDoPerfil));
+        dados.missas.forEach((m) => this.adicionarMissa(m.diaSemana, m.horario, m.observacao ?? ""));
+        this.isLoading = false;
+      },
+      error: (error) => {
+        // 403 = perdeu a permissão (ex.: capela ganhou responsável próprio)
+        if (error?.status === 403) {
+          this._message.add({
+            severity: "warn",
+            summary: "Sem permissão",
+            detail: "Você não pode mais editar esta igreja.",
+          });
+          this._router.navigate(["/meu-painel"]);
+          return;
+        }
+        this.erroCarregar = true;
+        this.isLoading = false;
+        this._logger.logError(error, "editar-igreja:carregar");
+      },
+    });
+  }
+
+  adicionarRede(tipo = 2, nome = ""): void {
+    this.redesSociais.push(
+      this._fb.group({
+        tipoRedeSocial: [tipo, Validators.required],
+        nomeDoPerfil: [nome, [Validators.required, Validators.maxLength(150)]],
+      })
+    );
+  }
+
+  removerRede(i: number): void {
+    this.redesSociais.removeAt(i);
+  }
+
+  adicionarMissa(dia = 0, horario = "", observacao = ""): void {
+    this.missas.push(
+      this._fb.group({
+        diaSemana: [dia, Validators.required],
+        horario: [horario, [Validators.required, Validators.pattern(/^([01]\d|2[0-3]):[0-5]\d$/)]],
+        observacao: [observacao, Validators.maxLength(255)],
+      })
+    );
+  }
+
+  removerMissa(i: number): void {
+    this.missas.removeAt(i);
+  }
+
+  salvar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this._message.add({
+        severity: "warn",
+        summary: "Revise o formulário",
+        detail: "Há campos inválidos (verifique horários no formato HH:mm e nomes de perfil).",
+      });
+      return;
+    }
+    this.salvando = true;
+    const v = this.form.value;
+    this._responsavel
+      .editarDados(this.igrejaId, {
+        contato: {
+          ddd: v.contato.ddd || null,
+          telefone: v.contato.telefone || null,
+          dddWhatsApp: v.contato.dddWhatsApp || null,
+          telefoneWhatsApp: v.contato.telefoneWhatsApp || null,
+          website: v.contato.website || null,
+          emailContato: v.contato.emailContato || null,
+        },
+        redesSociais: v.redesSociais,
+        missas: v.missas,
+      })
+      .subscribe({
+        next: (mensagem) => {
+          this._message.add({ severity: "success", summary: "Salvo", detail: mensagem });
+          setTimeout(() => this._router.navigate(["/meu-painel"]), 900);
+        },
+        error: (error) => {
+          this.salvando = false;
+          this._message.add({
+            severity: "error",
+            summary: "Não foi possível salvar",
+            detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+          });
+          this._logger.logError(error, "editar-igreja:salvar");
+        },
+      });
+  }
+}

--- a/src/app/modules/public/meu-painel/meu-painel.component.html
+++ b/src/app/modules/public/meu-painel/meu-painel.component.html
@@ -48,6 +48,10 @@
         </span>
       </div>
       <div class="card-acoes">
+        <a *ngIf="podeEditar(igreja)" [routerLink]="['/meu-painel/editar', igreja.igrejaId]">
+          <button pButton type="button" icon="pi pi-pencil" label="Editar informações"
+                  class="p-button-sm"></button>
+        </a>
         <a *ngIf="linkIgreja(igreja)" [routerLink]="linkIgreja(igreja)">
           <button pButton type="button" icon="pi pi-external-link" label="Ver página"
                   class="p-button-sm p-button-outlined"></button>
@@ -57,9 +61,8 @@
 
     <p class="rodape-dica">
       <i class="pi pi-info-circle"></i>
-      A edição direta dos dados (endereço, horários, contato) pela página da
-      igreja está chegando em breve para responsáveis verificados. Por enquanto,
-      use o fluxo de alteração normal — suas mudanças têm prioridade na análise.
+      Você edita contato, redes sociais e horários direto por aqui. A edição de
+      endereço e imagem chega em breve para responsáveis verificados.
     </p>
   </div>
 </div>

--- a/src/app/modules/public/meu-painel/meu-painel.component.ts
+++ b/src/app/modules/public/meu-painel/meu-painel.component.ts
@@ -63,6 +63,11 @@ export class MeuPainelComponent implements OnInit {
     this._router.navigate(["/home"]);
   }
 
+  /** Editável: aprovada direta ou herdada da paróquia (não pendente/rejeitada/revogada). */
+  podeEditar(igreja: MinhaResponsabilidade): boolean {
+    return igreja.porHeranca || igreja.status === "Aprovado";
+  }
+
   linkIgreja(igreja: MinhaResponsabilidade): string[] | null {
     // Slug canônico não carrega uf/cidade aqui; usa rota legada por segurança
     return igreja.igrejaSlug ? ["/igrejas", igreja.igrejaSlug] : null;


### PR DESCRIPTION
## Resumo
Fase 8 do plano **Responsável Verificado** (front público): o responsável edita **contato + redes sociais + horários** direto pelo painel.

Depende do backend: buscamissa/buscamissa-api-public#10 (deploy antes).

## Mudanças
- Rota `/meu-painel/editar/:igrejaId` + **EditarIgrejaComponent** (reactive forms; FormArray para redes e horários, com adicionar/remover)
- Botão **"Editar informações"** no painel apenas nas igrejas editáveis (aprovada direta **ou** herdada da paróquia — não em pendente/rejeitada)
- Carrega dados atuais e grava direto; 403 (perdeu permissão, ex.: capela ganhou responsável próprio) → aviso e volta ao painel
- Validação de horário HH:mm e e-mail; rodapé do painel atualizado (endereço/imagem "em breve")

## Testes (ponta a ponta local)
Painel mostra "Editar" só nas 3 editáveis (não na "Em análise"); formulário carrega contato/rede/horários reais; edição de telefone salva e persiste no banco; redirect pós-save; console limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)