### PR TITLE
feat: adiciona métricas ao painel de edição de igrejas

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -98,3 +98,12 @@ export interface EditarDadosRequest {
   imagem?: ImagemEdicao | null;
   sessoes?: SessaoEdicao[] | null;
 }
+
+export interface MetricasIgreja {
+  periodoInicio: Date;
+  periodoFim: Date;
+  visualizacoes: number;
+  favoritos: number;
+  cliquesInstagram: number;
+  compartilhamentos: number;
+}

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -52,7 +52,7 @@ export class ResponsavelService {
   obterMetricas(igrejaId: number) {
     return this.http
       .get<{ data: {
-        periodoInicio: string; periodoFim: string;
+        periodoInicio: Date; periodoFim: Date;
         visualizacoes: number; favoritos: number;
         cliquesInstagram: number; compartilhamentos: number;
       } }>(`v1/responsavel/igreja/${igrejaId}/metricas`)

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -6,6 +6,7 @@ import {
   EditarDadosRequest,
   MinhaResponsabilidade,
   SolicitarResponsabilidadeRequest,
+  MetricasIgreja,
 } from "../interfaces/responsavel.interface";
 
 /**
@@ -49,14 +50,23 @@ export class ResponsavelService {
   }
 
   /** Métricas dos últimos 30 dias — cards do painel do responsável. */
-  obterMetricas(igrejaId: number) {
+  obterMetricas(igrejaId: number): Observable<MetricasIgreja> {
     return this.http
       .get<{ data: {
-        periodoInicio: Date; periodoFim: Date;
+        periodoInicio: string; periodoFim: string;
         visualizacoes: number; favoritos: number;
         cliquesInstagram: number; compartilhamentos: number;
       } }>(`v1/responsavel/igreja/${igrejaId}/metricas`)
-      .pipe(map((r) => r.data));
+      .pipe(
+        map((r) => ({
+          periodoInicio: new Date(r.data.periodoInicio),
+          periodoFim: new Date(r.data.periodoFim),
+          visualizacoes: r.data.visualizacoes,
+          favoritos: r.data.favoritos,
+          cliquesInstagram: r.data.cliquesInstagram,
+          compartilhamentos: r.data.compartilhamentos
+        }))
+      );
   }
 
   /** Aplica a edição direta na igreja real. */

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -24,10 +24,10 @@
     <h1>{{ igrejaNome }}</h1>
     <p class="subtitulo">Suas alterações são aplicadas imediatamente na página da igreja.</p>
 
-    <!-- MÉTRICAS (últimos 30 dias) -->
+    <!-- MÉTRICAS (este mês) -->
     <section *ngIf="metricas" class="bloco bloco--metricas">
       <h2>
-        <i class="pi pi-chart-line"></i> Últimos 30 dias
+        <i class="pi pi-chart-line"></i> Este mês
         <span class="periodo">{{ metricas.periodoInicio | date: "dd/MM" }} – {{ metricas.periodoFim | date: "dd/MM/yyyy" }}</span>
       </h2>
       <div class="grid-metricas">

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -88,7 +88,7 @@ export class EditarIgrejaComponent implements OnInit {
 
   /** Cards de métricas (últimos 30 dias). */
   metricas: {
-    periodoInicio: string; periodoFim: string;
+    periodoInicio: Date; periodoFim: Date;
     visualizacoes: number; favoritos: number;
     cliquesInstagram: number; compartilhamentos: number;
   } | null = null;

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -16,6 +16,7 @@ import { AuthService } from "../../../../core/services/auth.service";
 import { ResponsavelService } from "../../../../core/services/responsavel.service";
 import { ChurchesService } from "../../../../core/services/churches.service";
 import { LoggerService } from "../../../../core/services/logger.service";
+import { MetricasIgreja } from "../../../../core/interfaces/responsavel.interface";
 import { STATES } from "../../../../core/constants/states";
 
 const REDES = [
@@ -87,11 +88,7 @@ export class EditarIgrejaComponent implements OnInit {
   cepSemCidade = false;
 
   /** Cards de métricas (últimos 30 dias). */
-  metricas: {
-    periodoInicio: Date; periodoFim: Date;
-    visualizacoes: number; favoritos: number;
-    cliquesInstagram: number; compartilhamentos: number;
-  } | null = null;
+  metricas: MetricasIgreja | null = null;
 
   /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
   private _localidadeOriginal = "";


### PR DESCRIPTION
## Resumo
Cards de métricas do mês corrente no painel de edição de igrejas do responsável verificado.

## O que foi implementado
- Cards informativos: Visualizações, Favoritos, Instagram, Compartilhamentos
- Período: Mês corrente (1º até último dia)
- Layout responsivo: 4 colunas desktop, 2 mobile
- Ícones em gradiente com hover effects
- Busca de CEP integrada
- Interface do responsável

## Commits
- feat: adiciona cards de métricas
- refactor: atualiza mensagem de aviso de URL
- fix: corrige tipagem de métricas
- refactor: interface dedicada para métricas
- refactor: label atualizado para "Este mês"

🚀 Pronto para merge em dev