### PR TITLE
feat: edição de endereço e foto no painel do responsável (Fase 9)

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -48,16 +48,40 @@ export interface MissaEdicao {
   observacao?: string | null;
 }
 
+// ---- Fase 9: endereço + imagem ----
+
+export interface EnderecoEdicao {
+  cep: string;
+  logradouro: string;
+  complemento?: string | null;
+  bairro?: string | null;
+  localidade: string;
+  uf: string;
+  /** 0 = sem número. */
+  numero: number;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export interface ImagemEdicao {
+  /** Base64 sem prefixo "data:image/...". */
+  base64: string;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;
   contato: ContatoEdicao;
   redesSociais: RedeSocialEdicao[];
   missas: MissaEdicao[];
+  endereco: EnderecoEdicao;
+  imagemUrl?: string | null;
 }
 
 export interface EditarDadosRequest {
   contato?: ContatoEdicao | null;
   redesSociais?: RedeSocialEdicao[] | null;
   missas?: MissaEdicao[] | null;
+  endereco?: EnderecoEdicao | null;
+  imagem?: ImagemEdicao | null;
 }

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -24,6 +24,65 @@
     <h1>{{ igrejaNome }}</h1>
     <p class="subtitulo">Suas alterações são aplicadas imediatamente na página da igreja.</p>
 
+    <!-- IMAGEM -->
+    <section class="bloco">
+      <h2><i class="pi pi-image"></i> Foto da igreja</h2>
+      <div class="imagem-area">
+        <div class="imagem-preview">
+          <img *ngIf="imagemPreview" [src]="imagemPreview" alt="Foto da igreja" />
+          <i *ngIf="!imagemPreview" class="pi pi-building"></i>
+        </div>
+        <div>
+          <input #inputImagem type="file" accept="image/*" hidden (change)="selecionarImagem($event)" />
+          <button pButton type="button" icon="pi pi-upload" label="Trocar foto"
+                  class="p-button-sm p-button-outlined" (click)="inputImagem.click()"></button>
+          <p class="dica-hora">JPG ou PNG, até 5MB.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ENDEREÇO -->
+    <section class="bloco" formGroupName="endereco">
+      <h2><i class="pi pi-map-marker"></i> Endereço</h2>
+      <div class="grid-endereco">
+        <div class="campo">
+          <label>CEP</label>
+          <input pInputText formControlName="cep" maxlength="9" />
+        </div>
+        <div class="campo campo--full">
+          <label>Logradouro</label>
+          <input pInputText formControlName="logradouro" maxlength="150" />
+        </div>
+        <div class="campo campo--numero">
+          <label>Número</label>
+          <input pInputText type="number" formControlName="numero" />
+        </div>
+        <div class="campo">
+          <label>Complemento</label>
+          <input pInputText formControlName="complemento" maxlength="100" />
+        </div>
+        <div class="campo">
+          <label>Bairro</label>
+          <input pInputText formControlName="bairro" maxlength="100" />
+        </div>
+        <div class="campo campo--full">
+          <label>Cidade</label>
+          <input pInputText formControlName="localidade" maxlength="100" />
+        </div>
+        <div class="campo campo--uf">
+          <label>UF</label>
+          <p-select formControlName="uf" [options]="estados" optionLabel="sigla" optionValue="sigla"
+                    styleClass="w-full" appendTo="body"></p-select>
+        </div>
+      </div>
+      <p class="aviso-url" *ngIf="cidadeOuUfMudou">
+        <i class="pi pi-info-circle"></i>
+        O endereço será atualizado, mas o link da página desta igreja
+        <strong>não muda</strong> — é assim por padrão do site, para não quebrar
+        acessos e resultados de busca já existentes.
+      </p>
+    </section>
+
     <!-- CONTATO -->
     <section class="bloco" formGroupName="contato">
       <h2><i class="pi pi-phone"></i> Contato</h2>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -147,3 +147,73 @@ h1 {
     }
   }
 }
+
+.imagem-area {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.imagem-preview {
+  width: 84px;
+  height: 84px;
+  border-radius: 10px;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .pi {
+    font-size: 1.75rem;
+    color: #d1d5db;
+  }
+}
+
+.grid-endereco {
+  display: grid;
+  grid-template-columns: 120px 1fr 100px;
+  gap: 0.75rem;
+
+  .campo--full {
+    grid-column: 1 / -1;
+  }
+
+  .campo--numero {
+    grid-column: span 1;
+  }
+
+  .campo--uf {
+    grid-column: span 1;
+  }
+}
+
+.aviso-url {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin: 0.75rem 0 0;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  font-size: 0.78rem;
+  color: #92400e;
+
+  .pi {
+    margin-top: 0.1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .grid-endereco {
+    grid-template-columns: 1fr 100px;
+  }
+}

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -15,6 +15,7 @@ import { PrimeNgModule } from "../../../../shared/primeng.module";
 import { AuthService } from "../../../../core/services/auth.service";
 import { ResponsavelService } from "../../../../core/services/responsavel.service";
 import { LoggerService } from "../../../../core/services/logger.service";
+import { STATES } from "../../../../core/constants/states";
 
 const REDES = [
   { tipo: 1, nome: "Facebook" },
@@ -35,8 +36,11 @@ const DIAS = [
 ];
 
 /**
- * Edição direta (Fase 8) de contato + redes sociais + horários pelo
- * responsável verificado. Grava direto na igreja real (sem código).
+ * Edição direta (Fases 8 e 9) de contato + redes sociais + horários +
+ * endereço + imagem pelo responsável verificado. Grava direto na igreja
+ * real (sem código). Trocar cidade/UF NÃO muda a URL da página (o
+ * identificador é congelado de propósito — protege SEO e links já
+ * compartilhados); o formulário avisa isso ao lado dos campos de endereço.
  */
 @Component({
   selector: "app-editar-igreja",
@@ -56,6 +60,7 @@ export class EditarIgrejaComponent implements OnInit {
 
   readonly redes = REDES;
   readonly dias = DIAS;
+  readonly estados = STATES;
 
   igrejaId!: number;
   igrejaNome = "";
@@ -63,6 +68,18 @@ export class EditarIgrejaComponent implements OnInit {
   erroCarregar = false;
   salvando = false;
   form!: FormGroup;
+
+  /** Imagem nova selecionada (base64 sem prefixo) — null = mantém a atual. */
+  imagemBase64: string | null = null;
+  /** Preview: nova imagem (com prefixo) ou a URL atual da igreja. */
+  imagemPreview: string | null = null;
+
+  /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
+  private _localidadeOriginal = "";
+  private _ufOriginal = "";
+  /** Preservados sem UI própria (não pedimos geolocalização manual). */
+  private _latitude: number | null = null;
+  private _longitude: number | null = null;
 
   get redesSociais(): FormArray {
     return this.form.get("redesSociais") as FormArray;
@@ -88,6 +105,15 @@ export class EditarIgrejaComponent implements OnInit {
       }),
       redesSociais: this._fb.array([]),
       missas: this._fb.array([]),
+      endereco: this._fb.group({
+        cep: ["", Validators.required],
+        logradouro: ["", Validators.required],
+        complemento: [""],
+        bairro: [""],
+        localidade: ["", Validators.required],
+        uf: ["", Validators.required],
+        numero: [0],
+      }),
     });
     this.carregar();
   }
@@ -108,6 +134,22 @@ export class EditarIgrejaComponent implements OnInit {
         });
         dados.redesSociais.forEach((r) => this.adicionarRede(r.tipoRedeSocial, r.nomeDoPerfil));
         dados.missas.forEach((m) => this.adicionarMissa(m.diaSemana, m.horario, m.observacao ?? ""));
+
+        this.form.get("endereco")!.patchValue({
+          cep: dados.endereco.cep ?? "",
+          logradouro: dados.endereco.logradouro ?? "",
+          complemento: dados.endereco.complemento ?? "",
+          bairro: dados.endereco.bairro ?? "",
+          localidade: dados.endereco.localidade ?? "",
+          uf: dados.endereco.uf ?? "",
+          numero: dados.endereco.numero ?? 0,
+        });
+        this._localidadeOriginal = dados.endereco.localidade ?? "";
+        this._ufOriginal = dados.endereco.uf ?? "";
+        this._latitude = dados.endereco.latitude ?? null;
+        this._longitude = dados.endereco.longitude ?? null;
+        this.imagemPreview = dados.imagemUrl ?? null;
+
         this.isLoading = false;
       },
       error: (error) => {
@@ -155,6 +197,38 @@ export class EditarIgrejaComponent implements OnInit {
     this.missas.removeAt(i);
   }
 
+  /** True quando cidade/UF mudou em relação ao carregado — dispara o aviso de URL. */
+  get cidadeOuUfMudou(): boolean {
+    const e = this.form.get("endereco")!.value;
+    return (
+      !!this._localidadeOriginal &&
+      (e.localidade?.trim() !== this._localidadeOriginal || e.uf !== this._ufOriginal)
+    );
+  }
+
+  selecionarImagem(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      this._message.add({ severity: "warn", summary: "Arquivo inválido", detail: "Selecione uma imagem." });
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      this._message.add({ severity: "warn", summary: "Arquivo muito grande", detail: "Máximo de 5MB." });
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const base64 = reader.result as string;
+      this.imagemBase64 = base64.split(",")[1];
+      this.imagemPreview = base64;
+    };
+    reader.readAsDataURL(file);
+  }
+
   salvar(): void {
     if (this.form.invalid) {
       this.form.markAllAsTouched();
@@ -179,6 +253,18 @@ export class EditarIgrejaComponent implements OnInit {
         },
         redesSociais: v.redesSociais,
         missas: v.missas,
+        endereco: {
+          cep: v.endereco.cep,
+          logradouro: v.endereco.logradouro,
+          complemento: v.endereco.complemento || null,
+          bairro: v.endereco.bairro || null,
+          localidade: v.endereco.localidade,
+          uf: v.endereco.uf,
+          numero: v.endereco.numero || 0,
+          latitude: this._latitude,
+          longitude: this._longitude,
+        },
+        imagem: this.imagemBase64 ? { base64: this.imagemBase64 } : null,
       })
       .subscribe({
         next: (mensagem) => {

--- a/src/app/modules/public/meu-painel/meu-painel.component.html
+++ b/src/app/modules/public/meu-painel/meu-painel.component.html
@@ -61,8 +61,8 @@
 
     <p class="rodape-dica">
       <i class="pi pi-info-circle"></i>
-      Você edita contato, redes sociais e horários direto por aqui. A edição de
-      endereço e imagem chega em breve para responsáveis verificados.
+      Você edita contato, redes sociais, horários, endereço e foto direto por
+      aqui — sem precisar de código de validação.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Resumo
Fase 9 do plano **Responsável Verificado** (front público) — última fatia da edição direta.

Depende do backend: buscamissa/buscamissa-api-public#11 (deploy antes).

## Mudanças
- Seções **Foto da igreja** e **Endereço** no `EditarIgrejaComponent`
- Upload de imagem: mesmo padrão do fluxo colaborativo (`FileReader` → base64 sem prefixo)
- **Aviso visível** quando cidade/UF muda: "o link da página desta igreja não muda — é assim por padrão do site, para não quebrar acessos e resultados de busca já existentes"
- Rodapé do painel atualizado (endereço/foto deixam de ser "em breve")

## Testes (ponta a ponta local: site + api-public + banco de teste + Blob Storage real)
Edição de endereço com troca de cidade (aviso apareceu corretamente); upload de imagem real (arquivo diferente confirmado no blob após salvar); slug da URL confirmado congelado no banco após a troca de cidade; console limpo (erros vistos eram residuais de um restart do backend, não regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)