### PR TITLE
Fix: build size do prerender ainda estourava em prod (786MB de dados reais)

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -18,24 +18,38 @@ import { buscarRotasSeo, normalizarBaseUrl } from '../../scripts/lib/seo-routes.
  *   sitemap).
  * - Fase 2.5 (aqui): prerender das páginas de PARÓQUIA (`/paroquia/:uf/:cidade/:slug`).
  *   O bulk `/v2/seo/paroquias` (interceptor só-server) evita as chamadas individuais.
- *   Prerenderiza SÓ paróquias COM missa (ver paroquiasComMissaDoDisco): corta as
- *   páginas thin (sem horário), dá folga no limite de 250 MB do SWA em prod (~4.5k
- *   paróquias) e melhora o SEO. As sem missa seguem CSR (e continuam no sitemap).
+ *   Prerenderiza SÓ paróquias com confiança Média/Alta (ver paroquiasComMissaDoDisco):
+ *   corta as páginas thin (sem horário) e as com horário nunca validado/desatualizado
+ *   (StatusConfianca Desconhecida/Baixa) — em prod (~4.5k paróquias) o dist estourava
+ *   200 MB mesmo só com o filtro "tem missa" (3.471 páginas). Cortar por confiança leva
+ *   a ~2.743, priorizando as páginas com dado mais confiável/visitado. As demais seguem
+ *   CSR (e continuam no sitemap).
  */
 
+/** Espelha Enums/StatusConfiancaEnum.cs do backend (api-public). */
+const enum StatusConfianca {
+  Media = 2,
+  Alta = 3,
+}
+
 /**
- * Lê o bulk baixado pelo prebuild (.prerender-cache/paroquias.json, que tem `missas`)
- * e retorna as rotas SÓ das paróquias com horário. Retorna null se o arquivo não
- * existe (ex.: build:dev sem prebuild) → o caller cai no fallback (todas via routes).
+ * Lê o bulk baixado pelo prebuild (.prerender-cache/paroquias.json, que tem `missas`
+ * e `statusConfianca`) e retorna as rotas só das paróquias com confiança Média/Alta.
+ * Retorna null se o arquivo não existe (ex.: build:dev sem prebuild) → o caller cai
+ * no fallback (todas via routes).
  */
 function paroquiasComMissaDoDisco(): Array<{ uf: string; cidade: string; slug: string }> | null {
   const arquivo = join(process.cwd(), '.prerender-cache', 'paroquias.json');
   if (!existsSync(arquivo)) return null;
   const lista = JSON.parse(readFileSync(arquivo, 'utf-8')) as Array<{
-    uf: string; cidadeSlug: string; slug: string; igreja?: { missas?: unknown[] };
+    uf: string; cidadeSlug: string; slug: string;
+    igreja?: { missas?: unknown[]; statusConfianca?: number };
   }>;
   return lista
-    .filter((p) => (p?.igreja?.missas?.length ?? 0) > 0 && p.uf && p.cidadeSlug && p.slug)
+    .filter((p) =>
+      (p?.igreja?.missas?.length ?? 0) > 0 &&
+      (p?.igreja?.statusConfianca === StatusConfianca.Media || p?.igreja?.statusConfianca === StatusConfianca.Alta) &&
+      p.uf && p.cidadeSlug && p.slug)
     .map((p) => ({ uf: p.uf, cidade: p.cidadeSlug, slug: p.slug }));
 }
 

--- a/src/app/core/middleware/prerender-intencao.interceptor.ts
+++ b/src/app/core/middleware/prerender-intencao.interceptor.ts
@@ -132,14 +132,35 @@ export class PrerenderIntencaoInterceptor implements HttpInterceptor {
       );
     }
 
-    // Hub: /v2/seo/missa-dia/{dia} → devolve a árvore inteira do dia.
+    // Hub: /v2/seo/missa-dia/{dia}[?uf=xx] → devolve a árvore do dia, FATIADA
+    // conforme o nível da página sendo prerenderizada (ver comentário de
+    // SeoPaginasService.getArvoreDia): sem isso, cada página de UF embutia a
+    // árvore nacional inteira (~5 MB) no HTML.
     const chaveArvore = chaveIntencaoArvore(req.url);
     if (chaveArvore) {
       return from(obterArvore(chaveArvore)).pipe(
         switchMap((arvore) => {
           if (!arvore?.estados?.length) return next.handle(req); // árvore fora → chamada normal
-          this._transferState.set(stateKeyIntencaoArvore(chaveArvore), arvore);
-          return of(new HttpResponse({ status: 200, url: req.url, body: arvore }));
+          const uf = new URL(req.url, 'http://localhost').searchParams.get('uf')?.toLowerCase();
+          const fatiada = uf
+            // Página de UF: só o estado pedido — cidades sem `paroquias` (o
+            // template só usa cidadeSlug/cidade; a folha busca as paróquias à parte).
+            ? {
+                ...arvore,
+                estados: (arvore.estados ?? [])
+                  .filter((e: any) => e.uf?.toLowerCase() === uf)
+                  .map((e: any) => ({
+                    ...e,
+                    cidades: (e.cidades ?? []).map((c: any) => ({ cidadeSlug: c.cidadeSlug, cidade: c.cidade })),
+                  })),
+              }
+            // Página nacional: só a lista de estados (uf/nome) — cidades não são usadas aqui.
+            : {
+                ...arvore,
+                estados: (arvore.estados ?? []).map((e: any) => ({ uf: e.uf, estado: e.estado })),
+              };
+          this._transferState.set(stateKeyIntencaoArvore(chaveArvore), fatiada);
+          return of(new HttpResponse({ status: 200, url: req.url, body: fatiada }));
         }),
       );
     }

--- a/src/app/core/services/seo-paginas.service.ts
+++ b/src/app/core/services/seo-paginas.service.ts
@@ -27,9 +27,17 @@ export class SeoPaginasService {
     return this.http.get(`${this.base}/v2/seo/estado/${uf}`);
   }
 
-  /** Árvore de um dia (hubs nacional/UF da intenção). */
-  getArvoreDia(dia: string): Observable<unknown> {
-    return this.http.get(`${this.base}/v2/seo/missa-dia/${dia}`);
+  /**
+   * Árvore de um dia (hubs nacional/UF da intenção). O endpoint real sempre devolve
+   * a árvore inteira (ignora `uf`) — o filtro por UF é feito no componente. O `uf`
+   * aqui só marca a requisição para o interceptor SÓ-SERVER de prerender (ver
+   * PrerenderIntencaoInterceptor), que fatia a árvore ANTES de gravar no
+   * TransferState: sem isso, cada uma das ~26 páginas de UF por dia embutia a
+   * árvore nacional inteira (~5 MB) no HTML — estourava o limite de tamanho do SWA.
+   */
+  getArvoreDia(dia: string, uf?: string): Observable<unknown> {
+    const query = uf ? `?uf=${encodeURIComponent(uf)}` : '';
+    return this.http.get(`${this.base}/v2/seo/missa-dia/${dia}${query}`);
   }
 
   /** Folha da intenção: uma cidade num dia (`/missa-{dia}/{uf}/{cidade}`). */

--- a/src/app/modules/public/intencao/intencao.component.ts
+++ b/src/app/modules/public/intencao/intencao.component.ts
@@ -104,7 +104,7 @@ export class IntencaoComponent implements OnInit {
 
   private carregarHub(): void {
     this._api
-      .getArvoreDia(this.dia)
+      .getArvoreDia(this.dia, this.nivel === 'uf' ? this.uf : undefined)
       .pipe(takeUntilDestroyed(this._destroyRef), finalize(() => (this.isLoading = false)))
       .subscribe({
         next: (arvore: any) => {


### PR DESCRIPTION
## Contexto
O corte anterior (folhas de intenção → CSR) só reduziu 766,7 MB → 694,1 MB. Rodei o build local contra a API de PRODUÇÃO (dev tem uma base bem menor, por isso o problema só aparecia em prod) e medi de verdade onde estava o peso.

## Causa raiz encontrada
1. **Menor**: filtro "paróquia com missa" (3.471 páginas) incluía páginas cujo horário nunca foi validado (`StatusConfianca` Desconhecida/Baixa). Restringido a Média/Alta → 2.743 páginas.
2. **Principal**: cada página de hub de intenção por UF (`/missa-domingo/sp`, `/missa-domingo/mg`...) chamava o MESMO endpoint da árvore nacional inteira e filtrava no client. No prerender, isso embutia a árvore do dia inteira (até 5,2 MB) no `TransferState` de **cada uma das ~26 páginas de UF**, por dia — ex.: `dist/.../missa-domingo/sp/index.html` sozinho tinha 5,3 MB.

## Fix
- `SeoPaginasService.getArvoreDia` aceita `uf` opcional (só marca a requisição — o endpoint real ignora e sempre devolve a árvore inteira, comportamento em runtime não muda)
- `PrerenderIntencaoInterceptor` (só-server) agora FATIA a árvore antes de gravar no TransferState: página de UF leva só o seu estado (sem `paroquias` aninhado, não usado nesse nível — a folha busca à parte); página nacional leva só a lista uf/nome (sem cidades)
- `paroquiasComMissaDoDisco` filtra por `StatusConfianca` Média/Alta

## Resultado medido (build local, API de produção)
- Antes deste PR: 660,3 MB (3.850 páginas)
- Depois: **170,9 MB** — dentro do limite de 200 MB
- `missa-domingo/sp/index.html`: 5,3 MB → 84 KB

## Test plan
- [x] Build local completo (`npm run build:prod`) contra a API de prod passou o guard-rail de tamanho
- [x] Conteúdo das páginas de hub (nacional e UF) segue correto (`Estados com missa` / `Cidades com missa` renderizando)
- [ ] Confirmar no CI do PR