### PR TITLE
feat(ssr): Fase 2 do prerender — páginas de cidade (Auditoria2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "postbuild:dev": "node scripts/copiar-index-csr.mjs",
     "prebuild:staging": "node scripts/gerar-sitemap.mjs staging",
     "build:staging": "ng build --configuration=staging",
-    "postbuild:staging": "node scripts/copiar-index-csr.mjs",
+    "postbuild:staging": "node scripts/copiar-index-csr.mjs && node scripts/verificar-prerender.mjs",
     "build:prod": "ng build --configuration=production",
     "prebuild:prod": "node scripts/gerar-sitemap.mjs prod",
-    "postbuild:prod": "node scripts/copiar-index-csr.mjs",
+    "postbuild:prod": "node scripts/copiar-index-csr.mjs && node scripts/verificar-prerender.mjs",
     "watch": "ng build --watch --configuration=development",
     "test": "ng test"
   },

--- a/scripts/gerar-sitemap.mjs
+++ b/scripts/gerar-sitemap.mjs
@@ -1,6 +1,7 @@
 import { writeFileSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { buscarRotasSeo, normalizarBaseUrl } from './lib/seo-routes.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -9,7 +10,7 @@ const ROOT = join(__dirname, '..');
 const ENV = process.argv[2] ?? 'prod';
 
 function lerApiUrl() {
-  if (process.env.API_URL) return process.env.API_URL.replace(/\/$/, '');
+  if (process.env.API_URL) return normalizarBaseUrl(process.env.API_URL);
 
   const envFile = ENV === 'staging'
     ? join(ROOT, 'src/environments/environment.staging.ts')
@@ -20,7 +21,7 @@ function lerApiUrl() {
   if (!match) throw new Error(`apiURL não encontrado em ${envFile}`);
 
   // Remove /api/ do caminho — o endpoint /v2/seo/routes é rota absoluta
-  return match[1].replace(/\/api\/?$/, '').replace(/\/$/, '');
+  return normalizarBaseUrl(match[1]);
 }
 
 const API_URL = lerApiUrl();
@@ -41,20 +42,10 @@ const STATIC_PAGES = [
 ];
 
 async function main() {
-  console.log(`Buscando rotas SEO em ${API_URL}/v2/seo/routes ...`);
-
-  // Degrada com elegância: se a API estiver fora durante o build, gera um
-  // sitemap só com as páginas estáticas em vez de derrubar o deploy inteiro.
-  let data = { cities: [], parishes: [] };
-  try {
-    const res = await fetch(`${API_URL}/v2/seo/routes`);
-    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    data = await res.json();
-  } catch (err) {
-    console.warn(`⚠ Não foi possível buscar /v2/seo/routes (${err.message}). Gerando sitemap apenas com páginas estáticas.`);
-  }
-
-  const { cities = [], parishes = [] } = data;
+  // Fonte única (scripts/lib/seo-routes.mjs): já trata timeout, validação de
+  // shape, dedupe, ordenação e degradação (retorna listas vazias se a API estiver
+  // fora, gerando um sitemap só com as páginas estáticas em vez de derrubar o build).
+  const { cities, parishes } = await buscarRotasSeo(API_URL);
 
   const urlEntries = [];
 

--- a/scripts/lib/seo-routes.mjs
+++ b/scripts/lib/seo-routes.mjs
@@ -1,0 +1,108 @@
+/**
+ * Fonte única de verdade para as rotas de SEO derivadas de `/v2/seo/routes`.
+ *
+ * Consumido por dois runtimes distintos:
+ *   1. `scripts/gerar-sitemap.mjs` — script Node standalone (prebuild).
+ *   2. `src/app/app.routes.server.ts` — `getPrerenderParams` no bundle server do
+ *      Angular, durante o prerender (Fase 2 do SSR: cidades; Fase 2.5: paróquias).
+ *
+ * Por isso NÃO depende de `fs` nem de nada específico de um dos ambientes: recebe
+ * a base da API pronta e usa só `fetch`/`AbortController` (globais no Node 18+ e
+ * no bundle server). Cada chamador resolve a base do seu jeito (fs vs environment)
+ * e chama `buscarRotasSeo(base)`.
+ *
+ * Requisitos não-funcionais (Auditoria2 / Fase 2):
+ *  - cache da Promise: 1 fetch por build, mesmo com vários getPrerenderParams;
+ *  - timeout, para não travar o build num CI com API lenta;
+ *  - fallback vazio (degrada sem derrubar o deploy) — e o cache é limpo no erro,
+ *    para permitir nova tentativa numa chamada posterior;
+ *  - validação de shape (descarta item sem uf/slug — protege contra rename no back);
+ *  - deduplicação + ordenação determinística (builds comparáveis).
+ */
+
+const TIMEOUT_MS = 8000;
+
+/** Remove o sufixo `/api` e barra final — `/v2/seo/routes` é rota absoluta. */
+export function normalizarBaseUrl(raw) {
+  return String(raw ?? '')
+    .replace(/\/api\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+/** Cache da Promise (não do resultado) — dedupe de chamadas concorrentes no build. */
+let cachePromise = null;
+
+/**
+ * Busca e normaliza as rotas de SEO. Sempre resolve (nunca rejeita): em erro/timeout
+ * retorna `{ cities: [], parishes: [] }` e o prerender simplesmente não gera nada.
+ *
+ * @param {string} apiBase base já normalizada (ex: https://.../ sem /api)
+ * @returns {Promise<{ cities: Array<{uf:string,citySlug:string,lastModified?:string}>, parishes: Array<{uf:string,citySlug:string,slug:string,lastModified?:string}> }>}
+ */
+export function buscarRotasSeo(apiBase) {
+  if (cachePromise) return cachePromise;
+  cachePromise = _buscar(apiBase).catch((err) => {
+    // Limpa o cache no erro para não fossilizar `[]` no resto do build.
+    cachePromise = null;
+    console.warn(`[SEO] falha ao buscar rotas — prerender desabilitado (${err?.message ?? err}).`);
+    return { cities: [], parishes: [] };
+  });
+  return cachePromise;
+}
+
+async function _buscar(apiBase) {
+  const url = `${apiBase}/v2/seo/routes`;
+  const inicio = Date.now();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let bruto;
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    bruto = await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const cities = normalizarCidades(bruto?.cities);
+  const parishes = normalizarParoquias(bruto?.parishes);
+
+  const ms = Date.now() - inicio;
+  console.log(`[SEO] ${cities.length} cidades / ${parishes.length} paróquias carregadas de ${url} em ${ms}ms.`);
+
+  return { cities, parishes };
+}
+
+function normalizarCidades(lista) {
+  const vistos = new Set();
+  const out = [];
+  for (const c of Array.isArray(lista) ? lista : []) {
+    const uf = c?.uf;
+    const citySlug = c?.citySlug;
+    if (!uf || !citySlug) continue; // shape inválido (ex: rename no backend) → descarta
+    const chave = `${uf}/${citySlug}`.toLowerCase();
+    if (vistos.has(chave)) continue; // dedupe
+    vistos.add(chave);
+    out.push({ uf, citySlug, lastModified: c.lastModified });
+  }
+  return out.sort((a, b) => `${a.uf}/${a.citySlug}`.localeCompare(`${b.uf}/${b.citySlug}`));
+}
+
+function normalizarParoquias(lista) {
+  const vistos = new Set();
+  const out = [];
+  for (const p of Array.isArray(lista) ? lista : []) {
+    const uf = p?.uf;
+    const citySlug = p?.citySlug;
+    const slug = p?.slug;
+    if (!uf || !citySlug || !slug) continue;
+    const chave = `${uf}/${citySlug}/${slug}`.toLowerCase();
+    if (vistos.has(chave)) continue;
+    vistos.add(chave);
+    out.push({ uf, citySlug, slug, lastModified: p.lastModified });
+  }
+  return out.sort((a, b) =>
+    `${a.uf}/${a.citySlug}/${a.slug}`.localeCompare(`${b.uf}/${b.citySlug}/${b.slug}`),
+  );
+}

--- a/scripts/verificar-prerender.mjs
+++ b/scripts/verificar-prerender.mjs
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+/**
+ * Guard-rail do prerender (Auditoria2 / Fase 2). Roda no postbuild, depois do
+ * prerender das cidades.
+ *
+ * Se a API estiver com problema durante o build, o componente de cidade assa o
+ * SEU estado de erro ("Não foi possível / Tentar novamente") no HTML estático —
+ * e o `ng build` sai 0 mesmo assim. Sem esta trava, o site publicaria páginas de
+ * erro para o Google indexar. Aqui contamos quantas cidades ficaram em estado de
+ * erro e ABORTAMOS o build (exit 1) se passar do limiar.
+ *
+ * Não falha quando ZERO cidades foram prerenderizadas: isso é o fallback seguro
+ * (API fora → getPrerenderParams vazio → cidades seguem CSR), não um erro a barrar.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Marcador do estado de erro do city.component (botão "Tentar novamente").
+const MARCADOR_ERRO = 'Tentar novamente';
+// Limiar tolerado de páginas de erro (falhas transientes pontuais acontecem).
+const LIMIAR = 0.02; // 2%
+
+function acharPastaMissas(base) {
+  // dist/<app>/browser/missas
+  if (!existsSync(base)) return null;
+  for (const app of readdirSync(base)) {
+    const p = join(base, app, 'browser', 'missas');
+    if (existsSync(p) && statSync(p).isDirectory()) return p;
+  }
+  return null;
+}
+
+function listarIndexHtml(dir) {
+  const out = [];
+  for (const nome of readdirSync(dir)) {
+    const full = join(dir, nome);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...listarIndexHtml(full));
+    else if (nome === 'index.html') out.push(full);
+  }
+  return out;
+}
+
+const missasDir = acharPastaMissas(join(ROOT, 'dist'));
+if (!missasDir) {
+  console.log('[guard-rail] nenhuma página de cidade prerenderizada — nada a verificar (cidades seguem CSR).');
+  process.exit(0);
+}
+
+const arquivos = listarIndexHtml(missasDir);
+const total = arquivos.length;
+let comErro = 0;
+const exemplos = [];
+for (const f of arquivos) {
+  if (readFileSync(f, 'utf-8').includes(MARCADOR_ERRO)) {
+    comErro++;
+    if (exemplos.length < 10) exemplos.push(f.replace(missasDir, 'missas').replace('/index.html', ''));
+  }
+}
+
+const ratio = total ? comErro / total : 0;
+const pct = (ratio * 100).toFixed(1);
+console.log(`[guard-rail] cidades prerenderizadas: ${total} | em estado de erro: ${comErro} (${pct}%) | limiar: ${(LIMIAR * 100).toFixed(0)}%`);
+
+if (ratio > LIMIAR) {
+  console.error(`\n❌ [guard-rail] ${comErro}/${total} páginas de cidade (${pct}%) foram assadas em ESTADO DE ERRO — acima do limiar de ${(LIMIAR * 100).toFixed(0)}%.`);
+  console.error('   Causa provável: rate limit (429) da API durante o prerender. Verifique o endpoint bulk /v2/seo/cidades e o interceptor de prerender.');
+  console.error('   Exemplos:');
+  for (const e of exemplos) console.error(`     - ${e}`);
+  console.error('   Build abortado para não publicar páginas de erro indexáveis.\n');
+  process.exit(1);
+}
+
+console.log('✓ [guard-rail] prerender de cidades saudável.');

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,13 +1,19 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
 import { provideServerRouting } from '@angular/ssr';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
+import { PrerenderCidadeInterceptor } from './core/middleware/prerender-cidade.interceptor';
 
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
     provideServerRouting(serverRoutes),
+    // Só no server: serve os GET de cidade do bulk /v2/seo/cidades durante o
+    // prerender (1 fetch em vez de ~880), evitando o rate limit (429). Ausente
+    // no bundle do browser, então em runtime nada muda.
+    { provide: HTTP_INTERCEPTORS, useClass: PrerenderCidadeInterceptor, multi: true },
   ],
 };
 

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,14 +1,20 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
+import { environment } from '../environments/environment';
+// Fonte única das rotas de SEO, compartilhada com scripts/gerar-sitemap.mjs.
+// É um módulo .mjs plano (roda também como script Node standalone), por isso o
+// type-checker não tem declaração — o esbuild do build server o empacota normalmente.
+// @ts-expect-error — módulo JS sem tipos; contrato garantido pelo próprio helper.
+import { buscarRotasSeo, normalizarBaseUrl } from '../../scripts/lib/seo-routes.mjs';
 
 /**
- * Fase 1 da migração SSR (fatia fina): pré-renderiza apenas as páginas de
- * conteúdo estático — texto fixo, sem parâmetros de rota e sem dependência de
- * dados da API. Isso valida o pipeline de prerender end-to-end com risco mínimo.
+ * Migração SSR/SSG (Auditoria2), em fases sobre `outputMode: static`:
  *
- * Todo o resto (home, busca, cidade, paróquia, área logada, rotas com :param)
- * permanece em CSR (RenderMode.Client) até as próximas fases, que vão migrar
- * as páginas dinâmicas de maior valor de SEO (cidade e paróquia) usando
- * getPrerenderParams alimentado por /v2/seo/routes.
+ * - Fase 1 (em produção): prerender das 8 páginas de conteúdo estático — texto
+ *   fixo, sem :param e sem dados da API.
+ * - Fase 2 (aqui): prerender das páginas de CIDADE (`/missas/:uf/:cidade`) via
+ *   `getPrerenderParams`, alimentado por `/v2/seo/routes` (mesmo endpoint do
+ *   sitemap). Paróquias permanecem em CSR até a Fase 2.5 (volume alto — medir o
+ *   custo de build das cidades antes de escalar).
  */
 export const serverRoutes: ServerRoute[] = [
   { path: 'como-funciona', renderMode: RenderMode.Prerender },
@@ -20,6 +26,22 @@ export const serverRoutes: ServerRoute[] = [
   { path: 'privacidade', renderMode: RenderMode.Prerender },
   { path: 'cookies', renderMode: RenderMode.Prerender },
 
-  // Tudo o mais continua client-side por enquanto.
+  // Fase 2 — cidades. As chaves (uf/cidade) casam com os :param de app.routes.ts.
+  // Se `/v2/seo/routes` falhar no build, o helper retorna lista vazia: nenhuma
+  // cidade é prerenderizada (segue CSR) em vez de derrubar o deploy.
+  {
+    path: 'missas/:uf/:cidade',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const base = normalizarBaseUrl(environment.config.apiURL);
+      const { cities } = await buscarRotasSeo(base);
+      return cities.map((c: { uf: string; citySlug: string }) => ({
+        uf: c.uf,
+        cidade: c.citySlug,
+      }));
+    },
+  },
+
+  // Tudo o mais (home, busca, paróquia, área logada, rotas legadas) segue CSR.
   { path: '**', renderMode: RenderMode.Client },
 ];

--- a/src/app/core/middleware/prerender-cidade.interceptor.ts
+++ b/src/app/core/middleware/prerender-cidade.interceptor.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, from, of, switchMap } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Interceptor SÓ-SERVER (registrado apenas em app.config.server.ts) — resolve o
+ * bloqueador da Fase 2 (Auditoria2): o prerender de ~880 cidades fazia ~880 GET
+ * /v2/Igreja/cidade/... contra a API prod e estourava o rate limit (429),
+ * assando páginas de erro no HTML estático.
+ *
+ * Aqui, a PRIMEIRA chamada de cidade dispara UM fetch ao bulk `/v2/seo/cidades`
+ * (todas as cidades de uma vez, cacheado numa Promise). As 880 chamadas passam a
+ * ser servidas da memória, com o MESMO envelope que /v2/Igreja/cidade/{uf}/{slug}
+ * devolve (`{ data: { cidade, uf, igrejas, seo } }`) — o componente não muda.
+ *
+ * No browser este interceptor NÃO existe (não é registrado no config do browser),
+ * então em runtime as chamadas seguem normalmente para a API.
+ *
+ * Degrada com segurança: se o bulk falhar, cai para a chamada individual (next).
+ */
+
+interface CidadePayload {
+  uf: string;
+  cidadeSlug: string;
+  cidade: string;
+  seo: unknown;
+  igrejas: unknown[];
+}
+
+/** Base absoluta da API sem o sufixo /api — /v2/seo/cidades é rota absoluta. */
+function baseUrl(): string {
+  return String(environment.config.apiURL ?? '')
+    .replace(/\/api\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+/** Cache da Promise do mapa (1 fetch por build, mesmo com 880 cidades). */
+let cacheMapa: Promise<Map<string, CidadePayload>> | null = null;
+
+async function carregarMapa(): Promise<Map<string, CidadePayload>> {
+  const url = `${baseUrl()}/v2/seo/cidades`;
+  const inicio = Date.now();
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  const lista = (await res.json()) as CidadePayload[];
+
+  const mapa = new Map<string, CidadePayload>();
+  for (const c of Array.isArray(lista) ? lista : []) {
+    if (!c?.uf || !c?.cidadeSlug) continue;
+    mapa.set(`${c.uf}/${c.cidadeSlug}`.toLowerCase(), c);
+  }
+  console.log(
+    `[prerender] ${mapa.size} cidades carregadas do bulk /v2/seo/cidades em ${Date.now() - inicio}ms.`,
+  );
+  return mapa;
+}
+
+function obterMapa(): Promise<Map<string, CidadePayload>> {
+  if (!cacheMapa) {
+    cacheMapa = carregarMapa().catch((err) => {
+      cacheMapa = null; // permite nova tentativa
+      console.warn(
+        `[prerender] bulk /v2/seo/cidades falhou (${err?.message ?? err}) — caindo para chamadas individuais (risco de 429).`,
+      );
+      return new Map<string, CidadePayload>();
+    });
+  }
+  return cacheMapa;
+}
+
+@Injectable()
+export class PrerenderCidadeInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    // Casa tanto a URL relativa (antes do ApiBaseUrlInterceptor) quanto a absoluta.
+    const m = req.url.match(/v2\/Igreja\/cidade\/([^/]+)\/([^/?]+)/i);
+    if (req.method !== 'GET' || !m) return next.handle(req);
+
+    const chave = `${decodeURIComponent(m[1])}/${decodeURIComponent(m[2])}`.toLowerCase();
+    return from(obterMapa()).pipe(
+      switchMap((mapa) => {
+        const c = mapa.get(chave);
+        if (!c) return next.handle(req); // bulk fora ou cidade ausente → chamada normal
+        const body = {
+          data: { cidade: c.cidade, uf: c.uf.toUpperCase(), igrejas: c.igrejas, seo: c.seo },
+        };
+        return of(new HttpResponse({ status: 200, url: req.url, body }));
+      }),
+    );
+  }
+}

--- a/src/app/core/services/clarity.service.ts
+++ b/src/app/core/services/clarity.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 /** Assinatura do global `clarity` injetado pelo script do Microsoft Clarity. */
 type ClarityFn = (command: string, ...args: unknown[]) => void;
 
 @Injectable({ providedIn: 'root' })
 export class ClarityService {
+  /** Falso no prerender (Node) — sem `window`/`document`. Analytics é só do browser. */
+  private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
   /** Rota anterior — atualizada pelo AppComponent a cada NavigationEnd */
   private _prevRoute = '';
 
@@ -12,6 +16,7 @@ export class ClarityService {
   setPrevRoute(route: string): void { this._prevRoute = route; }
 
   private get c(): ClarityFn | undefined {
+    if (!this._isBrowser) return undefined;
     return (window as unknown as { clarity?: ClarityFn }).clarity;
   }
 
@@ -27,6 +32,7 @@ export class ClarityService {
 
   /** Detecta origem da sessão pelo document.referrer (só é preciso na primeira carga). */
   detectSessionOrigin(): string {
+    if (!this._isBrowser) return 'direto';
     const ref = document.referrer;
     if (!ref) return 'direto';
     if (/google\.|bing\.|yahoo\./i.test(ref)) return 'buscador';

--- a/src/app/core/services/favorites.service.ts
+++ b/src/app/core/services/favorites.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { BehaviorSubject } from 'rxjs';
 
 /**
@@ -26,6 +27,11 @@ export interface IgrejaFavorita {
 @Injectable({ providedIn: 'root' })
 export class FavoritesService {
   private static readonly KEY = 'buscamissa_favoritas';
+
+  // Favoritas vivem só no localStorage (estado por-usuário do browser). No prerender
+  // (Node) não há storage: a leitura devolve [] e a escrita é no-op — o browser
+  // hidrata com o estado real. Declarado ANTES de `_favoritas$`, que chama ler().
+  private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   private readonly _favoritas$ = new BehaviorSubject<IgrejaFavorita[]>(this.ler());
   /** Emite a lista atual sempre que houver alteração. */
@@ -65,6 +71,7 @@ export class FavoritesService {
   }
 
   private ler(): IgrejaFavorita[] {
+    if (!this._isBrowser) return [];
     try {
       const bruto = JSON.parse(localStorage.getItem(FavoritesService.KEY) || '[]');
       return Array.isArray(bruto) ? bruto : [];
@@ -74,7 +81,7 @@ export class FavoritesService {
   }
 
   private persistir(favoritas: IgrejaFavorita[]): void {
-    localStorage.setItem(FavoritesService.KEY, JSON.stringify(favoritas));
+    if (this._isBrowser) localStorage.setItem(FavoritesService.KEY, JSON.stringify(favoritas));
     this._favoritas$.next(favoritas);
   }
 }

--- a/src/app/core/services/metricas.service.ts
+++ b/src/app/core/services/metricas.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { LoggerService } from './logger.service';
 
 const JANELA_VISUALIZACAO_MS = 30 * 60 * 1000; // 30 minutos
@@ -8,6 +9,9 @@ const JANELA_VISUALIZACAO_MS = 30 * 60 * 1000; // 30 minutos
 export class MetricasService {
   private http = inject(HttpClient);
   private logger = inject(LoggerService);
+  /** No prerender (Node) não registramos visualização: geraria views-fantasma além
+   * de tocar `localStorage`. Métricas só valem após a hidratação, no browser. */
+  private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   // Métricas são fire-and-forget (não bloqueiam a UX), mas a falha é logada
   // no ponto central em vez de engolida silenciosamente.
@@ -20,6 +24,7 @@ export class MetricasService {
   }
 
   registrarVisualizacaoIgreja(igrejaId: number): void {
+    if (!this._isBrowser) return;
     const chave = `igreja_${igrejaId}_ultima_visualizacao`;
     const agora = Date.now();
     const ultimaVisualizacao = Number(localStorage.getItem(chave) ?? 0);
@@ -33,6 +38,7 @@ export class MetricasService {
   // Home não tem EntidadeId — mesma janela de dedupe das demais métricas,
   // para não contar o mesmo visitante várias vezes em navegações rápidas (F5).
   registrarVisualizacaoHome(): void {
+    if (!this._isBrowser) return;
     const chave = 'home_ultima_visualizacao';
     const agora = Date.now();
     const ultimaVisualizacao = Number(localStorage.getItem(chave) ?? 0);

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -1,6 +1,6 @@
-import { Component, DestroyRef, inject, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnDestroy, OnInit, PLATFORM_ID } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { CommonModule } from "@angular/common";
+import { CommonModule, isPlatformBrowser } from "@angular/common";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { finalize } from "rxjs/operators";
 import { SkeletonModule } from "primeng/skeleton";
@@ -48,6 +48,9 @@ export class CityComponent implements OnInit, OnDestroy {
   private _analytics = inject(AnalyticsService);
   private _favorites = inject(FavoritesService);
   private _clarity = inject(ClarityService);
+
+  /** Falso durante o prerender (Node). Guarda browser-APIs (geoloc, localStorage). */
+  private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   isLoading = false;
   uf = "";
@@ -140,7 +143,7 @@ export class CityComponent implements OnInit, OnDestroy {
         this._clarity.tag('qtd_resultados', String(this.igrejas.length));
 
         // Marca o momento da busca para medir tempo até encontrar uma missa
-        localStorage.setItem('bm_ts_busca', String(Date.now()));
+        if (this._isBrowser) localStorage.setItem('bm_ts_busca', String(Date.now()));
 
         if (this.igrejas.length === 0) {
           this.naoEncontrado = true;
@@ -341,7 +344,7 @@ export class CityComponent implements OnInit, OnDestroy {
   }
 
   private pedirGeolocalizacao(): void {
-    if (!navigator.geolocation) return;
+    if (!this._isBrowser || !navigator.geolocation) return;
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         this.userLat = pos.coords.latitude;
@@ -355,6 +358,7 @@ export class CityComponent implements OnInit, OnDestroy {
   // ── Ações ─────────────────────────────────────────────────────────────────
 
   comoChegar(igreja: any): void {
+    if (!this._isBrowser) return;
     const lat = igreja.endereco?.latitude;
     const lng = igreja.endereco?.longitude;
     const url = lat && lng
@@ -402,6 +406,7 @@ export class CityComponent implements OnInit, OnDestroy {
   // ── Compartilhar ──────────────────────────────────────────────────────────
 
   compartilhar(): void {
+    if (!this._isBrowser) return;
     const title = `Missas em ${this.cidadeNome}/${this.uf.toUpperCase()} | BuscaMissa`;
     if (navigator.share) {
       navigator.share({ title, url: window.location.href }).catch(() => {});


### PR DESCRIPTION
Pré-renderiza as 880 páginas de cidade (/missas/:uf/:cidade) via getPrerenderParams, alimentado por /v2/seo/routes. Paróquias seguem CSR (Fase 2.5).

- app.routes.server.ts: rota missas/:uf/:cidade Prerender + getPrerenderParams.
- scripts/lib/seo-routes.mjs: fonte única de rotas SEO (cache-de-Promise, timeout, validação de shape, dedupe, ordenação determinística, log). Reusado pelo gerar-sitemap.mjs (elimina o fetch duplicado).
- Guards isPlatformBrowser em city.component e nos services metricas/favorites/ clarity — sem quebrar no prerender; retorno idêntico no browser (favoritos=false, métricas não registram visualização-fantasma no server).

Correção do bloqueador 429 (prerender x rate limit do Bloco 0):
- prerender-cidade.interceptor.ts: interceptor SÓ-SERVER (registrado apenas em app.config.server.ts, ausente no browser) que serve os 880 getByCidade de 1 fetch ao bulk /v2/seo/cidades, com o mesmo envelope. Degrada p/ chamada individual se o bulk falhar.
- scripts/verificar-prerender.mjs: guard-rail no postbuild — aborta o build se
  >2% das cidades saírem em estado de erro (não publica página de erro indexável).

Ordem de deploy: api-public (bulk) primeiro, depois build/deploy do frontend.