### PR TITLE
feat: registrar visualização da Home via MetricasDiarias

### DIFF
--- a/src/app/core/services/metricas.service.ts
+++ b/src/app/core/services/metricas.service.ts
@@ -30,6 +30,23 @@ export class MetricasService {
     localStorage.setItem(chave, String(agora));
   }
 
+  // Home não tem EntidadeId — mesma janela de dedupe das demais métricas,
+  // para não contar o mesmo visitante várias vezes em navegações rápidas (F5).
+  registrarVisualizacaoHome(): void {
+    const chave = 'home_ultima_visualizacao';
+    const agora = Date.now();
+    const ultimaVisualizacao = Number(localStorage.getItem(chave) ?? 0);
+
+    if (agora - ultimaVisualizacao < JANELA_VISUALIZACAO_MS) return;
+
+    this.http
+      .post('v2/metricas/visualizacao-home', {})
+      .subscribe({
+        error: (err) => this.logger.logError(err, 'metrica:visualizacao-home'),
+      });
+    localStorage.setItem(chave, String(agora));
+  }
+
   registrarCliqueRota(igrejaId: number): void {
     this.enviar('clique-rota', igrejaId);
   }

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -37,6 +37,7 @@ import { HomeCidadesComponent } from "./sections/home-cidades/home-cidades.compo
 import { HomeMissasMapaComponent } from "./sections/home-missas-mapa/home-missas-mapa.component";
 import { linkParoquia } from "../../../shared/utils/church-link.utils";
 import { SeoService } from "../../../core/services/seo.service";
+import { MetricasService } from "../../../core/services/metricas.service";
 
 interface AddressData {
   [uf: string]: {
@@ -76,6 +77,7 @@ export class HomeComponent {
   private _redesSociais = inject(RedesSociaisService);
   private _geo = inject(GeolocationService);
   private _seo = inject(SeoService);
+  private _metricas = inject(MetricasService);
   tiposRedeSocial: TipoRedeSocial[] = [];
 
   /** Status da geolocalização */
@@ -401,6 +403,11 @@ export class HomeComponent {
       error: () => { /* silencioso — mantém a lista padrão se a API falhar */ },
     });
     this.resultsMode = !!this._route.snapshot.data['resultsMode'];
+    // Só conta como visita à Home a rota /home — /buscar é a mesma tela em
+    // modo de resultados e não deve inflar a métrica.
+    if (!this.resultsMode) {
+      this._metricas.registrarVisualizacaoHome();
+    }
 
     this.form = this._fb.group({
       Uf: [null, Validators.required],


### PR DESCRIPTION
## Resumo
Adiciona rastreamento de acessos à Home, reaproveitando o mesmo pipeline de `MetricasDiarias` já usado para páginas de igreja (mesma técnica de dedupe por 30min via localStorage).

## Mudanças
- `MetricasService.registrarVisualizacaoHome()` — chama `POST /api/v2/metricas/visualizacao-home`
- Chamado no `ngOnInit` da `HomeComponent`, só quando `!resultsMode` (ou seja, na rota `/home`, não em `/buscar`, que reusa o mesmo componente)

## Depende de
- PR no `buscamissa-api-public` (endpoint `visualizacao-home`)
- PR no `buscamissa-api-admin` que expõe `cards.visualizacoesHome` no indicadores

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>