### PR TITLE
Feature/auditoria2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "ng build",
     "build:dev": "ng build --configuration=development",
     "postbuild:dev": "node scripts/copiar-index-csr.mjs",
+    "prebuild:staging": "node scripts/gerar-sitemap.mjs staging",
     "build:staging": "ng build --configuration=staging",
     "postbuild:staging": "node scripts/copiar-index-csr.mjs",
     "build:prod": "ng build --configuration=production",

--- a/scripts/gerar-sitemap.mjs
+++ b/scripts/gerar-sitemap.mjs
@@ -43,14 +43,15 @@ const STATIC_PAGES = [
 async function main() {
   console.log(`Buscando rotas SEO em ${API_URL}/v2/seo/routes ...`);
 
-  let data;
+  // Degrada com elegância: se a API estiver fora durante o build, gera um
+  // sitemap só com as páginas estáticas em vez de derrubar o deploy inteiro.
+  let data = { cities: [], parishes: [] };
   try {
     const res = await fetch(`${API_URL}/v2/seo/routes`);
     if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
     data = await res.json();
   } catch (err) {
-    console.error(`Erro ao buscar /v2/seo/routes: ${err.message}`);
-    process.exit(1);
+    console.warn(`⚠ Não foi possível buscar /v2/seo/routes (${err.message}). Gerando sitemap apenas com páginas estáticas.`);
   }
 
   const { cities = [], parishes = [] } = data;

--- a/src/app/core/services/geolocation.service.ts
+++ b/src/app/core/services/geolocation.service.ts
@@ -32,16 +32,29 @@ export class GeolocationService {
   private static readonly NOMINATIM = 'https://nominatim.openstreetmap.org';
   private static readonly VIACEP = 'https://viacep.com.br/ws';
 
+  // Opções do getCurrentPosition:
+  //  - enableHighAccuracy:false → usa rede/WiFi (mais rápido e confiável que GPS
+  //    no desktop, onde a alta precisão costuma falhar com kCLErrorLocationUnknown);
+  //  - timeout:10s → evita ficar preso em "carregando" para sempre;
+  //  - maximumAge:5min → aceita uma posição recente em cache, que frequentemente
+  //    resolve casos em que uma leitura nova falharia.
+  private static readonly GEO_OPTIONS: PositionOptions = {
+    enableHighAccuracy: false,
+    timeout: 10_000,
+    maximumAge: 300_000,
+  };
+
   /** Posição atual do usuário (Promise em torno do navigator.geolocation). */
   obterPosicaoAtual(): Promise<Coordenadas> {
     return new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
+      if (typeof navigator === 'undefined' || !navigator.geolocation) {
         reject(new Error('geolocation-indisponivel'));
         return;
       }
       navigator.geolocation.getCurrentPosition(
         (pos) => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
-        (err) => reject(err)
+        (err) => reject(err),
+        GeolocationService.GEO_OPTIONS
       );
     });
   }

--- a/src/app/modules/public/missa-agora/missa-agora.component.ts
+++ b/src/app/modules/public/missa-agora/missa-agora.component.ts
@@ -100,26 +100,29 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
   }
 
   private _pedirGeolocalizacao(): void {
-    if (!navigator.geolocation) {
-      this.geoStatus = 'denied';
-      return;
-    }
     this.geoStatus = 'loading';
-    navigator.geolocation.getCurrentPosition(
-      pos => {
+    this._geo.obterPosicaoAtual()
+      .then(({ lat, lng }) => {
         this.permissaoNegadaPeloBrowser = false;
         this.geoStatus = 'found';
-        this._buscarMissas(pos.coords.latitude, pos.coords.longitude);
-        this._reverseGeocode(pos.coords.latitude, pos.coords.longitude);
-        this._loadCidadesProximas(pos.coords.latitude, pos.coords.longitude);
-      },
-      err => {
+        this._buscarMissas(lat, lng);
+        this._reverseGeocode(lat, lng);
+        this._loadCidadesProximas(lat, lng);
+      })
+      .catch((err: GeolocationPositionError | Error) => {
         this.geoStatus = 'denied';
-        if (err.code === 1) {
-          this.permissaoNegadaPeloBrowser = true;
+        const code = (err as GeolocationPositionError)?.code;
+        this.permissaoNegadaPeloBrowser = code === 1;
+        // Posição indisponível (2) ou timeout (3): não foi o usuário que negou —
+        // avisa e direciona para o fallback de cidade/CEP, sem culpar a permissão.
+        if (code === 2 || code === 3) {
+          this._toast.add({
+            severity: 'info',
+            summary: 'Não conseguimos te localizar',
+            detail: 'Sua localização não está disponível agora. Busque por cidade ou CEP abaixo.',
+          });
         }
-      }
-    );
+      });
   }
 
   private _buscarMissas(lat: number, lng: number): void {

--- a/src/staticwebapp.config.json
+++ b/src/staticwebapp.config.json
@@ -9,7 +9,9 @@
       "/*.png",
       "/*.webmanifest",
       "/*.html",
-      "/*.map"
+      "/*.map",
+      "/*.xml",
+      "/*.txt"
     ]
   },
   "globalHeaders": {


### PR DESCRIPTION
Correções a partir da validação da Fase 1 (SSG) no staging.

## 1. sitemap / fallback (`1520b26`)
- **`prebuild:staging`**: o staging não gerava `sitemap.xml` (só o prod tinha `prebuild:prod`). Agora gera nos dois.
- **`navigationFallback.exclude`**: adiciona `/*.xml` e `/*.txt` — um arquivo ausente (ex: sitemap) agora dá **404 limpo** em vez de servir o HTML do SPA.
- **`gerar-sitemap.mjs` resiliente**: se a API estiver fora durante o build, gera sitemap só com as páginas estáticas em vez de derrubar o deploy (`exit 1`).

## 2. missa-agora — geolocalização (`193629b`)
Corrige o "não funcionou" reportado (console: `kCLErrorLocationUnknown`, erro código 2 = posição indisponível):
- `GeolocationService.obterPosicaoAtual` agora usa `PositionOptions` (`enableHighAccuracy:false`, `timeout:10s`, `maximumAge:5min` — aceita posição recente em cache, que costuma resolver o erro).
- `missa-agora` passa a usar o serviço (remove `navigator.geolocation` duplicado) e diferencia a mensagem: posição indisponível/timeout mostram um toast direcionando ao fallback de cidade/CEP, **sem** dar a entender que o usuário bloqueou a permissão.

## Checklist de validação (staging)
- [ ] `/sitemap.xml` acessível no staging (200, `text/xml`).
- [ ] `/algo-inexistente.xml` → 404 limpo (não HTML).
- [ ] `/missa-agora` com localização bloqueada/indisponível → toast claro + busca por cidade/CEP funcionando.
- [ ] Build não quebra se a API estiver fora (sitemap degrada p/ estáticas).

_Nota: a home também chama `navigator.geolocation` direto — migrar p/ o serviço fica como follow-up._