### PR TITLE
fix: 403 em rotas App após login + menu "Meu painel"

### DIFF
--- a/src/app/core/layout/home/header/header.component.html
+++ b/src/app/core/layout/home/header/header.component.html
@@ -21,6 +21,9 @@
         <span class="bm-header__contador" *ngIf="favoritosCount > 0">{{ favoritosCount }}</span>
       </a>
       <a routerLink="/nova" routerLinkActive="bm-header__link--ativo" class="bm-header__link">Cadastrar igreja</a>
+      <a *ngIf="estaLogado" routerLink="/meu-painel" routerLinkActive="bm-header__link--ativo" class="bm-header__link">
+        <i class="pi pi-verified"></i> Meu painel
+      </a>
     </nav>
 
     <!-- Hamburger (mobile) -->
@@ -42,5 +45,8 @@
       <span class="bm-header__contador" *ngIf="favoritosCount > 0">{{ favoritosCount }}</span>
     </a>
     <a routerLink="/nova" class="bm-header__mobile-link bm-header__mobile-link--cta">Cadastrar igreja</a>
+    <a *ngIf="estaLogado" routerLink="/meu-painel" class="bm-header__mobile-link">
+      <i class="pi pi-verified"></i> Meu painel
+    </a>
   </nav>
 </header>

--- a/src/app/core/layout/home/header/header.component.ts
+++ b/src/app/core/layout/home/header/header.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FavoritesService } from '../../../services/favorites.service';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-header-home',
@@ -12,9 +13,14 @@ import { FavoritesService } from '../../../services/favorites.service';
 })
 export class HeaderHomeComponent {
   private favorites = inject(FavoritesService);
+  private auth = inject(AuthService);
   menuAberto = false;
 
   get favoritosCount(): number {
     return this.favorites.quantidade();
+  }
+
+  get estaLogado(): boolean {
+    return this.auth.estaLogado;
   }
 }

--- a/src/app/core/middleware/auth.interceptor.ts
+++ b/src/app/core/middleware/auth.interceptor.ts
@@ -9,9 +9,17 @@ export class AuthInterceptor implements HttpInterceptor {
   private authService = inject(AuthService);
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    // Sessão de usuário logado (Responsável Verificado) tem prioridade;
-    // chamadas anônimas seguem com o token estático de app, como sempre.
-    const token = this.authService.accessToken ?? environment.config.token;
+    // O JWT do usuário logado só tem papel Regular/Dono — só serve nas rotas
+    // do Responsável Verificado (api/v1/responsavel). Todo o resto do backend
+    // (busca de igreja, cadastro colaborativo etc.) exige role App/Admin, que
+    // só o token estático de config carrega. Usar o token de sessão fora de
+    // v1/responsavel derruba essas chamadas com 403 mesmo estando logado.
+    // req.url ainda é relativo aqui (AuthInterceptor roda antes do
+    // ApiBaseUrlInterceptor, que só então prefixa a apiURL) — sem barra inicial.
+    const ehRotaDoResponsavel = req.url.includes('v1/responsavel/') || req.url.includes('v1/auth/');
+    const token = ehRotaDoResponsavel
+      ? (this.authService.accessToken ?? environment.config.token)
+      : environment.config.token;
     if (token) {
       const clonedReq = req.clone({
         setHeaders: {


### PR DESCRIPTION
## Bug corrigido
Reportado em teste de dev: após logar como responsável, `GET v1/Igreja/buscar-por-filtro?Uf=SP...` (usado para escolher a paróquia no cadastro colaborativo) voltava **403**.

**Causa:** o `AuthInterceptor` da Fase 3 fazia o JWT do usuário (role `Regular`/`Dono`) ter prioridade em **todas** as chamadas. Só o `ResponsavelController` exige `Regular,Dono` — todo o resto do backend (busca de igreja, cadastro colaborativo, etc.) exige `App`/`Admin`, papel que só o token estático de config carrega.

**Correção:** o token de sessão do usuário só é usado em chamadas para `v1/responsavel` e `v1/auth`; todo o resto volta a usar o token estático, como era antes da Fase 3.

## Melhoria
Item **"Meu painel"** no header (desktop + mobile), visível só quando logado — antes só dava para acessar digitando a URL direto.

## Testes (local)
- `/meu-painel` volta a carregar corretamente com o token do usuário (bug de URL relativa encontrado e corrigido durante a própria verificação: `req.url` não tem barra inicial nesse ponto do pipeline)
- Item "Meu painel" aparece só logado, some ao deslogar
- Chamada a endpoint `App`-only confirmada usando o token estático (não o de sessão) fora de `/responsavel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)