### PR TITLE
feat(swr): revalidação em background das páginas prerenderizadas (paróquia/cidade)

### DIFF
--- a/src/app/core/middleware/prerender-transfer-state.interceptor.spec.ts
+++ b/src/app/core/middleware/prerender-transfer-state.interceptor.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID, TransferState } from '@angular/core';
+import { HttpRequest, HttpHandler, HttpResponse, HttpEvent } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+import { PrerenderTransferStateInterceptor } from './prerender-transfer-state.interceptor';
+import { chaveParoquia, stateKeyParoquia } from './prerender-state-keys';
+
+/**
+ * Contrato SWR do interceptor de leitura do TransferState (Fase "frescor de dados"):
+ * emitir o cache prerenderizado na hora E revalidar ao vivo, sem que a falha da
+ * revalidação derrube o conteúdo já renderizado.
+ */
+describe('PrerenderTransferStateInterceptor (SWR)', () => {
+  let interceptor: PrerenderTransferStateInterceptor;
+  let ts: TransferState;
+
+  const url = 'https://api.exemplo.com/api/v2/Igreja/paroquia/rj/mendes/paroquia-santa-cruz';
+  const key = stateKeyParoquia(chaveParoquia(url)!);
+
+  const next = (resp$: Observable<HttpEvent<unknown>>): HttpHandler =>
+    ({ handle: () => resp$ } as HttpHandler);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PrerenderTransferStateInterceptor,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+    ts = TestBed.inject(TransferState);
+    interceptor = TestBed.inject(PrerenderTransferStateInterceptor);
+  });
+
+  it('emite o cache do TransferState e DEPOIS a revalidação viva (2 emissões)', (done) => {
+    ts.set<any>(key, { data: { igreja: { id: 1, nome: 'cache' } } });
+    const vivo = new HttpResponse({ status: 200, url, body: { data: { igreja: { id: 1, nome: 'vivo' } } } });
+
+    interceptor.intercept(new HttpRequest('GET', url), next(of(vivo)))
+      .pipe(toArray())
+      .subscribe((eventos) => {
+        const nomes = eventos.map((e) => (e as HttpResponse<any>).body.data.igreja.nome);
+        expect(nomes).toEqual(['cache', 'vivo']);       // ordem SWR: cache → vivo
+        expect(ts.hasKey(key)).toBeFalse();             // chave consumida no finalize
+        done();
+      });
+  });
+
+  it('revalidação que FALHA não propaga erro — mantém só o cache (catchError + finalize)', (done) => {
+    ts.set<any>(key, { data: { igreja: { id: 1, nome: 'cache' } } });
+
+    interceptor.intercept(new HttpRequest('GET', url), next(throwError(() => new Error('500'))))
+      .pipe(toArray())
+      .subscribe({
+        next: (eventos) => {
+          expect(eventos.length).toBe(1);               // só o cache; erro engolido
+          expect(ts.hasKey(key)).toBeFalse();           // finalize roda mesmo com erro
+          done();
+        },
+        error: () => fail('a revalidação NÃO deve virar erro da página'),
+      });
+  });
+
+  it('sem chave no TransferState → passthrough (1 emissão, direto da rede)', (done) => {
+    const vivo = new HttpResponse({ status: 200, url, body: { data: { igreja: { id: 9 } } } });
+
+    interceptor.intercept(new HttpRequest('GET', url), next(of(vivo)))
+      .pipe(toArray())
+      .subscribe((eventos) => {
+        expect(eventos.length).toBe(1);
+        done();
+      });
+  });
+});

--- a/src/app/core/middleware/prerender-transfer-state.interceptor.ts
+++ b/src/app/core/middleware/prerender-transfer-state.interceptor.ts
@@ -7,7 +7,8 @@ import {
   HttpRequest,
   HttpResponse,
 } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable, of, concat, EMPTY } from 'rxjs';
+import { catchError, finalize } from 'rxjs/operators';
 import {
   chaveParoquia,
   chaveCidade,
@@ -20,13 +21,22 @@ import {
  * interceptors de prerender (server), que ESCREVEM o dado de paróquia/cidade no
  * TransferState durante o prerender.
  *
- * Na hidratação, serve o GET de paróquia/cidade a partir do TransferState de forma
- * SÍNCRONA (`of`), então o details resolve o getByCidadeESlug na hora → `isLoading`
- * fica true por ~0ms → NÃO mostra o skeleton por cima do conteúdo prerenderizado
- * (elimina o flash + o CLS) e evita o request duplicado à API.
+ * SWR (stale-while-revalidate): na hidratação, emite o corpo do TransferState de
+ * forma SÍNCRONA (paint instantâneo do conteúdo prerenderizado — sem skeleton, sem
+ * CLS) E em seguida revalida ao vivo na API, reconciliando o que mudou. Assim o
+ * visitante vê o dado editado no admin SEM esperar um novo deploy (frescor ≤ ~30s do
+ * ResponseCache dos endpoints), preservando o SEO/CWV do prerender.
  *
- * Consome a chave uma única vez (remove do state): navegações posteriores fazem a
- * chamada normal à API (dado fresco). Registrado só no config do browser.
+ * - `catchError(() => EMPTY)` na 2ª perna: uma revalidação que falha (offline/500)
+ *   NUNCA vira erro da página já renderizada — o conteúdo do prerender permanece.
+ *   NÃO remover: sem isto a tela cairia no "Tentar novamente" mesmo já mostrando dados.
+ * - `remove(key)` no `finalize` da 2ª perna: consome a chave uma vez, mas só ao FIM
+ *   da revalidação (se a subscription for cancelada antes — troca rápida de rota —
+ *   o TransferState não é descartado prematuramente).
+ * - Navegações client posteriores não têm chave → chamada normal à API (dado fresco).
+ *
+ * Registrado só no config do browser. Os componentes (details/city) reatribuem o
+ * dado nas duas emissões e protegem só os efeitos únicos (analytics/métricas).
  */
 @Injectable()
 export class PrerenderTransferStateInterceptor implements HttpInterceptor {
@@ -45,8 +55,21 @@ export class PrerenderTransferStateInterceptor implements HttpInterceptor {
 
     if (!this._transferState.hasKey(key)) return next.handle(req);
     const body = this._transferState.get(key, null);
-    this._transferState.remove(key); // usa uma vez; próximas navegações buscam fresco
-    if (body == null) return next.handle(req);
-    return of(new HttpResponse({ status: 200, url: req.url, body }));
+    if (body == null) {
+      this._transferState.remove(key);
+      return next.handle(req);
+    }
+
+    const cached = new HttpResponse({ status: 200, url: req.url, body });
+    return concat(
+      of(cached), // paint instantâneo (0ms, sem skeleton) — nunca falha
+      next.handle(req).pipe(
+        // 2ª perna: revalidação viva (a única que pode falhar). Falha NÃO derruba o
+        // conteúdo já renderizado — ver comentário do cabeçalho.
+        catchError(() => EMPTY),
+        // Consome a chave só ao fim da revalidação (robusto a cancelamento).
+        finalize(() => this._transferState.remove(key)),
+      ),
+    );
   }
 }

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -125,6 +125,10 @@ export class CityComponent implements OnInit, OnDestroy {
     this.isLoading = true;
     this.naoEncontrado = false;
     this.erroCarregar = false;
+    // SWR: com o interceptor de TransferState, `next` roda 2x (cache prerenderizado,
+    // depois a revalidação viva). Dados/estado/SEO reatribuem nas duas (idempotente);
+    // os efeitos ÚNICOS (analytics/marca de busca/evento de "sem resultado") só na 1ª.
+    let primeira = true;
     this._church.getByCidade(this.uf, this.cidade).pipe(
       finalize(() => { this.isLoading = false; })
     ).subscribe({
@@ -135,22 +139,26 @@ export class CityComponent implements OnInit, OnDestroy {
         const seo = data?.seo;
 
         this.aplicarFiltros();
-        this._analytics.searchPerformed(this.cidadeNome, this.uf);
 
-        // Tags Clarity de contexto
+        // Tags Clarity de contexto (idempotente — só sobrescreve valores)
         this._clarity.tag('cidade', this.cidadeNome);
         this._clarity.tag('estado', this.uf?.toUpperCase());
         this._clarity.tag('qtd_resultados', String(this.igrejas.length));
 
-        // Marca o momento da busca para medir tempo até encontrar uma missa
-        if (this._isBrowser) localStorage.setItem('bm_ts_busca', String(Date.now()));
+        // Estado da view — reflete o dado atual (idempotente nas duas emissões)
+        this.naoEncontrado = this.igrejas.length === 0;
 
-        if (this.igrejas.length === 0) {
-          this.naoEncontrado = true;
-          this._clarity.track('nenhum_resultado', {
-            cidade: this.cidadeNome,
-            estado: this.uf?.toUpperCase(),
-          });
+        if (primeira) {
+          this._analytics.searchPerformed(this.cidadeNome, this.uf);
+          // Marca o momento da busca para medir tempo até encontrar uma missa
+          if (this._isBrowser) localStorage.setItem('bm_ts_busca', String(Date.now()));
+          if (this.igrejas.length === 0) {
+            this._clarity.track('nenhum_resultado', {
+              cidade: this.cidadeNome,
+              estado: this.uf?.toUpperCase(),
+            });
+          }
+          primeira = false;
         }
 
         const ufUpper = this.uf?.toUpperCase();

--- a/src/app/modules/public/home/details/details.component.ts
+++ b/src/app/modules/public/home/details/details.component.ts
@@ -202,31 +202,45 @@ export class DetailsComponent implements OnInit {
     this._reqAtual = req;
     this.isLoading = true;
     this.erroCarregar = false;
+    // SWR: com o interceptor de TransferState, `next` roda 2x (cache prerenderizado,
+    // depois a revalidação viva). Reatribuir o dado é idempotente; os efeitos ÚNICOS
+    // (analytics/métricas/selo) só podem rodar na 1ª emissão.
+    let primeira = true;
     req.pipe(
       finalize(() => { this.isLoading = false; })
     ).subscribe({
       next: (response: any) => {
         const igreja = response?.data?.igreja ?? response?.data;
         const seo = response?.data?.seo;
-        this.churchInfo = igreja;
 
         if (!igreja) {
+          this.churchInfo = igreja;
           this._toast.add({ severity: "error", summary: "Erro", detail: "Dados da igreja não encontrados." });
           this._router.navigate(['/home']);
           return;
         }
 
-        this._loadFavoritaState();
-        this._analytics.churchView(igreja.nome, igreja.endereco?.localidade ?? '', igreja.endereco?.uf ?? '');
-        if (igreja.id) this._metricas.registrarVisualizacaoIgreja(igreja.id);
+        // Comparação por REFERÊNCIA (não por campo): a resposta da rede é sempre um
+        // objeto novo → normalmente reconcilia; só pula se vier a MESMA instância.
+        const mudou = this.churchInfo !== igreja;
+        if (mudou) this.churchInfo = igreja;
 
-        // Browser-only: no prerender (server) o selo dispararia ~4.4k GETs a
-        // v1/responsavel/... (risco de 429) e _aplicarClarityTags lê localStorage
-        // (quebra no server). Ambos são informativos e hidratam no cliente.
-        if (this._isBrowser) {
-          this._carregarSeloVerificado(igreja.id);
-          this._aplicarClarityTags(igreja);
+        if (primeira) {
+          this._loadFavoritaState();
+          this._analytics.churchView(igreja.nome, igreja.endereco?.localidade ?? '', igreja.endereco?.uf ?? '');
+          if (igreja.id) this._metricas.registrarVisualizacaoIgreja(igreja.id);
+
+          // Browser-only: no prerender (server) o selo dispararia ~4.4k GETs a
+          // v1/responsavel/... (risco de 429) e _aplicarClarityTags lê localStorage
+          // (quebra no server). Ambos são informativos e hidratam no cliente.
+          if (this._isBrowser) {
+            this._carregarSeloVerificado(igreja.id);
+            this._aplicarClarityTags(igreja);
+          }
+          primeira = false;
         }
+
+        if (!mudou) return; // SEO/schema idênticos — nada a reaplicar
 
         const cidadeUf = igreja.endereco?.localidade
           ? `${igreja.endereco.localidade}${igreja.endereco?.uf ? '/' + igreja.endereco.uf : ''}`


### PR DESCRIPTION
## Problema
As páginas de paróquia (`/paroquia/:uf/:cidade/:slug`) e cidade (`/missas/:uf/:cidade`) são HTML estático prerenderizado (Fase 2/2.5), congelado no build. Uma edição feita no admin (horário, contato) só aparecia no site no próximo deploy — o "editei e não apareceu". O dado ESTÁ salvo; o público servia HTML velho.

## Solução — Stale-While-Revalidate
O `PrerenderTransferStateInterceptor` passa a emitir o cache do TransferState (paint instantâneo, sem skeleton/CLS) **e** revalidar ao vivo em background, reconciliando o que mudou. Visitante vê o dado fresco (≤30s do ResponseCache) sem esperar deploy, preservando CWV/SEO.

- Interceptor: `concat(of(cache), next.handle(req).pipe(catchError(() => EMPTY), finalize(remove)))` — falha na revalidação NÃO derruba o conteúdo; chave consumida no `finalize`.
- `details`/`city`: reatribuem dados nas 2 emissões (comparação por referência); flag de 1ª emissão protege efeitos únicos (analytics/métricas/selo).
- Sem ETag/versionamento/cache-busting/rebuild/ISR — 1 GET de revalidação por load.

## Verificação
- Build dev verde (1482 rotas prerenderizadas).
- 3 testes unitários do contrato SWR passam (cache→vivo, catchError, passthrough).
- Runtime: paróquia prerenderizada hidrata sem flash/CLS; efeito de 1ª emissão dispara 1x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)