### PR TITLE
feat: painel de edição de igrejas com métricas e busca de CEP

### DIFF
--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -267,6 +267,9 @@ export class EditarIgrejaComponent implements OnInit {
           logradouro: e.logradouro || this.form.get("endereco.logradouro")?.value,
           bairro: e.bairro || this.form.get("endereco.bairro")?.value,
         });
+        // Atualiza valores originais para refletir o CEP preenchido
+        this._localidadeOriginal = e.localidade || "";
+        this._ufOriginal = e.uf || "";
       },
       error: () => {
         this.buscandoCep = false;


### PR DESCRIPTION
## Resumo
Implementação completa do painel de edição de igrejas com cards de métricas do mês corrente e integração de busca de CEP com preenchimento automático.

## O que foi implementado
### Métricas
- **Cards informativos**: Visualizações, Favoritos, Instagram, Compartilhamentos
- **Período**: Mês corrente (1º até último dia) com datas de início e fim
- **Layout responsivo**: 4 colunas desktop, 2 em mobile
- **Visual**: Ícones em gradiente com hover effects

### Busca de CEP
- **Integração com backend**: Consulta CEP e preenche logradouro/bairro/localidade/UF
- **Validação automática**: Bloqueia cidade/UF quando preenchidas pelo CEP
- **Feedback visual**: Spinner durante busca

### Aviso de URL
- **Lógica corrigida**: Só aparece quando há mudança manual de Estado/Cidade
- **Sem falsos positivos**: CEP não dispara o aviso

## Commits
- fix: aviso de URL não aparece quando CEP preenche cidade/UF
- fix: corrige exibição do aviso de mudança de URL
- refactor: melhora lógica de detecção de mudança de cidade/UF
- refactor: altera label de métricas para "Este mês"
- refactor: melhora tipagem de métricas com interface dedicada
- fix: corrige tipo de dados das métricas (DateOnly → Date)
- refactor: atualiza mensagem de aviso de mudança de URL
- feat: adiciona cards de métricas ao painel de edição de igrejas

## Testes
- ✅ Métricas carregam do mês corrente
- ✅ Aviso só aparece com mudança real
- ✅ CEP preenche e não dispara aviso
- ✅ Layout responsivo funciona
- ✅ Tipagem corrigida

🚀 Pronto para merge em dev