### PR TITLE
Reduzir build size: CSR nas folhas de intenção (dia×uf×cidade)

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -98,18 +98,12 @@ const rotasIntencao: ServerRoute[] = DIAS_INTENCAO.flatMap((dia) => [
         .map((e) => ({ uf: e.uf.toLowerCase() }));
     },
   },
-  {
-    path: `missa-${dia}/:uf/:cidade`,
-    renderMode: RenderMode.Prerender,
-    getPrerenderParams: async () => {
-      const arvore = await arvoreDoDia(dia);
-      return (arvore.estados ?? []).flatMap((e) =>
-        (e.cidades ?? [])
-          .filter((c) => c?.cidadeSlug && e.uf)
-          .map((c) => ({ uf: e.uf.toLowerCase(), cidade: c.cidadeSlug.toLowerCase() })),
-      );
-    },
-  },
+  // Folha cidade (`/missa-{dia}/:uf/:cidade`): CSR, não prerender. Long-tail de
+  // baixíssimo volume de busca por combinação — os hubs nacional/UF acima já
+  // cobrem o SEO principal. Prerenderizar as ~2.937 combinações estourava o
+  // limite de tamanho do Azure SWA (~300 MB só desta categoria). O componente
+  // busca os dados via SeoPaginasService normalmente, então funciona em CSR puro.
+  { path: `missa-${dia}/:uf/:cidade`, renderMode: RenderMode.Client },
 ]);
 
 export const serverRoutes: ServerRoute[] = [


### PR DESCRIPTION
## Summary
- O build de produção estava estourando o limite de tamanho do Azure SWA: 766,7 MB vs 200 MB configurado (limite real do Free é 250 MB)
- ~2.937 das 7.515 páginas prerenderizadas (39%) vinham da árvore de intenção folha (`/missa-{dia}/:uf/:cidade`) — long-tail de baixo volume de busca por combinação
- Troquei `RenderMode.Prerender` → `RenderMode.Client` só nessa camada folha; hubs nacional e por UF continuam prerenderizados (mantém o SEO principal)
- O componente `intencao.component.ts` já busca os dados via `SeoPaginasService` em runtime, então funciona normalmente em CSR puro

## Impacto estimado
- -2.937 páginas prerenderizadas (-39% do total)
- Redução estimada de ~300 MB no dist (de ~767 MB para ~467 MB) — reduz bastante mas provavelmente ainda não fica abaixo de 200/250 MB sozinho; pode ser necessário um corte adicional depois (ex.: paróquias sem tráfego)

## Test plan
- [ ] Rodar `npm run build:prod` e conferir que o dist final está menor
- [ ] Acessar uma URL de `/missa-domingo/sp/sao-paulo` em produção e confirmar que carrega normalmente via CSR
- [ ] Confirmar que os hubs `/missa-domingo` e `/missa-domingo/sp` continuam pré-renderizados