### PR TITLE
seo: reforça noindex de páginas logadas no robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,11 @@
 User-agent: *
 Allow: /
 
-# Não indexar páginas de fluxo interno
+# Não indexar páginas de fluxo interno / área logada
 Disallow: /editar/
 Disallow: /enviar-codigo/
 Disallow: /validar
+Disallow: /entrar
+Disallow: /meu-painel
 
 Sitemap: https://buscamissa.com.br/sitemap.xml


### PR DESCRIPTION
Adiciona Disallow /entrar e /meu-painel ao robots.txt. Antes o noindex dessas rotas dependia apenas do meta injetado por JS (SeoService), que crawlers que não executam JS não veem. O Disallow garante a exclusão no nível do robots.