### PR TITLE
feat: melhorias no painel de edição - métricas e aviso de URL

### DIFF
--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -173,6 +173,7 @@ export class EditarIgrejaComponent implements OnInit {
         });
         this._localidadeOriginal = dados.endereco.localidade ?? "";
         this._ufOriginal = dados.endereco.uf ?? "";
+        this.form.get("endereco")?.markAsPristine();
         this._latitude = dados.endereco.latitude ?? null;
         this._longitude = dados.endereco.longitude ?? null;
         this.imagemPreview = dados.imagemUrl ?? null;
@@ -276,17 +277,18 @@ export class EditarIgrejaComponent implements OnInit {
 
   /** True quando cidade/UF mudou em relação ao carregado — dispara o aviso de URL. */
   get cidadeOuUfMudou(): boolean {
+    // Se não tem valores originais, não mostra mensagem
+    if (!this._localidadeOriginal && !this._ufOriginal) return false;
+
     const e = this.form.get("endereco")!.value;
-    const localidadeAtual = e.localidade?.trim() || "";
-    const ufAtual = e.uf || "";
+    const localidadeAtual = (e.localidade || "").trim();
+    const ufAtual = (e.uf || "").trim();
 
-    // Só mostra mensagem se:
-    // 1. Havia localidade/UF original
-    // 2. E mudou em relação ao original
-    const localidadeMudou = localidadeAtual !== this._localidadeOriginal;
-    const ufMudou = ufAtual !== this._ufOriginal;
+    // Comparação segura: só mostra se mudou de fato
+    const localidadeMudou = localidadeAtual !== this._localidadeOriginal.trim();
+    const ufMudou = ufAtual !== this._ufOriginal.trim();
 
-    return !!this._localidadeOriginal && (localidadeMudou || ufMudou);
+    return localidadeMudou || ufMudou;
   }
 
   selecionarImagem(event: Event): void {

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -277,10 +277,16 @@ export class EditarIgrejaComponent implements OnInit {
   /** True quando cidade/UF mudou em relação ao carregado — dispara o aviso de URL. */
   get cidadeOuUfMudou(): boolean {
     const e = this.form.get("endereco")!.value;
-    return (
-      !!this._localidadeOriginal &&
-      (e.localidade?.trim() !== this._localidadeOriginal || e.uf !== this._ufOriginal)
-    );
+    const localidadeAtual = e.localidade?.trim() || "";
+    const ufAtual = e.uf || "";
+
+    // Só mostra mensagem se:
+    // 1. Havia localidade/UF original
+    // 2. E mudou em relação ao original
+    const localidadeMudou = localidadeAtual !== this._localidadeOriginal;
+    const ufMudou = ufAtual !== this._ufOriginal;
+
+    return !!this._localidadeOriginal && (localidadeMudou || ufMudou);
   }
 
   selecionarImagem(event: Event): void {


### PR DESCRIPTION
## Resumo
Correções e melhorias no painel de edição de igrejas: métricas do mês corrente e lógica de aviso de URL.

## O que foi implementado
- **Métricas do mês corrente**: Visualizações, Favoritos, Instagram, Compartilhamentos
- **Label atualizado**: "Este mês" em vez de "Últimos 30 dias"
- **Aviso de URL**: Só aparece quando há mudança efetiva de Estado/Cidade
- **Busca de CEP**: Integrada com preenchimento automático
- **Tipagem melhorada**: Interface MetricasIgreja dedicada

## Commits
- fix: corrige exibição do aviso de mudança de URL
- refactor: melhora lógica de detecção de mudança de cidade/UF
- refactor: altera label de métricas para "Este mês"
- refactor: melhora tipagem de métricas com interface dedicada
- fix: corrige tipo de dados das métricas (DateOnly → Date)

## Testes
- ✅ Métricas carregam corretamente
- ✅ Aviso só aparece com mudança efetiva
- ✅ Label reflete período correto
- ✅ Busca de CEP funciona

🚀 Pronto para merge em dev