### PR TITLE
fix: botão 'Solicitar Responsabilidade' redirecionar para /entrar

### DIFF
--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -126,11 +126,10 @@
         </div>
       </div>
       <div class="shrink-0">
-        <!-- Fase 4: Se logado → vai para /nova com nomeUnico pré-preenchido -->
         <button pButton type="button"
           icon="pi pi-plus" label="Solicitar Responsabilidade"
           class="p-button-sm p-button-success"
-          (click)="solicitarResponsabilidadeLogado()">
+          (click)="abrirSolicitacaoResponsavel()">
         </button>
       </div>
     </section>


### PR DESCRIPTION
## Problema
O botão "Solicitar Responsabilidade" na página de detalhe da paróquia não estava funcionando. Ele chamava uma função que não verificava se o usuário estava logado e não fazia nenhuma navegação quando o usuário não estava autenticado.

## Solução
Alterado o botão para chamar `abrirSolicitacaoResponsavel()` que:
- ✅ Verifica se o usuário está logado
- ✅ Se não logado: mostra um toast e redireciona para `/entrar`
- ✅ Se logado: abre o modal de solicitação de responsabilidade

## Arquivo modificado
- `src/app/modules/public/home/details/details.component.html`

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>