### PR TITLE
Rastrear visualização de páginas e favoritos em todos os pontos

### DIFF
--- a/src/app/core/services/metricas.service.ts
+++ b/src/app/core/services/metricas.service.ts
@@ -5,6 +5,19 @@ import { LoggerService } from './logger.service';
 
 const JANELA_VISUALIZACAO_MS = 30 * 60 * 1000; // 30 minutos
 
+/**
+ * Espelha Enums/TipoPaginaEnum.cs do backend (api-public). Valores numéricos —
+ * o backend não usa JsonStringEnumConverter, então o enum é serializado como int.
+ */
+export enum PaginaMetrica {
+  Cidades = 1,
+  MissaAgora = 2,
+  ComoFunciona = 3,
+  MinhasIgrejas = 4,
+  GuiaResponsavel = 5,
+  Entrar = 6,
+}
+
 @Injectable({ providedIn: 'root' })
 export class MetricasService {
   private http = inject(HttpClient);
@@ -49,6 +62,23 @@ export class MetricasService {
       .post('v2/metricas/visualizacao-home', {})
       .subscribe({
         error: (err) => this.logger.logError(err, 'metrica:visualizacao-home'),
+      });
+    localStorage.setItem(chave, String(agora));
+  }
+
+  // Mesma janela de dedupe das demais visualizações, uma chave por página.
+  registrarVisualizacaoPagina(pagina: PaginaMetrica): void {
+    if (!this._isBrowser) return;
+    const chave = `pagina_${PaginaMetrica[pagina]}_ultima_visualizacao`;
+    const agora = Date.now();
+    const ultimaVisualizacao = Number(localStorage.getItem(chave) ?? 0);
+
+    if (agora - ultimaVisualizacao < JANELA_VISUALIZACAO_MS) return;
+
+    this.http
+      .post('v2/metricas/visualizacao-pagina', { pagina })
+      .subscribe({
+        error: (err) => this.logger.logError(err, 'metrica:visualizacao-pagina'),
       });
     localStorage.setItem(chave, String(agora));
   }

--- a/src/app/modules/public/cidades/cidades.component.ts
+++ b/src/app/modules/public/cidades/cidades.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { ChurchesService } from '../../../core/services/churches.service';
+import { MetricasService, PaginaMetrica } from '../../../core/services/metricas.service';
 import { STATES } from '../../../core/constants/states';
 
 interface CidadeItem { nome: string; slug: string; }
@@ -17,6 +18,7 @@ interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expan
 })
 export class CidadesComponent implements OnInit {
   private _church = inject(ChurchesService);
+  private _metricas = inject(MetricasService);
 
   isLoading = true;
   busca = '';
@@ -46,6 +48,7 @@ export class CidadesComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.Cidades);
     this._church.addressRange().subscribe({
       next: ({ data }: any) => {
         this.estados = Object.entries(data)

--- a/src/app/modules/public/como-funciona/como-funciona.component.ts
+++ b/src/app/modules/public/como-funciona/como-funciona.component.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@angular/router';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { ChurchesService } from '../../../core/services/churches.service';
 import { ClarityService } from '../../../core/services/clarity.service';
+import { MetricasService, PaginaMetrica } from '../../../core/services/metricas.service';
 
 @Component({
   selector: 'app-como-funciona',
@@ -14,6 +15,7 @@ import { ClarityService } from '../../../core/services/clarity.service';
 export class ComoFuncionaComponent implements OnInit, AfterViewInit, OnDestroy {
   private _church = inject(ChurchesService);
   private _clarity = inject(ClarityService);
+  private _metricas = inject(MetricasService);
   private _scrollObserver: IntersectionObserver | null = null;
   private _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
@@ -58,6 +60,7 @@ export class ComoFuncionaComponent implements OnInit, AfterViewInit, OnDestroy {
   ];
 
   ngOnInit(): void {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.ComoFunciona);
     // Só no browser: mantém o prerender hermético (sem I/O de rede no build).
     // Os números carregam na hidratação; o HTML estático usa os defaults.
     if (!this._isBrowser) return;

--- a/src/app/modules/public/entrar/entrar.component.ts
+++ b/src/app/modules/public/entrar/entrar.component.ts
@@ -12,6 +12,7 @@ import { MessageService } from "primeng/api";
 import { PrimeNgModule } from "../../../shared/primeng.module";
 import { AuthService } from "../../../core/services/auth.service";
 import { LoggerService } from "../../../core/services/logger.service";
+import { MetricasService, PaginaMetrica } from "../../../core/services/metricas.service";
 
 type Modo = "login" | "solicitar-codigo" | "definir-senha";
 
@@ -33,6 +34,7 @@ export class EntrarComponent implements OnInit {
   private _fb = inject(FormBuilder);
   private _logger = inject(LoggerService);
   private _router = inject(Router);
+  private _metricas = inject(MetricasService);
 
   public modo: Modo = "login";
   public isLoading = false;
@@ -41,6 +43,7 @@ export class EntrarComponent implements OnInit {
   public formDefinir!: FormGroup;
 
   ngOnInit(): void {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.Entrar);
     // Forms antes do redirect: o template renderiza uma vez mesmo quando
     // vamos navegar embora — sem os forms criados isso estoura NG01052.
     this.formLogin = this._fb.group({

--- a/src/app/modules/public/guia-responsavel/guia-responsavel.component.ts
+++ b/src/app/modules/public/guia-responsavel/guia-responsavel.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from "@angular/common";
 import { RouterLink } from "@angular/router";
 import { PrimeNgModule } from "../../../shared/primeng.module";
 import { SeoService } from "../../../core/services/seo.service";
+import { MetricasService, PaginaMetrica } from "../../../core/services/metricas.service";
 
 interface FAQ {
   pergunta: string;
@@ -19,6 +20,7 @@ interface FAQ {
 })
 export class GuiaResponsavelComponent implements OnInit {
   private _seo = inject(SeoService);
+  private _metricas = inject(MetricasService);
 
   faqs: FAQ[] = [
     {
@@ -48,6 +50,7 @@ export class GuiaResponsavelComponent implements OnInit {
   ];
 
   ngOnInit() {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.GuiaResponsavel);
     this._seo.update({
       title: "Guia do Responsável Verificado | BuscaMissa",
       description:

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -12,6 +12,7 @@ import { getNextOccurrenceMinutes } from "../../../../shared/utils/mass-time.uti
 import { AnalyticsService } from "../../../../core/services/analytics.service";
 import { FavoritesService } from "../../../../core/services/favorites.service";
 import { ClarityService } from "../../../../core/services/clarity.service";
+import { MetricasService } from "../../../../core/services/metricas.service";
 import { CityMapComponent, MapChurch } from "../../../../shared/components/city-map/city-map.component";
 import { DIAS, PERIODOS } from "./city.constants";
 import { CityFiltrosComponent, Ordenacao, QuickFilter } from "./sections/city-filtros/city-filtros.component";
@@ -48,6 +49,7 @@ export class CityComponent implements OnInit, OnDestroy {
   private _analytics = inject(AnalyticsService);
   private _favorites = inject(FavoritesService);
   private _clarity = inject(ClarityService);
+  private _metricas = inject(MetricasService);
 
   /** Falso durante o prerender (Node). Guarda browser-APIs (geoloc, localStorage). */
   private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -404,6 +406,7 @@ export class CityComponent implements OnInit, OnDestroy {
     });
 
     if (agoraFavorita) {
+      this._metricas.registrarFavorito(ig.id);
       this.favoritasIds = [...this.favoritasIds, ig.id];
       this._analytics.favoriteParishSaved(ig.nome);
     } else {

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -693,6 +693,7 @@ export class HomeComponent {
       horario: card.mass.horario,
     };
     this._favorites.adicionar(novaFavorita);
+    this._metricas.registrarFavorito(card.churchId);
     this.paroquiasFavoritas = [...this.paroquiasFavoritas, novaFavorita];
     this._analytics.favoriteParishSaved(card.churchName);
   }

--- a/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
+++ b/src/app/modules/public/minhas-igrejas/minhas-igrejas.component.ts
@@ -10,6 +10,7 @@ import { getMissaAgoraUrgency } from '../../../shared/utils/mass-time.utils';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { FavoritesService, IgrejaFavorita } from '../../../core/services/favorites.service';
+import { MetricasService, PaginaMetrica } from '../../../core/services/metricas.service';
 import { linkParoquia } from '../../../shared/utils/church-link.utils';
 
 @Component({
@@ -26,11 +27,13 @@ export class MinhasIgrejasComponent implements OnInit, OnDestroy {
   private _toast = inject(MessageService);
   private _clarity = inject(ClarityService);
   private _favorites = inject(FavoritesService);
+  private _metricas = inject(MetricasService);
 
   igrejas: IgrejaFavorita[] = [];
   private _navSub: Subscription | null = null;
 
   ngOnInit(): void {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.MinhasIgrejas);
     this._seo.update({
       title: 'Minhas Igrejas | BuscaMissa',
       description: 'Veja todas as suas igrejas favoritas e horários de missa.',

--- a/src/app/modules/public/missa-agora/missa-agora.component.ts
+++ b/src/app/modules/public/missa-agora/missa-agora.component.ts
@@ -12,6 +12,7 @@ import { Mass } from "../../../core/interfaces/church.interface";
 import { getMissaAgoraUrgency, getCountdownLabel } from "../../../shared/utils/mass-time.utils";
 import { CIDADES_POPULARES_MISSA_AGORA } from "../../../core/constants/cidades-populares";
 import { GeolocationService } from "../../../core/services/geolocation.service";
+import { MetricasService, PaginaMetrica } from "../../../core/services/metricas.service";
 import { MessageService } from "primeng/api";
 import { PrimeNgModule } from "../../../shared/primeng.module";
 
@@ -33,6 +34,7 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
   private _toast = inject(MessageService);
   private _favorites = inject(FavoritesService);
   private _geo = inject(GeolocationService);
+  private _metricas = inject(MetricasService);
 
   geoStatus: GeoStatus = 'idle';
   permissaoNegadaPeloBrowser = false;
@@ -79,6 +81,7 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this._metricas.registrarVisualizacaoPagina(PaginaMetrica.MissaAgora);
     this._loadFavoritas();
     this._seo.update({
       title: 'Missa Agora | BuscaMissa',
@@ -321,6 +324,7 @@ export class MissaAgoraComponent implements OnInit, OnDestroy {
 
       // atualiza o Set reativo para que o ícone mude imediatamente
       if (agoraFavorita) {
+        this._metricas.registrarFavorito(card.churchId);
         this.favoritasIds.add(card.churchId);
       } else {
         this.favoritasIds.delete(card.churchId);

--- a/src/app/shared/components/church-result-card/church-result-card.component.ts
+++ b/src/app/shared/components/church-result-card/church-result-card.component.ts
@@ -4,6 +4,7 @@ import { RouterLink } from "@angular/router";
 import { ConfidenceBadgeComponent } from "../confidence-badge/confidence-badge.component";
 import { ChurchPlaceholderComponent } from "../church-placeholder/church-placeholder.component";
 import { FavoritesService } from "../../../core/services/favorites.service";
+import { MetricasService } from "../../../core/services/metricas.service";
 import {
   getNextOccurrenceMinutes,
   formatMassTime,
@@ -51,6 +52,7 @@ export class ChurchResultCardComponent implements OnInit {
   @Output() favoriteToggled = new EventEmitter<any>();
 
   private favorites = inject(FavoritesService);
+  private metricas = inject(MetricasService);
 
   imagemQuebrada = false;
   favorita = false;
@@ -176,6 +178,9 @@ export class ChurchResultCardComponent implements OnInit {
       diaSemana: pm?.diaSemana,
       horario: pm?.horario,
     });
+    if (this.favorita) {
+      this.metricas.registrarFavorito(this.igreja.id);
+    }
     this.favoriteToggled.emit(this.igreja);
   }
 }


### PR DESCRIPTION
## Summary
- Novas páginas (cidades, missa-agora, como-funciona, minhas-igrejas, guia-responsavel, entrar) registram métrica de visualização via `MetricasService.registrarVisualizacaoPagina` (dedupe de 30min, mesmo padrão da home)
- Métrica de favorito agora dispara em todos os pontos de favoritar do site (home, cidade, card de busca reutilizável), não só na tela de detalhe da igreja

## Test plan
- [ ] Visitar cada uma das 6 páginas e confirmar chamada a `v2/metricas/visualizacao-pagina`
- [ ] Favoritar uma igreja pela home, pela página de cidade e pelo card de busca e confirmar chamada a `v2/metricas/favorito`