### PR TITLE
feat(seo): páginas de Estado e árvore de Intenção (Fase 3 SEO)

### DIFF
--- a/scripts/baixar-bulk-prerender.mjs
+++ b/scripts/baixar-bulk-prerender.mjs
@@ -37,7 +37,16 @@ function lerApiUrl() {
   return normalizarBaseUrl(match[1]);
 }
 
-async function baixar(base, rota, arquivo) {
+// Dias explícitos da árvore de intenção (Fase 3). "hoje" NÃO entra: o dia atual
+// depende do fuso do usuário e é resolvido no cliente (Brasil tem 4 fusos).
+const DIAS = ['domingo', 'segunda-feira', 'terca-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sabado'];
+
+/**
+ * Baixa `rota` para `arquivo`. `tipo`:
+ *  - 'array'  → valida Array (bulks de cidades/paróquias/estados);
+ *  - 'objeto' → valida objeto não-array (árvore de intenção /v2/seo/missa-dia/{dia}).
+ */
+async function baixar(base, rota, arquivo, tipo = 'array') {
   const url = `${base}${rota}`;
   const inicio = Date.now();
   const controller = new AbortController();
@@ -45,13 +54,17 @@ async function baixar(base, rota, arquivo) {
   try {
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    const lista = await res.json();
-    if (!Array.isArray(lista)) throw new Error('resposta não é um array');
+    const dados = await res.json();
+    if (tipo === 'array' && !Array.isArray(dados)) throw new Error('resposta não é um array');
+    if (tipo === 'objeto' && (dados === null || typeof dados !== 'object' || Array.isArray(dados)))
+      throw new Error('resposta não é um objeto');
     mkdirSync(CACHE_DIR, { recursive: true });
-    writeFileSync(join(CACHE_DIR, arquivo), JSON.stringify(lista));
+    const json = JSON.stringify(dados);
+    writeFileSync(join(CACHE_DIR, arquivo), json);
     const ms = Date.now() - inicio;
-    const mb = (JSON.stringify(lista).length / 1_048_576).toFixed(1);
-    console.log(`[prerender-cache] ${lista.length} itens de ${rota} → ${arquivo} (${mb} MB, ${ms}ms).`);
+    const mb = (json.length / 1_048_576).toFixed(1);
+    const qtd = Array.isArray(dados) ? `${dados.length} itens` : 'árvore';
+    console.log(`[prerender-cache] ${qtd} de ${rota} → ${arquivo} (${mb} MB, ${ms}ms).`);
     return true;
   } catch (err) {
     console.warn(`[prerender-cache] falha ao baixar ${rota} (${err?.message ?? err}) — interceptor fará fetch ao vivo.`);
@@ -67,6 +80,9 @@ async function main() {
   await Promise.all([
     baixar(base, '/v2/seo/cidades', 'cidades.json'),
     baixar(base, '/v2/seo/paroquias', 'paroquias.json'),
+    // Fase 3 — Estado (array de UFs) + árvore de intenção por dia (objeto).
+    baixar(base, '/v2/seo/estados', 'estados.json'),
+    ...DIAS.map((d) => baixar(base, `/v2/seo/missa-dia/${d}`, `missa-${d}.json`, 'objeto')),
   ]);
 }
 

--- a/scripts/verificar-prerender.mjs
+++ b/scripts/verificar-prerender.mjs
@@ -27,7 +27,10 @@ const LIMIAR = 0.02; // 2%
 // Seções prerenderizadas com estado de erro auditável (city, details e home).
 // 'home' cobre dist/<app>/browser/home/index.html (rota `home`). A raiz `''`
 // (browser/index.html) é verificada à parte, por não ficar numa subpasta.
-const SECOES = ['missas', 'paroquia', 'home'];
+// 'missas' cobre também os hubs de Estado (/missas/{uf}, Fase 3). Os `missa-{dia}`
+// são as landings/hubs/folhas da árvore de intenção (Fase 3), uma pasta por dia.
+const DIAS_INTENCAO = ['domingo', 'segunda-feira', 'terca-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sabado'];
+const SECOES = ['missas', 'paroquia', 'home', ...DIAS_INTENCAO.map((d) => `missa-${d}`)];
 
 /** Acha dist/<app>/browser, varrendo os apps sob dist/. */
 function acharBrowserDir(base) {

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -6,6 +6,8 @@ import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 import { PrerenderCidadeInterceptor } from './core/middleware/prerender-cidade.interceptor';
 import { PrerenderParoquiaInterceptor } from './core/middleware/prerender-paroquia.interceptor';
+import { PrerenderEstadoInterceptor } from './core/middleware/prerender-estado.interceptor';
+import { PrerenderIntencaoInterceptor } from './core/middleware/prerender-intencao.interceptor';
 
 const serverConfig: ApplicationConfig = {
   providers: [
@@ -17,6 +19,10 @@ const serverConfig: ApplicationConfig = {
     { provide: HTTP_INTERCEPTORS, useClass: PrerenderCidadeInterceptor, multi: true },
     // Idem para as ~4.4k paróquias (Fase 2.5), via bulk /v2/seo/paroquias.
     { provide: HTTP_INTERCEPTORS, useClass: PrerenderParoquiaInterceptor, multi: true },
+    // Fase 3 — Estado (/v2/seo/estado/{uf}) e Intenção-cidade
+    // (/v2/seo/missa-dia/{dia}/{uf}/{cidade}), servidos dos bulks em disco.
+    { provide: HTTP_INTERCEPTORS, useClass: PrerenderEstadoInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: PrerenderIntencaoInterceptor, multi: true },
   ],
 };
 

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -39,6 +39,79 @@ function paroquiasComMissaDoDisco(): Array<{ uf: string; cidade: string; slug: s
     .map((p) => ({ uf: p.uf, cidade: p.cidadeSlug, slug: p.slug }));
 }
 
+// --- Fase 3 SEO: Estado + árvore de Intenção -------------------------------
+
+// Dias explícitos da intenção. "hoje" NÃO é prerenderizado (depende do fuso do
+// usuário → redirect client-side). Slugs iguais ao DiaDaSemanaHelper do backend.
+const DIAS_INTENCAO = ['domingo', 'segunda-feira', 'terca-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sabado'];
+
+/** Lê um JSON do cache do prebuild; null se não existir (ex.: build:dev). */
+function lerCache<T>(arquivo: string): T | null {
+  const caminho = join(process.cwd(), '.prerender-cache', arquivo);
+  if (!existsSync(caminho)) return null;
+  return JSON.parse(readFileSync(caminho, 'utf-8')) as T;
+}
+
+/** UFs (lowercase) que têm paróquia — do cache estados.json, senão do bulk ao vivo. */
+async function ufsParaPrerender(): Promise<Array<{ uf: string }>> {
+  let lista = lerCache<Array<{ uf: string }>>('estados.json');
+  if (!lista) {
+    const base = normalizarBaseUrl(environment.config.apiURL);
+    try {
+      const res = await fetch(`${base}/v2/seo/estados`);
+      lista = res.ok ? ((await res.json()) as Array<{ uf: string }>) : [];
+    } catch {
+      lista = [];
+    }
+  }
+  return (Array.isArray(lista) ? lista : []).filter((e) => e?.uf).map((e) => ({ uf: e.uf.toLowerCase() }));
+}
+
+interface ArvoreDia {
+  estados?: Array<{ uf: string; cidades?: Array<{ cidadeSlug: string }> }>;
+}
+
+/** Árvore de um dia — do cache missa-{dia}.json, senão do bulk ao vivo (build:dev). */
+async function arvoreDoDia(dia: string): Promise<ArvoreDia> {
+  const cache = lerCache<ArvoreDia>(`missa-${dia}.json`);
+  if (cache) return cache;
+  const base = normalizarBaseUrl(environment.config.apiURL);
+  try {
+    const res = await fetch(`${base}/v2/seo/missa-dia/${dia}`);
+    return res.ok ? ((await res.json()) as ArvoreDia) : {};
+  } catch {
+    return {};
+  }
+}
+
+// Rotas por dia: nacional (sem param), UF e cidade (com getPrerenderParams).
+// Só entram UF/cidade com ≥1 missa no dia (a árvore já vem filtrada pelo backend).
+const rotasIntencao: ServerRoute[] = DIAS_INTENCAO.flatMap((dia) => [
+  { path: `missa-${dia}`, renderMode: RenderMode.Prerender },
+  {
+    path: `missa-${dia}/:uf`,
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const arvore = await arvoreDoDia(dia);
+      return (arvore.estados ?? [])
+        .filter((e) => e?.uf)
+        .map((e) => ({ uf: e.uf.toLowerCase() }));
+    },
+  },
+  {
+    path: `missa-${dia}/:uf/:cidade`,
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      const arvore = await arvoreDoDia(dia);
+      return (arvore.estados ?? []).flatMap((e) =>
+        (e.cidades ?? [])
+          .filter((c) => c?.cidadeSlug && e.uf)
+          .map((c) => ({ uf: e.uf.toLowerCase(), cidade: c.cidadeSlug.toLowerCase() })),
+      );
+    },
+  },
+]);
+
 export const serverRoutes: ServerRoute[] = [
   { path: 'como-funciona', renderMode: RenderMode.Prerender },
   { path: 'guia-responsavel', renderMode: RenderMode.Prerender },
@@ -84,6 +157,21 @@ export const serverRoutes: ServerRoute[] = [
       }));
     },
   },
+
+  // Fase 3 — Estado (`/missas/:uf`). getPrerenderParams do cache estados.json
+  // (fallback: bulk ao vivo). Vem ANTES de 'missas/:uf/:cidade' (menos segmentos).
+  {
+    path: 'missas/:uf',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => ufsParaPrerender(),
+  },
+
+  // Fase 3 — árvore de INTENÇÃO por dia (`/missa-{dia}[/:uf[/:cidade]]`), 7 dias.
+  ...rotasIntencao,
+
+  // `/missa-hoje` NÃO é prerenderizado: resolve o dia local no browser e redireciona
+  // pro dia explícito (Brasil tem 4 fusos). Segue CSR.
+  { path: 'missa-hoje', renderMode: RenderMode.Client },
 
   // Fase 3 — HOME (página de maior tráfego e pior CWV). Sem :param → sem
   // getPrerenderParams. A home guarda navigator/document/geo com isPlatformBrowser

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,40 @@
 import { Routes } from "@angular/router";
 import { LayoutHomeComponent } from "./core/layout/home/layout/layout.component";
 
+// Fase 3 SEO — árvore de INTENÇÃO por dia. O slug do dia é literal na rota (não é
+// :param), então geramos 3 níveis por dia e passamos o dia em `data.dia` para o
+// IntencaoComponent. Os 7 dias explícitos; "hoje" é redirect client-side à parte.
+const DIAS_INTENCAO: { slug: string; label: string }[] = [
+  { slug: 'domingo', label: 'domingo' },
+  { slug: 'segunda-feira', label: 'segunda-feira' },
+  { slug: 'terca-feira', label: 'terça-feira' },
+  { slug: 'quarta-feira', label: 'quarta-feira' },
+  { slug: 'quinta-feira', label: 'quinta-feira' },
+  { slug: 'sexta-feira', label: 'sexta-feira' },
+  { slug: 'sabado', label: 'sábado' },
+];
+
+const carregarIntencao = () =>
+  import("./modules/public/intencao/intencao.component").then((m) => m.IntencaoComponent);
+
+const rotasIntencao: Routes = DIAS_INTENCAO.flatMap((d) => [
+  {
+    path: `missa-${d.slug}`,
+    data: { dia: d.slug, title: `Missa de ${d.label} no Brasil | BuscaMissa` },
+    loadComponent: carregarIntencao,
+  },
+  {
+    path: `missa-${d.slug}/:uf`,
+    data: { dia: d.slug, title: `Missa de ${d.label} | BuscaMissa` },
+    loadComponent: carregarIntencao,
+  },
+  {
+    path: `missa-${d.slug}/:uf/:cidade`,
+    data: { dia: d.slug, title: `Missa de ${d.label} | BuscaMissa` },
+    loadComponent: carregarIntencao,
+  },
+]);
+
 export const routes: Routes = [
   {
     path: "",
@@ -63,6 +97,25 @@ export const routes: Routes = [
           import("./modules/public/home/details/details.component").then(
             (m) => m.DetailsComponent
           ),
+      },
+      // Hub de Estado (SEO): /missas/sp — antes de missas/:uf/:cidade (menos segmentos).
+      {
+        path: "missas/:uf",
+        data: {
+          title: 'Horários de Missa por Estado | BuscaMissa',
+          description: 'Horários de missa neste estado. Escolha a cidade e veja as paróquias.',
+        },
+        loadComponent: () =>
+          import("./modules/public/estado/estado.component").then((m) => m.EstadoComponent),
+      },
+      // Árvore de intenção por dia (SEO): /missa-domingo[/:uf[/:cidade]] — 7 dias.
+      ...rotasIntencao,
+      // /missa-hoje: redirect client-side pro dia local (Brasil tem 4 fusos).
+      {
+        path: "missa-hoje",
+        data: { title: 'Missa de hoje perto de você | BuscaMissa' },
+        loadComponent: () =>
+          import("./modules/public/missa-hoje/missa-hoje.component").then((m) => m.MissaHojeComponent),
       },
       // Página de cidade (SEO): /missas/sp/sao-jose-dos-campos
       {

--- a/src/app/core/middleware/prerender-estado.interceptor.ts
+++ b/src/app/core/middleware/prerender-estado.interceptor.ts
@@ -1,0 +1,102 @@
+import { Injectable, TransferState, inject } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, from, of, switchMap } from 'rxjs';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { environment } from '../../../environments/environment';
+import { chaveEstado, stateKeyEstado } from './prerender-state-keys';
+
+/**
+ * Interceptor SÓ-SERVER (registrado apenas em app.config.server.ts) — serve o
+ * endpoint por-item de Estado (`GET /v2/seo/estado/{uf}`) durante o prerender das
+ * páginas `/missas/{uf}` (Fase 3 SEO), a partir do bulk `/v2/seo/estados` baixado
+ * pro disco no prebuild. Evita ~26 fetches ao vivo durante o render.
+ *
+ * Diferente de cidade/paróquia: os endpoints `/v2/seo/*` devolvem o DTO CRU (sem o
+ * wrapper `{ data }` do ApiResponse), então servimos o objeto direto — o MESMO
+ * shape que o browser recebe do endpoint real em runtime (sem mismatch de hydration).
+ *
+ * No browser este interceptor NÃO existe; a chamada segue pro endpoint real.
+ * Degrada com segurança: se o bulk faltar/UF ausente, cai na chamada individual (next).
+ */
+
+interface EstadoPayload {
+  uf: string;
+  estado: string;
+  totalCidades: number;
+  totalParoquias: number;
+  seo: unknown;
+  cidades: unknown[];
+}
+
+/** Cache da Promise do mapa (1 leitura por build). */
+let cacheMapa: Promise<Map<string, EstadoPayload>> | null = null;
+
+/** Base absoluta da API sem o sufixo /api — /v2/seo/estados é rota absoluta. */
+function baseUrl(): string {
+  return String(environment.config.apiURL ?? '')
+    .replace(/\/api\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+function lerDoDisco(): EstadoPayload[] | null {
+  const arquivo = join(process.cwd(), '.prerender-cache', 'estados.json');
+  if (!existsSync(arquivo)) return null;
+  return JSON.parse(readFileSync(arquivo, 'utf-8')) as EstadoPayload[];
+}
+
+async function carregarMapa(): Promise<Map<string, EstadoPayload>> {
+  const inicio = Date.now();
+  let lista = lerDoDisco();
+  const origem = lista ? 'disco (.prerender-cache)' : 'bulk /v2/seo/estados';
+  if (!lista) {
+    const res = await fetch(`${baseUrl()}/v2/seo/estados`);
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    lista = (await res.json()) as EstadoPayload[];
+  }
+
+  const mapa = new Map<string, EstadoPayload>();
+  for (const e of Array.isArray(lista) ? lista : []) {
+    if (!e?.uf) continue;
+    mapa.set(e.uf.toLowerCase(), e);
+  }
+  console.log(`[prerender] ${mapa.size} estados carregados de ${origem} em ${Date.now() - inicio}ms.`);
+  return mapa;
+}
+
+function obterMapa(): Promise<Map<string, EstadoPayload>> {
+  if (!cacheMapa) {
+    cacheMapa = carregarMapa().catch((err) => {
+      cacheMapa = null;
+      console.warn(`[prerender] bulk /v2/seo/estados falhou (${err?.message ?? err}) — caindo para chamadas individuais.`);
+      return new Map<string, EstadoPayload>();
+    });
+  }
+  return cacheMapa;
+}
+
+@Injectable()
+export class PrerenderEstadoInterceptor implements HttpInterceptor {
+  private _transferState = inject(TransferState);
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (req.method !== 'GET') return next.handle(req);
+    const chave = chaveEstado(req.url);
+    if (!chave) return next.handle(req);
+
+    return from(obterMapa()).pipe(
+      switchMap((mapa) => {
+        const e = mapa.get(chave);
+        if (!e) return next.handle(req); // bulk fora ou UF ausente → chamada normal
+        this._transferState.set(stateKeyEstado(chave), e);
+        return of(new HttpResponse({ status: 200, url: req.url, body: e }));
+      }),
+    );
+  }
+}

--- a/src/app/core/middleware/prerender-intencao.interceptor.ts
+++ b/src/app/core/middleware/prerender-intencao.interceptor.ts
@@ -1,0 +1,149 @@
+import { Injectable, TransferState, inject } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, from, of, switchMap } from 'rxjs';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { environment } from '../../../environments/environment';
+import {
+  chaveIntencao,
+  chaveIntencaoArvore,
+  stateKeyIntencao,
+  stateKeyIntencaoArvore,
+} from './prerender-state-keys';
+
+/**
+ * Interceptor SÓ-SERVER (registrado apenas em app.config.server.ts) — serve o
+ * endpoint por-item da árvore de intenção (`GET /v2/seo/missa-dia/{dia}/{uf}/{cidade}`)
+ * durante o prerender das páginas `/missa-{dia}/{uf}/{cidade}` (Fase 3 SEO), a
+ * partir das árvores por dia (`missa-{dia}.json`) baixadas pro disco no prebuild.
+ *
+ * Cada arquivo de dia é a ÁRVORE inteira (estados → cidades → paróquias). Aqui
+ * indexamos por `uf/cidade` e devolvemos só o nó da cidade (`IntencaoCidadeDto`),
+ * o MESMO shape (cru) que o endpoint real por-item devolve em runtime.
+ *
+ * Cache por dia (1 leitura por dia por build). Degrada para `next.handle()` se o
+ * arquivo do dia faltar ou a cidade não estiver na árvore.
+ */
+
+interface IntencaoCidadePayload {
+  cidadeSlug: string;
+  cidade: string;
+  seo: unknown;
+  paroquias: unknown[];
+}
+
+interface ArvoreDia {
+  estados?: Array<{ uf: string; cidades?: IntencaoCidadePayload[] }>;
+}
+
+/** Cache por dia da Promise do mapa `uf/cidade` → cidade (folha). */
+const cachePorDia = new Map<string, Promise<Map<string, IntencaoCidadePayload>>>();
+/** Cache por dia da Promise da árvore completa (hubs nacional/UF). */
+const cacheArvorePorDia = new Map<string, Promise<ArvoreDia>>();
+
+function baseUrl(): string {
+  return String(environment.config.apiURL ?? '')
+    .replace(/\/api\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+function lerDoDisco(dia: string): ArvoreDia | null {
+  const arquivo = join(process.cwd(), '.prerender-cache', `missa-${dia}.json`);
+  if (!existsSync(arquivo)) return null;
+  return JSON.parse(readFileSync(arquivo, 'utf-8')) as ArvoreDia;
+}
+
+/** Árvore do dia — disco (cache do prebuild), senão bulk ao vivo. */
+async function carregarArvore(dia: string): Promise<ArvoreDia> {
+  const disco = lerDoDisco(dia);
+  if (disco) return disco;
+  const res = await fetch(`${baseUrl()}/v2/seo/missa-dia/${dia}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  return (await res.json()) as ArvoreDia;
+}
+
+function obterArvore(dia: string): Promise<ArvoreDia> {
+  let p = cacheArvorePorDia.get(dia);
+  if (!p) {
+    p = carregarArvore(dia).catch((err) => {
+      cacheArvorePorDia.delete(dia);
+      console.warn(`[prerender] árvore de intenção (${dia}) falhou (${err?.message ?? err}) — caindo para chamada individual.`);
+      return {} as ArvoreDia;
+    });
+    cacheArvorePorDia.set(dia, p);
+  }
+  return p;
+}
+
+async function carregarMapa(dia: string): Promise<Map<string, IntencaoCidadePayload>> {
+  const inicio = Date.now();
+  const arvore = await obterArvore(dia);
+
+  const mapa = new Map<string, IntencaoCidadePayload>();
+  for (const estado of arvore?.estados ?? []) {
+    const uf = estado?.uf?.toLowerCase();
+    if (!uf) continue;
+    for (const cidade of estado.cidades ?? []) {
+      if (!cidade?.cidadeSlug) continue;
+      mapa.set(`${dia}/${uf}/${cidade.cidadeSlug.toLowerCase()}`, cidade);
+    }
+  }
+  console.log(`[prerender] ${mapa.size} cidades de intenção (${dia}) em ${Date.now() - inicio}ms.`);
+  return mapa;
+}
+
+function obterMapa(dia: string): Promise<Map<string, IntencaoCidadePayload>> {
+  let p = cachePorDia.get(dia);
+  if (!p) {
+    p = carregarMapa(dia).catch((err) => {
+      cachePorDia.delete(dia);
+      console.warn(`[prerender] árvore de intenção (${dia}) falhou (${err?.message ?? err}) — caindo para chamadas individuais.`);
+      return new Map<string, IntencaoCidadePayload>();
+    });
+    cachePorDia.set(dia, p);
+  }
+  return p;
+}
+
+@Injectable()
+export class PrerenderIntencaoInterceptor implements HttpInterceptor {
+  private _transferState = inject(TransferState);
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (req.method !== 'GET') return next.handle(req);
+
+    // Folha: /v2/seo/missa-dia/{dia}/{uf}/{cidade} → devolve o nó da cidade.
+    const chaveFolha = chaveIntencao(req.url);
+    if (chaveFolha) {
+      const dia = chaveFolha.split('/')[0];
+      return from(obterMapa(dia)).pipe(
+        switchMap((mapa) => {
+          const cidade = mapa.get(chaveFolha);
+          if (!cidade) return next.handle(req); // cidade sem missa no dia → chamada normal
+          this._transferState.set(stateKeyIntencao(chaveFolha), cidade);
+          return of(new HttpResponse({ status: 200, url: req.url, body: cidade }));
+        }),
+      );
+    }
+
+    // Hub: /v2/seo/missa-dia/{dia} → devolve a árvore inteira do dia.
+    const chaveArvore = chaveIntencaoArvore(req.url);
+    if (chaveArvore) {
+      return from(obterArvore(chaveArvore)).pipe(
+        switchMap((arvore) => {
+          if (!arvore?.estados?.length) return next.handle(req); // árvore fora → chamada normal
+          this._transferState.set(stateKeyIntencaoArvore(chaveArvore), arvore);
+          return of(new HttpResponse({ status: 200, url: req.url, body: arvore }));
+        }),
+      );
+    }
+
+    return next.handle(req);
+  }
+}

--- a/src/app/core/middleware/prerender-state-keys.ts
+++ b/src/app/core/middleware/prerender-state-keys.ts
@@ -17,6 +17,11 @@ import { makeStateKey, StateKey } from '@angular/core';
 
 const RE_PAROQUIA = /v2\/Igreja\/paroquia\/([^/]+)\/([^/]+)\/([^/?]+)/i;
 const RE_CIDADE = /v2\/Igreja\/cidade\/([^/]+)\/([^/?]+)/i;
+// Endpoints das páginas de SEO (Fase 3): Estado, Intenção-cidade (folha) e a
+// árvore do dia (hubs nacional/UF da intenção).
+const RE_ESTADO = /v2\/seo\/estado\/([^/?]+)/i;
+const RE_INTENCAO = /v2\/seo\/missa-dia\/([^/]+)\/([^/]+)\/([^/?]+)/i;
+const RE_INTENCAO_ARVORE = /v2\/seo\/missa-dia\/([^/?]+)(?:\?|$)/i;
 
 /** Chave lógica uf/cidade/slug (lowercase) a partir da URL, ou null se não casar. */
 export function chaveParoquia(url: string): string | null {
@@ -32,6 +37,27 @@ export function chaveCidade(url: string): string | null {
   return `${decodeURIComponent(m[1])}/${decodeURIComponent(m[2])}`.toLowerCase();
 }
 
+/** Chave lógica uf (lowercase) do endpoint por-item de Estado, ou null. */
+export function chaveEstado(url: string): string | null {
+  const m = url.match(RE_ESTADO);
+  if (!m) return null;
+  return decodeURIComponent(m[1]).toLowerCase();
+}
+
+/** Chave lógica dia/uf/cidade (lowercase) da Intenção-cidade, ou null. */
+export function chaveIntencao(url: string): string | null {
+  const m = url.match(RE_INTENCAO);
+  if (!m) return null;
+  return `${decodeURIComponent(m[1])}/${decodeURIComponent(m[2])}/${decodeURIComponent(m[3])}`.toLowerCase();
+}
+
+/** Chave lógica do dia (lowercase) da árvore de intenção (hub), ou null. */
+export function chaveIntencaoArvore(url: string): string | null {
+  const m = url.match(RE_INTENCAO_ARVORE);
+  if (!m) return null;
+  return decodeURIComponent(m[1]).toLowerCase();
+}
+
 /** StateKey do TransferState para uma resposta de paróquia. */
 export function stateKeyParoquia(chave: string): StateKey<unknown> {
   return makeStateKey<unknown>(`pp:${chave}`);
@@ -40,4 +66,19 @@ export function stateKeyParoquia(chave: string): StateKey<unknown> {
 /** StateKey do TransferState para uma resposta de cidade. */
 export function stateKeyCidade(chave: string): StateKey<unknown> {
   return makeStateKey<unknown>(`pc:${chave}`);
+}
+
+/** StateKey do TransferState para uma resposta de Estado. */
+export function stateKeyEstado(chave: string): StateKey<unknown> {
+  return makeStateKey<unknown>(`pe:${chave}`);
+}
+
+/** StateKey do TransferState para uma resposta de Intenção-cidade. */
+export function stateKeyIntencao(chave: string): StateKey<unknown> {
+  return makeStateKey<unknown>(`pi:${chave}`);
+}
+
+/** StateKey do TransferState para a árvore de um dia (hub de intenção). */
+export function stateKeyIntencaoArvore(chave: string): StateKey<unknown> {
+  return makeStateKey<unknown>(`pia:${chave}`);
 }

--- a/src/app/core/middleware/prerender-transfer-state.interceptor.ts
+++ b/src/app/core/middleware/prerender-transfer-state.interceptor.ts
@@ -9,12 +9,34 @@ import {
 } from '@angular/common/http';
 import { Observable, of, concat, EMPTY } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
+import { StateKey } from '@angular/core';
 import {
   chaveParoquia,
   chaveCidade,
+  chaveEstado,
+  chaveIntencao,
+  chaveIntencaoArvore,
   stateKeyParoquia,
   stateKeyCidade,
+  stateKeyEstado,
+  stateKeyIntencao,
+  stateKeyIntencaoArvore,
 } from './prerender-state-keys';
+
+/** Resolve a StateKey da resposta prerenderizada a partir da URL, ou null. */
+function resolverStateKey(url: string): StateKey<unknown> | null {
+  const cp = chaveParoquia(url);
+  if (cp) return stateKeyParoquia(cp);
+  const cc = chaveCidade(url);
+  if (cc) return stateKeyCidade(cc);
+  const ci = chaveIntencao(url); // dia/uf/cidade (folha) — antes da árvore e do estado
+  if (ci) return stateKeyIntencao(ci);
+  const cia = chaveIntencaoArvore(url); // dia (hub) — antes do estado
+  if (cia) return stateKeyIntencaoArvore(cia);
+  const ce = chaveEstado(url);
+  if (ce) return stateKeyEstado(ce);
+  return null;
+}
 
 /**
  * Interceptor de LEITURA do TransferState (roda no browser). Complementa os
@@ -46,11 +68,7 @@ export class PrerenderTransferStateInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     if (!this._isBrowser || req.method !== 'GET') return next.handle(req);
 
-    const cp = chaveParoquia(req.url);
-    const key = cp ? stateKeyParoquia(cp) : (() => {
-      const cc = chaveCidade(req.url);
-      return cc ? stateKeyCidade(cc) : null;
-    })();
+    const key = resolverStateKey(req.url);
     if (!key) return next.handle(req);
 
     if (!this._transferState.hasKey(key)) return next.handle(req);

--- a/src/app/core/services/seo-paginas.service.ts
+++ b/src/app/core/services/seo-paginas.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Consome os endpoints públicos de SEO por-item das páginas de Estado e Intenção
+ * (Fase 3). Diferente do ChurchesService (que usa rotas relativas + prefixo /api
+ * do ApiBaseUrlInterceptor), aqui as rotas são ABSOLUTAS no host raiz (`/v2/seo/...`,
+ * sem `/api`) — por isso montamos a URL completa (que o ApiBaseUrlInterceptor ignora
+ * por começar com http). No prerender os interceptors só-server servem estes GET do
+ * bulk em disco; no browser eles respondem ao vivo (mesmo shape).
+ */
+@Injectable({ providedIn: 'root' })
+export class SeoPaginasService {
+  private http = inject(HttpClient);
+
+  /** Base do host sem o sufixo /api (os /v2/seo/* ficam na raiz). */
+  private get base(): string {
+    return String(environment.config.apiURL ?? '')
+      .replace(/\/api\/?$/, '')
+      .replace(/\/$/, '');
+  }
+
+  /** Hub de Estado (`/missas/{uf}`). */
+  getEstado(uf: string): Observable<unknown> {
+    return this.http.get(`${this.base}/v2/seo/estado/${uf}`);
+  }
+
+  /** Árvore de um dia (hubs nacional/UF da intenção). */
+  getArvoreDia(dia: string): Observable<unknown> {
+    return this.http.get(`${this.base}/v2/seo/missa-dia/${dia}`);
+  }
+
+  /** Folha da intenção: uma cidade num dia (`/missa-{dia}/{uf}/{cidade}`). */
+  getIntencaoCidade(dia: string, uf: string, cidade: string): Observable<unknown> {
+    return this.http.get(`${this.base}/v2/seo/missa-dia/${dia}/${uf}/${cidade}`);
+  }
+}

--- a/src/app/modules/public/estado/estado.component.html
+++ b/src/app/modules/public/estado/estado.component.html
@@ -1,0 +1,54 @@
+<section class="estado">
+  @if (isLoading) {
+    <p-skeleton width="60%" height="2rem" styleClass="mb-3" />
+    <p-skeleton width="40%" height="1rem" styleClass="mb-4" />
+    <div class="grid">
+      @for (i of [1,2,3,4,5,6]; track i) {
+        <p-skeleton height="4.5rem" />
+      }
+    </div>
+  } @else if (naoEncontrado) {
+    <div class="estado__vazio">
+      <h1>Estado não encontrado</h1>
+      <p>Não encontramos paróquias cadastradas para esta UF.</p>
+      <a routerLink="/cidades">Ver todas as cidades</a>
+    </div>
+  } @else if (erroCarregar) {
+    <div class="estado__erro">
+      <p>Não foi possível carregar as missas deste estado.</p>
+      <button type="button" (click)="tentarNovamente()">Tentar novamente</button>
+    </div>
+  } @else {
+    <nav class="breadcrumb" aria-label="Trilha de navegação">
+      <a routerLink="/home">Início</a>
+      <span aria-hidden="true">›</span>
+      <span aria-current="page">Missas em {{ estadoNome }}</span>
+    </nav>
+
+    <header class="estado__head">
+      <h1>Horários de Missa em {{ estadoNome }}</h1>
+      <p class="estado__stats">
+        {{ totalParoquias }} paróquia(s) em {{ totalCidades }} cidade(s). Escolha a cidade e veja os horários de missa.
+      </p>
+    </header>
+
+    <h2>Cidades</h2>
+    <ul class="grid" role="list">
+      @for (c of cidades; track c.cidadeSlug) {
+        <li>
+          <a [routerLink]="['/missas', uf, c.cidadeSlug]">
+            <span class="grid__nome">{{ c.cidade }}</span>
+            <span class="grid__meta">{{ c.totalParoquias }} paróquia(s)</span>
+          </a>
+        </li>
+      }
+    </ul>
+
+    <h2>Missa por dia da semana em {{ estadoNome }}</h2>
+    <ul class="dias" role="list">
+      @for (d of dias; track d.slug) {
+        <li><a [routerLink]="['/missa-' + d.slug, uf]">Missa de {{ d.label }} em {{ estadoNome }}</a></li>
+      }
+    </ul>
+  }
+</section>

--- a/src/app/modules/public/estado/estado.component.scss
+++ b/src/app/modules/public/estado/estado.component.scss
@@ -1,0 +1,97 @@
+.estado {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+
+  h1 {
+    font-size: clamp(1.5rem, 4vw, 2.1rem);
+    line-height: 1.15;
+    margin: 0 0 0.5rem;
+  }
+
+  h2 {
+    font-size: 1.15rem;
+    margin: 2rem 0 0.75rem;
+  }
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-bottom: 1rem;
+
+  a { color: #2563eb; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  span[aria-current] { color: #374151; font-weight: 600; }
+}
+
+.estado__stats { color: #4b5563; margin: 0; }
+
+.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+
+  a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.6rem;
+    text-decoration: none;
+    color: inherit;
+    background: #fff;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  a:hover { border-color: #93c5fd; box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06); }
+
+  &__nome { font-weight: 600; }
+  &__meta { font-size: 0.82rem; color: #6b7280; }
+}
+
+.dias {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  a {
+    display: inline-block;
+    padding: 0.5rem 0.9rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 999px;
+    text-decoration: none;
+    color: #2563eb;
+    font-size: 0.9rem;
+  }
+  a:hover { background: #eff6ff; border-color: #93c5fd; }
+}
+
+.estado__vazio,
+.estado__erro {
+  text-align: center;
+  padding: 3rem 1rem;
+
+  button {
+    margin-top: 1rem;
+    padding: 0.6rem 1.2rem;
+    border: 0;
+    border-radius: 0.5rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+  }
+}
+
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1.25rem; }

--- a/src/app/modules/public/estado/estado.component.ts
+++ b/src/app/modules/public/estado/estado.component.ts
@@ -1,0 +1,127 @@
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { finalize } from 'rxjs/operators';
+import { SkeletonModule } from 'primeng/skeleton';
+import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
+import { SeoService } from '../../../core/services/seo.service';
+
+const SITE = 'https://buscamissa.com.br';
+
+const DIAS: { slug: string; label: string }[] = [
+  { slug: 'domingo', label: 'Domingo' },
+  { slug: 'segunda-feira', label: 'Segunda-feira' },
+  { slug: 'terca-feira', label: 'Terça-feira' },
+  { slug: 'quarta-feira', label: 'Quarta-feira' },
+  { slug: 'quinta-feira', label: 'Quinta-feira' },
+  { slug: 'sexta-feira', label: 'Sexta-feira' },
+  { slug: 'sabado', label: 'Sábado' },
+];
+
+/**
+ * Hub de ESTADO (`/missas/:uf`) — Fase 3 SEO. Lista as cidades da UF com paróquias
+ * e distribui autoridade para os níveis abaixo (cidade) e para a intenção por dia.
+ * Dados por-item de /v2/seo/estado/{uf}; no prerender vêm do bulk (interceptor).
+ */
+@Component({
+  selector: 'app-estado',
+  standalone: true,
+  imports: [CommonModule, RouterLink, SkeletonModule],
+  templateUrl: './estado.component.html',
+  styleUrl: './estado.component.scss',
+})
+export class EstadoComponent implements OnInit {
+  private _route = inject(ActivatedRoute);
+  private _seo = inject(SeoService);
+  private _api = inject(SeoPaginasService);
+  private _destroyRef = inject(DestroyRef);
+
+  readonly dias = DIAS;
+
+  isLoading = false;
+  erroCarregar = false;
+  naoEncontrado = false;
+
+  uf = '';
+  estadoNome = '';
+  totalCidades = 0;
+  totalParoquias = 0;
+  cidades: { cidadeSlug: string; cidade: string; totalParoquias: number }[] = [];
+
+  ngOnInit(): void {
+    this._route.paramMap.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((pm) => {
+      this.uf = (pm.get('uf') ?? '').toLowerCase();
+      this.carregar();
+    });
+  }
+
+  private carregar(): void {
+    this.isLoading = true;
+    this.erroCarregar = false;
+    this.naoEncontrado = false;
+
+    this._api
+      .getEstado(this.uf)
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        finalize(() => (this.isLoading = false)),
+      )
+      .subscribe({
+        next: (data: any) => {
+          if (!data) {
+            this.naoEncontrado = true;
+            return;
+          }
+          this.estadoNome = data.estado ?? '';
+          this.totalCidades = data.totalCidades ?? 0;
+          this.totalParoquias = data.totalParoquias ?? 0;
+          this.cidades = data.cidades ?? [];
+          this.aplicarSeo(data.seo);
+          this.aplicarJsonLd();
+        },
+        error: (err) => {
+          if (err?.status === 404) this.naoEncontrado = true;
+          else this.erroCarregar = true;
+        },
+      });
+  }
+
+  tentarNovamente(): void {
+    this.carregar();
+  }
+
+  private aplicarSeo(seo: any): void {
+    if (!seo) return;
+    this._seo.update({
+      title: seo.title,
+      description: seo.description,
+      canonical: seo.canonicalUrl,
+      image: seo.ogImage ?? undefined,
+    });
+  }
+
+  private aplicarJsonLd(): void {
+    this._seo.setJsonLd('breadcrumb', {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Início', item: `${SITE}/home` },
+        { '@type': 'ListItem', position: 2, name: `Missas em ${this.estadoNome}`, item: `${SITE}/missas/${this.uf}` },
+      ],
+    });
+
+    this._seo.setJsonLd('itemlist', {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: `Cidades com missa em ${this.estadoNome}`,
+      numberOfItems: this.cidades.length,
+      itemListElement: this.cidades.map((c, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: c.cidade,
+        item: `${SITE}/missas/${this.uf}/${c.cidadeSlug}`,
+      })),
+    });
+  }
+}

--- a/src/app/modules/public/intencao/intencao.component.html
+++ b/src/app/modules/public/intencao/intencao.component.html
@@ -1,0 +1,83 @@
+<section class="intencao">
+  @if (isLoading) {
+    <p-skeleton width="60%" height="2rem" styleClass="mb-3" />
+    <p-skeleton width="40%" height="1rem" styleClass="mb-4" />
+    <div class="grid">
+      @for (i of [1,2,3,4,5,6]; track i) { <p-skeleton height="4rem" /> }
+    </div>
+  } @else if (naoEncontrado) {
+    <div class="intencao__vazio">
+      <h1>Nenhuma missa de {{ rotulo }} encontrada</h1>
+      <p>Não há paróquias com missa de {{ rotulo }} cadastradas aqui.</p>
+      <a routerLink="/home">Voltar ao início</a>
+    </div>
+  } @else if (erroCarregar) {
+    <div class="intencao__erro">
+      <p>Não foi possível carregar as missas de {{ rotulo }}.</p>
+      <button type="button" (click)="tentarNovamente()">Tentar novamente</button>
+    </div>
+  } @else {
+    <nav class="breadcrumb" aria-label="Trilha de navegação">
+      <a routerLink="/home">Início</a>
+      <span aria-hidden="true">›</span>
+      @if (nivel === 'nacional') {
+        <span aria-current="page">Missa de {{ rotulo }}</span>
+      } @else {
+        <a [routerLink]="['/missa-' + dia]">Missa de {{ rotulo }}</a>
+        <span aria-hidden="true">›</span>
+        @if (nivel === 'uf') {
+          <span aria-current="page">{{ estadoNome || uf.toUpperCase() }}</span>
+        } @else {
+          <a [routerLink]="['/missa-' + dia, uf]">{{ estadoNome || uf.toUpperCase() }}</a>
+          <span aria-hidden="true">›</span>
+          <span aria-current="page">{{ cidadeNome }}</span>
+        }
+      }
+    </nav>
+
+    <!-- NÍVEL NACIONAL -->
+    @if (nivel === 'nacional') {
+      <header class="intencao__head">
+        <h1>Missa de {{ rotulo }}: horários no Brasil</h1>
+        <p>Escolha o estado e veja as paróquias com missa de {{ rotulo }} perto de você.</p>
+      </header>
+      <ul class="grid" role="list">
+        @for (e of estados; track e.uf) {
+          <li><a [routerLink]="['/missa-' + dia, e.uf]">{{ e.estado }}</a></li>
+        }
+      </ul>
+    }
+
+    <!-- NÍVEL UF -->
+    @if (nivel === 'uf') {
+      <header class="intencao__head">
+        <h1>Missa de {{ rotulo }} em {{ estadoNome }}</h1>
+        <p>Escolha a cidade e veja as paróquias com missa de {{ rotulo }}.</p>
+      </header>
+      <ul class="grid" role="list">
+        @for (c of cidades; track c.cidadeSlug) {
+          <li><a [routerLink]="['/missa-' + dia, uf, c.cidadeSlug]">{{ c.cidade }}</a></li>
+        }
+      </ul>
+    }
+
+    <!-- NÍVEL CIDADE (folha) -->
+    @if (nivel === 'cidade') {
+      <header class="intencao__head">
+        <h1>Missa de {{ rotulo }} em {{ cidadeNome }}</h1>
+        <p>{{ paroquias.length }} paróquia(s) com missa de {{ rotulo }}.</p>
+      </header>
+      <ul class="paroquias" role="list">
+        @for (p of paroquias; track p.id) {
+          <li class="paroquia">
+            <a class="paroquia__nome" [routerLink]="urlParoquia(p)">{{ p.nome }}</a>
+            @if (p.endereco) {
+              <p class="paroquia__end">{{ p.endereco.bairro }}{{ p.endereco.bairro ? ', ' : '' }}{{ p.endereco.localidade }}/{{ p.endereco.uf }}</p>
+            }
+            <p class="paroquia__horarios"><strong>Missa de {{ rotulo }}:</strong> {{ horariosDoDia(p) }}</p>
+          </li>
+        }
+      </ul>
+    }
+  }
+</section>

--- a/src/app/modules/public/intencao/intencao.component.scss
+++ b/src/app/modules/public/intencao/intencao.component.scss
@@ -1,0 +1,87 @@
+.intencao {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+
+  h1 {
+    font-size: clamp(1.5rem, 4vw, 2.1rem);
+    line-height: 1.15;
+    margin: 0 0 0.5rem;
+  }
+}
+
+.intencao__head p { color: #4b5563; margin: 0 0 1.5rem; }
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-bottom: 1rem;
+
+  a { color: #2563eb; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  span[aria-current] { color: #374151; font-weight: 600; }
+}
+
+.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.6rem;
+
+  a {
+    display: block;
+    padding: 0.85rem 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.6rem;
+    text-decoration: none;
+    color: inherit;
+    background: #fff;
+    font-weight: 600;
+  }
+  a:hover { border-color: #93c5fd; box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06); }
+}
+
+.paroquias {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.paroquia {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  background: #fff;
+
+  &__nome { font-weight: 700; color: #1f2937; text-decoration: none; font-size: 1.05rem; }
+  &__nome:hover { color: #2563eb; text-decoration: underline; }
+  &__end { color: #6b7280; font-size: 0.85rem; margin: 0.25rem 0; }
+  &__horarios { margin: 0.25rem 0 0; color: #374151; }
+}
+
+.intencao__vazio,
+.intencao__erro {
+  text-align: center;
+  padding: 3rem 1rem;
+
+  button {
+    margin-top: 1rem;
+    padding: 0.6rem 1.2rem;
+    border: 0;
+    border-radius: 0.5rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+  }
+}
+
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1.25rem; }

--- a/src/app/modules/public/intencao/intencao.component.ts
+++ b/src/app/modules/public/intencao/intencao.component.ts
@@ -1,0 +1,206 @@
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { combineLatest } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { SkeletonModule } from 'primeng/skeleton';
+import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
+import { SeoService } from '../../../core/services/seo.service';
+
+const SITE = 'https://buscamissa.com.br';
+
+const ROTULO: Record<string, string> = {
+  domingo: 'domingo',
+  'segunda-feira': 'segunda-feira',
+  'terca-feira': 'terça-feira',
+  'quarta-feira': 'quarta-feira',
+  'quinta-feira': 'quinta-feira',
+  'sexta-feira': 'sexta-feira',
+  sabado: 'sábado',
+};
+
+type Nivel = 'nacional' | 'uf' | 'cidade';
+
+/**
+ * Árvore de INTENÇÃO (`/missa-{dia}[/:uf[/:cidade]]`) — Fase 3 SEO. Um componente,
+ * três níveis (via `data.dia` + params): nacional (lista UFs), UF (lista cidades)
+ * e cidade (folha: paróquias com os horários do dia). O dia vem de `route.data.dia`
+ * porque o slug (`missa-domingo`) é literal na rota, não um :param.
+ */
+@Component({
+  selector: 'app-intencao',
+  standalone: true,
+  imports: [CommonModule, RouterLink, SkeletonModule],
+  templateUrl: './intencao.component.html',
+  styleUrl: './intencao.component.scss',
+})
+export class IntencaoComponent implements OnInit {
+  private _route = inject(ActivatedRoute);
+  private _seo = inject(SeoService);
+  private _api = inject(SeoPaginasService);
+  private _destroyRef = inject(DestroyRef);
+
+  isLoading = false;
+  erroCarregar = false;
+  naoEncontrado = false;
+
+  dia = '';
+  uf = '';
+  cidadeSlug = '';
+  nivel: Nivel = 'nacional';
+
+  get rotulo(): string {
+    return ROTULO[this.dia] ?? this.dia;
+  }
+
+  // Dados por nível.
+  estados: { uf: string; estado: string }[] = [];
+  estadoNome = '';
+  cidades: { cidadeSlug: string; cidade: string; paroquias?: unknown[] }[] = [];
+  cidadeNome = '';
+  paroquias: any[] = [];
+
+  ngOnInit(): void {
+    combineLatest([this._route.data, this._route.paramMap])
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(([data, pm]) => {
+        this.dia = (data['dia'] as string) ?? '';
+        this.uf = (pm.get('uf') ?? '').toLowerCase();
+        this.cidadeSlug = (pm.get('cidade') ?? '').toLowerCase();
+        this.nivel = this.cidadeSlug ? 'cidade' : this.uf ? 'uf' : 'nacional';
+        this.carregar();
+      });
+  }
+
+  carregar(): void {
+    this.isLoading = true;
+    this.erroCarregar = false;
+    this.naoEncontrado = false;
+
+    if (this.nivel === 'cidade') this.carregarCidade();
+    else this.carregarHub();
+  }
+
+  private carregarCidade(): void {
+    this._api
+      .getIntencaoCidade(this.dia, this.uf, this.cidadeSlug)
+      .pipe(takeUntilDestroyed(this._destroyRef), finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: (data: any) => {
+          if (!data) return void (this.naoEncontrado = true);
+          this.cidadeNome = data.cidade ?? '';
+          this.paroquias = data.paroquias ?? [];
+          this.aplicarSeo(data.seo);
+          this.jsonLdBreadcrumb();
+          this.jsonLdItemList(
+            this.paroquias.map((p) => ({ nome: p.nome, url: this.urlParoquia(p) })),
+            `Paróquias com missa de ${this.rotulo} em ${this.cidadeNome}`,
+          );
+        },
+        error: (err) => this.tratarErro(err),
+      });
+  }
+
+  private carregarHub(): void {
+    this._api
+      .getArvoreDia(this.dia)
+      .pipe(takeUntilDestroyed(this._destroyRef), finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: (arvore: any) => {
+          if (!arvore?.estados) return void (this.naoEncontrado = true);
+          if (this.nivel === 'nacional') {
+            this.estados = arvore.estados.map((e: any) => ({ uf: e.uf, estado: e.estado }));
+            this.aplicarSeo(arvore.seo);
+            this.jsonLdBreadcrumb();
+            this.jsonLdItemList(
+              this.estados.map((e) => ({ nome: e.estado, url: `${SITE}/missa-${this.dia}/${e.uf}` })),
+              `Estados com missa de ${this.rotulo}`,
+            );
+          } else {
+            const estado = arvore.estados.find((e: any) => e.uf?.toLowerCase() === this.uf);
+            if (!estado) return void (this.naoEncontrado = true);
+            this.estadoNome = estado.estado ?? '';
+            this.cidades = estado.cidades ?? [];
+            this.aplicarSeo(estado.seo);
+            this.jsonLdBreadcrumb();
+            this.jsonLdItemList(
+              this.cidades.map((c) => ({ nome: c.cidade, url: `${SITE}/missa-${this.dia}/${this.uf}/${c.cidadeSlug}` })),
+              `Cidades com missa de ${this.rotulo} em ${this.estadoNome}`,
+            );
+          }
+        },
+        error: (err) => this.tratarErro(err),
+      });
+  }
+
+  private tratarErro(err: any): void {
+    if (err?.status === 404) this.naoEncontrado = true;
+    else this.erroCarregar = true;
+  }
+
+  tentarNovamente(): void {
+    this.carregar();
+  }
+
+  urlParoquia(p: any): string {
+    const uf = p?.endereco?.uf?.toLowerCase() ?? this.uf;
+    const cidade = p?.endereco?.cidadeSlug ?? this.cidadeSlug;
+    return p?.slug ? `/paroquia/${uf}/${cidade}/${p.slug}` : `/igrejas/${p?.nomeUnico}`;
+  }
+
+  horariosDoDia(p: any): string {
+    return (p?.missas ?? [])
+      .map((m: any) => (m?.horario ?? '').slice(0, 5))
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  private aplicarSeo(seo: any): void {
+    if (!seo) return;
+    this._seo.update({
+      title: seo.title,
+      description: seo.description,
+      canonical: seo.canonicalUrl,
+      image: seo.ogImage ?? undefined,
+    });
+  }
+
+  private jsonLdBreadcrumb(): void {
+    const itens: any[] = [
+      { '@type': 'ListItem', position: 1, name: 'Início', item: `${SITE}/home` },
+      { '@type': 'ListItem', position: 2, name: `Missa de ${this.rotulo}`, item: `${SITE}/missa-${this.dia}` },
+    ];
+    if (this.nivel !== 'nacional') {
+      itens.push({
+        '@type': 'ListItem',
+        position: 3,
+        name: this.estadoNome || this.uf.toUpperCase(),
+        item: `${SITE}/missa-${this.dia}/${this.uf}`,
+      });
+    }
+    if (this.nivel === 'cidade') {
+      itens.push({ '@type': 'ListItem', position: 4, name: this.cidadeNome });
+    }
+    this._seo.setJsonLd('breadcrumb', {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: itens,
+    });
+  }
+
+  private jsonLdItemList(itens: { nome: string; url?: string }[], nome: string): void {
+    this._seo.setJsonLd('itemlist', {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: nome,
+      numberOfItems: itens.length,
+      itemListElement: itens.map((it, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: it.nome,
+        ...(it.url ? { item: it.url } : {}),
+      })),
+    });
+  }
+}

--- a/src/app/modules/public/missa-hoje/missa-hoje.component.ts
+++ b/src/app/modules/public/missa-hoje/missa-hoje.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Router } from '@angular/router';
+
+// getDay(): 0=domingo … 6=sábado — mesma ordem do DiaDaSemanaEnum do backend.
+const SLUG_POR_DIA = ['domingo', 'segunda-feira', 'terca-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sabado'];
+
+/**
+ * `/missa-hoje` — resolve o dia atual NO CLIENTE (o Brasil tem 4 fusos, então não
+ * existe um "hoje" único no servidor) e redireciona para a landing do dia explícito
+ * (`/missa-domingo`, ...). Rota CSR (não prerenderizada). No SSR não faz nada.
+ */
+@Component({
+  selector: 'app-missa-hoje',
+  standalone: true,
+  template: '<p class="sr-only">Redirecionando para a missa de hoje…</p>',
+})
+export class MissaHojeComponent implements OnInit {
+  private _router = inject(Router);
+  private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  ngOnInit(): void {
+    if (!this._isBrowser) return;
+    const slug = SLUG_POR_DIA[new Date().getDay()] ?? 'domingo';
+    this._router.navigate(['/missa-' + slug], { replaceUrl: true });
+  }
+}


### PR DESCRIPTION
## Contexto
Frontend da Fase 3 SEO. Consome os endpoints novos do api-public (#29/#30/#31) e cria as duas páginas que faltavam — **Estado** e o **eixo de Intenção** — no mesmo padrão SSG de cidade/paróquia (bulk em disco → interceptor só-server → TransferState/SWR no browser; endpoints por-item em runtime).

## O que entra
- **Estado** `/missas/:uf` — hub que lista as cidades da UF (+ links por dia). `estado.component`, consome `/v2/seo/estado/{uf}`.
- **Intenção** `/missa-{dia}[/:uf[/:cidade]]` (7 dias) — o eixo pelo qual a busca começa. Um `intencao.component` em 3 níveis (nacional → UF → cidade-folha); o dia vem de `data.dia` (o slug é literal na rota). A folha mostra as paróquias com os horários **daquele dia**.
- **`/missa-hoje`** — redirect client-side pro dia local (Brasil tem 4 fusos; nunca HTML estático de "hoje").
- **SEO/Schema** — `seo.update` + JSON-LD `BreadcrumbList`/`ItemList` reusando o `SeoService`.
- **Infra** — chaves de TransferState (estado/intenção/árvore), interceptors `prerender-estado`/`prerender-intencao` (registrados no config server), leitura no SWR `prerender-transfer-state`, cache em disco dos novos bulks (estados + 7 dias), rotas de prerender (`getPrerenderParams`), guard-rail estendido.

## Decisão de arquitetura
Mantém **prerender + próxima missa client-side** (não reverte): o prerender serve a grade estável (SEO); "próxima missa"/countdown seguem client-side (`mass-time.utils`). Guarda **anti-thin**: só dias/cidades com ≥1 missa entram (o backend já filtra).

## Verificação
- `npm run build:dev`: **exit 0, 2557 rotas prerenderizadas** (1061 de intenção + 391 estado/cidade + paróquia/home).
- **guard-rail: 0% de erro** em todas as seções.
- HTML conferido: título/canonical corretos, JSON-LD `BreadcrumbList`+`ItemList`, horários reais (ex.: "Missa de domingo: 08:00, 19:00").

## Pré-requisito de deploy
Requer os endpoints do api-public (#29/#30/#31, já na `dev`) em produção antes do `build:prod` (o prebuild baixa os bulks; senão cai no fallback ao vivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)