### PR TITLE
feat: sessões de Atendimento/Confissão no painel e na página pública (Fases S3–S4)

### DIFF
--- a/docs/plano-notificacoes-e-sessoes.md
+++ b/docs/plano-notificacoes-e-sessoes.md
@@ -5,7 +5,7 @@ Duas features novas, independentes entre si, ambas construídas sobre a base do 
 ## Progresso
 - [x] Elaboração do plano e decisões de arquitetura (19/07/2026)
 - [x] Feature A — Notificações (fases N1–N3) — PRs abertos, aguardando merge
-- [ ] Feature B — Sessões de Atendimento/Confissão (fases S1–S4)
+- [x] Feature B — Sessões de Atendimento/Confissão (fases S1–S4) — PRs: api-admin #16, api-public #13, front (branch fase S3-4)
 
 ## Decisões fixadas
 - **Notificações**: canal in-app apenas (painel `/meu-painel`), sem e-mail nesta primeira entrega.
@@ -94,10 +94,10 @@ Por que não reaproveitar `Missa`: `Missa` tem campos específicos de missa (`Fo
 ### Fases sugeridas
 | Fase | Conteúdo |
 |---|---|
-| S1 | Schema `IgrejaSessao` (api-admin) + réplica leitura no api-public |
-| S2 | Backend: incluir `IgrejaSessao` no `GET/PUT /responsavel/igreja/{id}/dados` (mesmo padrão de replace integral da lista, igual `Missas`) |
-| S3 | Frontend painel: seção nova no `EditarIgrejaComponent` (FormArray, mesmo padrão de horários) |
-| S4 | Frontend público: seção "Atendimento e Confissão" na página da igreja (só renderiza se houver dados) |
+| S1 ✅ | Schema `IgrejaSessao` (api-admin, PR #16) + réplica no api-public (PR #13) |
+| S2 ✅ | Backend: sessões no `GET/PUT /responsavel/igreja/{id}/dados` + na resposta pública dos detalhes da igreja (PR #13, empilhado no #12) |
+| S3 ✅ | Frontend painel: seção "Atendimento e confissão" no `EditarIgrejaComponent` (FormArray tipo+dia+início/fim+observação) |
+| S4 ✅ | Frontend público: seção "Atendimento e Confissão" nos detalhes da igreja (só renderiza se houver dados; agrupada por tipo) |
 
 ---
 

--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -71,6 +71,14 @@ export interface ImagemEdicao {
   base64: string;
 }
 
+export interface SessaoEdicao {
+  tipo: number; // 1=Secretaria, 2=Confissao
+  diaSemana: number; // 0=Domingo ... 6=Sábado
+  horarioInicio: string; // "HH:mm"
+  horarioFim: string; // "HH:mm"
+  observacao?: string | null;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;
@@ -79,6 +87,7 @@ export interface DadosEdicao {
   missas: MissaEdicao[];
   endereco: EnderecoEdicao;
   imagemUrl?: string | null;
+  sessoes: SessaoEdicao[];
 }
 
 export interface EditarDadosRequest {
@@ -87,4 +96,5 @@ export interface EditarDadosRequest {
   missas?: MissaEdicao[] | null;
   endereco?: EnderecoEdicao | null;
   imagem?: ImagemEdicao | null;
+  sessoes?: SessaoEdicao[] | null;
 }

--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -55,6 +55,29 @@
       (adicionarHorarios)="reportarErro()"
     />
 
+    <!-- ATENDIMENTO E CONFISSÃO (Feature B) — só aparece se o responsável cadastrou -->
+    <section *ngIf="churchInfo.sessoes?.length" class="mt-6 rounded-xl border border-surface-100 bg-white px-4 py-4">
+      <h2 class="text-sm font-bold text-gray-700 flex items-center gap-2 mt-0 mb-3">
+        <i class="pi pi-calendar text-gray-400"></i> Atendimento e Confissão
+      </h2>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div *ngIf="sessoesSecretaria.length">
+          <p class="text-xs font-semibold text-gray-500 uppercase mb-1.5">Secretaria</p>
+          <p *ngFor="let s of sessoesSecretaria" class="text-sm text-gray-600 my-0.5">
+            {{ diaCurto(s.diaSemana) }} — {{ s.horarioInicio }} às {{ s.horarioFim }}
+            <span *ngIf="s.observacao" class="text-xs text-gray-400">({{ s.observacao }})</span>
+          </p>
+        </div>
+        <div *ngIf="sessoesConfissao.length">
+          <p class="text-xs font-semibold text-gray-500 uppercase mb-1.5">Confissão</p>
+          <p *ngFor="let s of sessoesConfissao" class="text-sm text-gray-600 my-0.5">
+            {{ diaCurto(s.diaSemana) }} — {{ s.horarioInicio }} às {{ s.horarioFim }}
+            <span *ngIf="s.observacao" class="text-xs text-gray-400">({{ s.observacao }})</span>
+          </p>
+        </div>
+      </div>
+    </section>
+
     <!-- CONFIRMAR (largura total) -->
     <app-details-confirmar
       *ngIf="churchInfo.missas?.length"

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -84,6 +84,19 @@ export class DetailsComponent implements OnInit {
   // Reportar problema
   modalReportarProblemaVisible = false;
 
+  // Sessões de atendimento/confissão (Feature B)
+  private static readonly DIAS_CURTOS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+  get sessoesSecretaria(): any[] {
+    return (this.churchInfo?.sessoes ?? []).filter((s: any) => s.tipo === 1);
+  }
+  get sessoesConfissao(): any[] {
+    return (this.churchInfo?.sessoes ?? []).filter((s: any) => s.tipo === 2);
+  }
+  diaCurto(dia: number): string {
+    return DetailsComponent.DIAS_CURTOS[dia] ?? "";
+  }
+
   // Responsável Verificado (Fase 5)
   igrejaVerificada = false;
   modalResponsavelVisible = false;

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -152,6 +152,32 @@
       <p class="dica-hora">Use o formato 24h, ex.: 07:30, 19:00.</p>
     </section>
 
+    <!-- ATENDIMENTO E CONFISSÃO (Feature B) -->
+    <section class="bloco">
+      <h2><i class="pi pi-calendar"></i> Atendimento e confissão</h2>
+      <p class="dica-hora" style="margin-top:0">
+        Horários da secretaria e de confissão — aparecem na página da igreja.
+      </p>
+      <div formArrayName="sessoes">
+        <div *ngFor="let sessao of sessoes.controls; let i = index" [formGroupName]="i" class="linha-sessao">
+          <p-select formControlName="tipo" [options]="tiposSessao" optionLabel="nome" optionValue="valor"
+                    styleClass="w-full" appendTo="body"></p-select>
+          <p-select formControlName="diaSemana" [options]="dias" optionLabel="nome" optionValue="valor"
+                    styleClass="w-full" appendTo="body"></p-select>
+          <input pInputText formControlName="horarioInicio" placeholder="09:00" maxlength="5" class="input-hora"
+                 [class.ng-invalid-visual]="sessoes.at(i).get('horarioInicio')?.invalid && sessoes.at(i).get('horarioInicio')?.touched" />
+          <span class="ate">às</span>
+          <input pInputText formControlName="horarioFim" placeholder="17:00" maxlength="5" class="input-hora"
+                 [class.ng-invalid-visual]="sessoes.at(i).get('horarioFim')?.invalid && sessoes.at(i).get('horarioFim')?.touched" />
+          <input pInputText formControlName="observacao" placeholder="Observação (opcional)" maxlength="255" />
+          <button pButton type="button" icon="pi pi-trash" class="p-button-text p-button-danger p-button-sm"
+                  (click)="removerSessao(i)" aria-label="Remover sessão"></button>
+        </div>
+      </div>
+      <button pButton type="button" icon="pi pi-plus" label="Adicionar horário de atendimento"
+              class="p-button-text p-button-sm mt-1" (click)="adicionarSessao()"></button>
+    </section>
+
     <div class="acoes">
       <a routerLink="/meu-painel">
         <button pButton type="button" label="Cancelar" class="p-button-text" [disabled]="salvando"></button>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -217,3 +217,26 @@ h1 {
     grid-template-columns: 1fr 100px;
   }
 }
+
+.linha-sessao {
+  display: grid;
+  grid-template-columns: 130px 150px 70px auto 70px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+
+  .ate {
+    font-size: 0.78rem;
+    color: #9ca3af;
+  }
+
+  .input-hora {
+    text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .linha-sessao {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -25,6 +25,11 @@ const REDES = [
   { tipo: 5, nome: "Twitter/X" },
 ];
 
+const TIPOS_SESSAO = [
+  { valor: 1, nome: "Secretaria" },
+  { valor: 2, nome: "Confissão" },
+];
+
 const DIAS = [
   { valor: 0, nome: "Domingo" },
   { valor: 1, nome: "Segunda-feira" },
@@ -61,6 +66,7 @@ export class EditarIgrejaComponent implements OnInit {
   readonly redes = REDES;
   readonly dias = DIAS;
   readonly estados = STATES;
+  readonly tiposSessao = TIPOS_SESSAO;
 
   igrejaId!: number;
   igrejaNome = "";
@@ -87,6 +93,9 @@ export class EditarIgrejaComponent implements OnInit {
   get missas(): FormArray {
     return this.form.get("missas") as FormArray;
   }
+  get sessoes(): FormArray {
+    return this.form.get("sessoes") as FormArray;
+  }
 
   ngOnInit(): void {
     if (!this._auth.estaLogado) {
@@ -105,6 +114,7 @@ export class EditarIgrejaComponent implements OnInit {
       }),
       redesSociais: this._fb.array([]),
       missas: this._fb.array([]),
+      sessoes: this._fb.array([]),
       endereco: this._fb.group({
         cep: ["", Validators.required],
         logradouro: ["", Validators.required],
@@ -134,6 +144,8 @@ export class EditarIgrejaComponent implements OnInit {
         });
         dados.redesSociais.forEach((r) => this.adicionarRede(r.tipoRedeSocial, r.nomeDoPerfil));
         dados.missas.forEach((m) => this.adicionarMissa(m.diaSemana, m.horario, m.observacao ?? ""));
+        dados.sessoes.forEach((se) =>
+          this.adicionarSessao(se.tipo, se.diaSemana, se.horarioInicio, se.horarioFim, se.observacao ?? ""));
 
         this.form.get("endereco")!.patchValue({
           cep: dados.endereco.cep ?? "",
@@ -195,6 +207,23 @@ export class EditarIgrejaComponent implements OnInit {
 
   removerMissa(i: number): void {
     this.missas.removeAt(i);
+  }
+
+  adicionarSessao(tipo = 1, dia = 1, horarioInicio = "", horarioFim = "", observacao = ""): void {
+    const horaValida = Validators.pattern(/^([01]\d|2[0-3]):[0-5]\d$/);
+    this.sessoes.push(
+      this._fb.group({
+        tipo: [tipo, Validators.required],
+        diaSemana: [dia, Validators.required],
+        horarioInicio: [horarioInicio, [Validators.required, horaValida]],
+        horarioFim: [horarioFim, [Validators.required, horaValida]],
+        observacao: [observacao, Validators.maxLength(255)],
+      })
+    );
+  }
+
+  removerSessao(i: number): void {
+    this.sessoes.removeAt(i);
   }
 
   /** True quando cidade/UF mudou em relação ao carregado — dispara o aviso de URL. */
@@ -265,6 +294,7 @@ export class EditarIgrejaComponent implements OnInit {
           longitude: this._longitude,
         },
         imagem: this.imagemBase64 ? { base64: this.imagemBase64 } : null,
+        sessoes: v.sessoes,
       })
       .subscribe({
         next: (mensagem) => {


### PR DESCRIPTION
## Resumo
Fases S3 e S4 do plano [Notificações + Sessões](https://github.com/FabioVeiga/buscamissa-frondend/blob/feature/notificacoes-n3-frontend/docs/plano-notificacoes-e-sessoes.md) — fecha a Feature B.

⚠️ **PR empilhado**: base é a branch da N3 (PR #99) — mesclar o #99 primeiro. Depende dos backends: buscamissa/buscamissa-api-admin#16 (schema) e buscamissa/buscamissa-api-public#13 (edição + resposta pública).

## Mudanças
- **Painel** (`/meu-painel/editar/:igrejaId`): seção "Atendimento e confissão" — FormArray com tipo (Secretaria/Confissão), dia da semana, horário início/fim ("HH:mm" validado) e observação opcional. Input estruturado, não texto livre.
- **Página pública da igreja**: seção "Atendimento e Confissão" agrupada por tipo — só renderiza se o responsável cadastrou ao menos uma sessão.
- Interfaces `SessaoEdicao` espelhando os DTOs.

## Testes (ponta a ponta local)
Sessões cadastradas (secretaria seg–sex 9h–17h + confissão qua 11h–12h "ou por agendamento" — exemplo do pedido), formulário carrega e edita, página pública exibe agrupado, console limpo. `tsc` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)