### PR TITLE
feat(fase3): guard-rails de esteira + prerender da HOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "postbuild:dev": "node scripts/copiar-index-csr.mjs",
     "prebuild:staging": "node scripts/baixar-bulk-prerender.mjs staging && node scripts/gerar-sitemap.mjs staging",
     "build:staging": "ng build --configuration=staging",
-    "postbuild:staging": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs",
+    "postbuild:staging": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs && node scripts/verificar-dist-size.mjs",
     "build:prod": "ng build --configuration=production",
     "prebuild:prod": "node scripts/baixar-bulk-prerender.mjs prod && node scripts/gerar-sitemap.mjs prod",
-    "postbuild:prod": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs",
+    "postbuild:prod": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs && node scripts/verificar-dist-size.mjs",
     "watch": "ng build --watch --configuration=development",
     "test": "ng test"
   },

--- a/scripts/verificar-dist-size.mjs
+++ b/scripts/verificar-dist-size.mjs
@@ -1,0 +1,95 @@
+import { readdirSync, statSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+/**
+ * Guard-rail da ESTEIRA de build (Auditoria2 / Fase 3). Roda no postbuild, depois
+ * do dedupe de CSS (que é quem de fato reduz o tamanho).
+ *
+ * Lição da Fase 2.5: o risco real do prerender não é o código da feature — é a
+ * esteira. O dist quase estourou o limite de 250 MB do Azure Static Web Apps (Free),
+ * porque o PrimeNG inlina o tema em CADA página e o tamanho cresce linearmente com o
+ * nº de páginas prerenderizadas. Aqui travamos o build ANTES do deploy se:
+ *
+ *   1. o dist/<app>/browser passar de LIMITE_MB (margem folgada abaixo dos 250 MB), ou
+ *   2. o nº de arquivos passar de MAX_FILES (alguém reintroduziu prerender em massa).
+ *
+ * Sempre loga o tamanho/contagem atuais para acompanhar a TENDÊNCIA a cada build —
+ * é o alarme antecipado para decidir SWA Standard com dado, não com susto.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Azure SWA Free rejeita conteúdo > 250 MB (descomprimido). Margem folgada, NÃO 249.
+const LIMITE_MB = 200;
+const LIMITE_BYTES = LIMITE_MB * 1024 * 1024;
+// Teto de arquivos: se alguém reintroduzir prerender de milhares de páginas por engano,
+// a esteira quebra na hora — não depois do deploy. Base atual (~8 estáticas + ~380
+// cidades + ~3.4k paróquias com missa) fica muito abaixo; 15000 dá folga sem mascarar.
+const MAX_FILES = 15000;
+
+/** Acha dist/<app>/browser varrendo os apps sob dist/. */
+function acharBrowserDir(base) {
+  if (!existsSync(base)) return null;
+  for (const app of readdirSync(base)) {
+    const p = join(base, app, 'browser');
+    if (existsSync(p) && statSync(p).isDirectory()) return p;
+  }
+  return null;
+}
+
+/** Soma recursiva de bytes e contagem de arquivos. */
+function medir(dir) {
+  let bytes = 0;
+  let arquivos = 0;
+  for (const nome of readdirSync(dir)) {
+    const full = join(dir, nome);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      const sub = medir(full);
+      bytes += sub.bytes;
+      arquivos += sub.arquivos;
+    } else {
+      bytes += st.size;
+      arquivos++;
+    }
+  }
+  return { bytes, arquivos };
+}
+
+const distBase = join(ROOT, 'dist');
+const browserDir = acharBrowserDir(distBase);
+
+if (!browserDir) {
+  console.log('[dist-size] nenhum dist/<app>/browser encontrado — nada a verificar.');
+  process.exit(0);
+}
+
+const { bytes, arquivos } = medir(browserDir);
+const mb = (bytes / (1024 * 1024)).toFixed(1);
+
+console.log(`[dist-size] dist browser: ${mb} MB | ${arquivos} arquivos | limites: ${LIMITE_MB} MB / ${MAX_FILES} arquivos`);
+
+let falhou = false;
+
+if (bytes > LIMITE_BYTES) {
+  falhou = true;
+  console.error(`\n❌ [dist-size] ${mb} MB excede o limite de ${LIMITE_MB} MB.`);
+  console.error('   O Azure SWA (Free) rejeita > 250 MB. Reduza páginas prerenderizadas, revise');
+  console.error('   o dedupe de CSS (dedupe-prerender-css.mjs) ou considere o plano Standard.');
+}
+
+if (arquivos > MAX_FILES) {
+  falhou = true;
+  console.error(`\n❌ [dist-size] ${arquivos} arquivos excede o limite de ${MAX_FILES}.`);
+  console.error('   Provável prerender em massa não intencional — confira os getPrerenderParams');
+  console.error('   em app.routes.server.ts.');
+}
+
+if (falhou) {
+  console.error('\n   Build abortado para não estourar a esteira de deploy.\n');
+  process.exit(1);
+}
+
+console.log('✓ [dist-size] esteira dentro dos limites.');

--- a/scripts/verificar-prerender.mjs
+++ b/scripts/verificar-prerender.mjs
@@ -3,8 +3,8 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 /**
- * Guard-rail do prerender (Auditoria2 / Fases 2 e 2.5). Roda no postbuild, depois
- * do prerender das cidades (/missas) e das paróquias (/paroquia).
+ * Guard-rail do prerender (Auditoria2 / Fases 2, 2.5 e 3). Roda no postbuild, depois
+ * do prerender das cidades (/missas), das paróquias (/paroquia) e da HOME (raiz + /home).
  *
  * Se a API estiver com problema durante o build, o componente assa o SEU estado de
  * erro ("Não foi possível / Tentar novamente") no HTML estático — e o `ng build`
@@ -24,17 +24,27 @@ const MARCADOR_ERRO = 'Tentar novamente';
 // Limiar tolerado de páginas de erro (falhas transientes pontuais acontecem).
 const LIMIAR = 0.02; // 2%
 
-// Seções prerenderizadas com estado de erro auditável (city e details).
-const SECOES = ['missas', 'paroquia'];
+// Seções prerenderizadas com estado de erro auditável (city, details e home).
+// 'home' cobre dist/<app>/browser/home/index.html (rota `home`). A raiz `''`
+// (browser/index.html) é verificada à parte, por não ficar numa subpasta.
+const SECOES = ['missas', 'paroquia', 'home'];
 
-/** Acha dist/<app>/browser/<secao>, varrendo os apps sob dist/. */
-function acharPastaSecao(base, secao) {
+/** Acha dist/<app>/browser, varrendo os apps sob dist/. */
+function acharBrowserDir(base) {
   if (!existsSync(base)) return null;
   for (const app of readdirSync(base)) {
-    const p = join(base, app, 'browser', secao);
+    const p = join(base, app, 'browser');
     if (existsSync(p) && statSync(p).isDirectory()) return p;
   }
   return null;
+}
+
+/** Acha dist/<app>/browser/<secao>, varrendo os apps sob dist/. */
+function acharPastaSecao(base, secao) {
+  const browser = acharBrowserDir(base);
+  if (!browser) return null;
+  const p = join(browser, secao);
+  return existsSync(p) && statSync(p).isDirectory() ? p : null;
 }
 
 function listarIndexHtml(dir) {
@@ -81,6 +91,22 @@ for (const secao of SECOES) {
     console.error(`   Causa provável: rate limit (429) da API durante o prerender. Verifique o endpoint bulk (/v2/seo/cidades ou /v2/seo/paroquias) e o interceptor de prerender.`);
     console.error('   Exemplos:');
     for (const e of exemplos) console.error(`     - ${e}`);
+  }
+}
+
+// Raiz `''` (browser/index.html): pode ser o shell CSR (pré-Fase 3) ou a home
+// prerenderizada. Em qualquer caso, não pode conter o marcador de erro.
+const browserDir = acharBrowserDir(distBase);
+if (browserDir) {
+  const raiz = join(browserDir, 'index.html');
+  if (existsSync(raiz)) {
+    algoVerificado = true;
+    if (readFileSync(raiz, 'utf-8').includes(MARCADOR_ERRO)) {
+      algumFalhou = true;
+      console.error(`\n❌ [guard-rail] a raiz (index.html) foi assada em ESTADO DE ERRO.`);
+    } else {
+      console.log('[guard-rail] raiz (index.html): OK.');
+    }
   }
 }
 

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -85,6 +85,13 @@ export const serverRoutes: ServerRoute[] = [
     },
   },
 
-  // Tudo o mais (home, busca, área logada, rotas legadas) segue CSR.
+  // Fase 3 — HOME (página de maior tráfego e pior CWV). Sem :param → sem
+  // getPrerenderParams. A home guarda navigator/document/geo com isPlatformBrowser
+  // (o server assa o estado default estável; o browser faz o upgrade ao hidratar).
+  // Precisa vir ANTES do '**'. A raiz '' redireciona p/ home mas também é assada.
+  { path: 'home', renderMode: RenderMode.Prerender },
+  { path: '', renderMode: RenderMode.Prerender },
+
+  // Tudo o mais (busca, área logada, rotas legadas) segue CSR.
   { path: '**', renderMode: RenderMode.Client },
 ];

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -1,7 +1,7 @@
-import { Component, DestroyRef, inject } from "@angular/core";
+import { Component, DestroyRef, inject, PLATFORM_ID } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { finalize } from "rxjs/operators";
-import { CommonModule, DatePipe } from "@angular/common";
+import { CommonModule, DatePipe, isPlatformBrowser } from "@angular/common";
 import {
   FormGroup,
   Validators,
@@ -299,6 +299,14 @@ export class HomeComponent {
   /** Estatísticas (números reais via getInfo, com fallback) */
   stats = { igrejas: 2000, horarios: 9100, cidades: 213, estados: 26 };
 
+  /**
+   * True só no browser. No prerender/SSG (Fase 3) a home é assada no server, onde
+   * navigator/document/timers não existem — qualquer acesso trava o render e aborta
+   * o build inteiro. Guardamos o caminho de geolocalização/scroll com este flag.
+   * Ver city.component.ts / countdown-chip.component.ts (mesmo padrão).
+   */
+  private _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
   setSearchTab(tab: 'cidade' | 'local'): void {
     if (this.searchTab === tab) return;
     this.searchTab = tab;
@@ -392,6 +400,7 @@ export class HomeComponent {
   }
 
   private _scrollToProximas(): void {
+    if (!this._isBrowser) return;
     document.getElementById('proximas-section')
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
@@ -505,7 +514,10 @@ export class HomeComponent {
       finalize(() => {
         this.isLoadingAddress = false;
         this._restoreFromQueryParams();
-        if (!this.resultsMode) {
+        // Geolocalização e próximas missas são UPGRADE do cliente: no prerender o
+        // server assa o estado default estável (sem geo), o browser preenche ao
+        // hidratar. Guardar evita crash no SSR e hydration swap.
+        if (!this.resultsMode && this._isBrowser) {
           this._loadProximasMissas();
           this._requestGeolocation();
         }
@@ -532,7 +544,7 @@ export class HomeComponent {
   }
 
   private _requestGeolocation(): void {
-    if (!navigator.geolocation) return;
+    if (!this._isBrowser || !navigator.geolocation) return;
     this.geoStatus = 'loading';
     navigator.geolocation.getCurrentPosition(
       pos => {


### PR DESCRIPTION
## Contexto
A HOME era a única página de conteúdo ainda em CSR — maior tráfego e pior CWV (campo: LCP p75 5,3s SLOW, CLS 0,28 SLOW). Prerenderizá-la é o maior lever de LCP/FCP/CLS restante.

## Fase 3.0 — Guard Rails da Esteira (pré-requisito)
Transforma os aprendizados da Fase 2.5 (quase estourou o limite de 250MB do SWA) em checks de CI:
- `scripts/verificar-dist-size.mjs` (novo): falha o build se `dist/browser` > 200 MB ou > 15000 arquivos.
- `scripts/verificar-prerender.mjs`: estendido para cobrir a home (raiz + `/home`).
- `package.json`: encaixa o dist-size no postbuild:staging/prod.

## Fase 3.2 — Prerender da HOME
- `app.routes.server.ts`: rotas `home` + `''` como `Prerender` (antes do `**` client).
- `home.component.ts`: guard `isPlatformBrowser` no `_requestGeolocation`/finalize do `getAddress` (o bloqueador real de SSR) + `_scrollToProximas`.

## Verificação
Build dev verde — 1104 rotas prerenderizadas, home não trava o build; `copiar-index-csr` vira no-op (raiz prerenderizada).

⚠️ Conflito esperado com o PR de remoção do sitemap estático (ambos editam `package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)