### PR TITLE
Fase 2 (leitura): exibir diocese/arquidiocese e capelas no painel do responsável

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -79,6 +79,25 @@ export interface SessaoEdicao {
   observacao?: string | null;
 }
 
+// ---- Fase 2 (diocese/arquidiocese + capelas/comunidades) — só leitura por enquanto ----
+
+export interface Circunscricao {
+  dioceseId?: number | null;
+  dioceseNome?: string | null;
+  arquidioceseId?: number | null;
+  arquidioceseNome?: string | null;
+  /** "Nenhuma" | "Direta" | "Herdada" */
+  origem: string;
+}
+
+export interface CapelaComunidade {
+  id: number;
+  nome: string;
+  slug?: string | null;
+  /** "Paroquia" | "Capela" | "Comunidade" | "Santuario" | "Outro" */
+  tipoIgreja: string;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;
@@ -88,6 +107,8 @@ export interface DadosEdicao {
   endereco: EnderecoEdicao;
   imagemUrl?: string | null;
   sessoes: SessaoEdicao[];
+  circunscricao: Circunscricao;
+  capelasComunidades: CapelaComunidade[];
 }
 
 export interface EditarDadosRequest {

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -54,6 +54,31 @@
       </div>
     </section>
 
+    <!-- DIOCESE/ARQUIDIOCESE + CAPELAS/COMUNIDADES (Fase 2: só leitura) -->
+    <section class="bloco" *ngIf="circunscricao || capelasComunidades.length">
+      <h2><i class="pi pi-sitemap"></i> Circunscrição eclesiástica</h2>
+      <p *ngIf="circunscricao?.origem === 'Nenhuma'" class="texto-auxiliar">
+        Nenhuma diocese/arquidiocese vinculada ainda.
+      </p>
+      <p *ngIf="circunscricao?.dioceseNome">
+        Diocese: <strong>{{ circunscricao?.dioceseNome }}</strong>
+        <span *ngIf="circunscricao?.arquidioceseNome"> (Arquidiocese: {{ circunscricao?.arquidioceseNome }})</span>
+      </p>
+      <p *ngIf="!circunscricao?.dioceseNome && circunscricao?.arquidioceseNome">
+        Arquidiocese: <strong>{{ circunscricao?.arquidioceseNome }}</strong>
+      </p>
+      <p *ngIf="circunscricao?.origem === 'Herdada'" class="texto-auxiliar">
+        Herdada da paróquia-sede.
+      </p>
+
+      <ng-container *ngIf="capelasComunidades.length">
+        <h2><i class="pi pi-building"></i> Capelas / comunidades</h2>
+        <ul class="lista-capelas">
+          <li *ngFor="let c of capelasComunidades">{{ c.nome }} <span class="texto-auxiliar">({{ c.tipoIgreja }})</span></li>
+        </ul>
+      </ng-container>
+    </section>
+
     <!-- IMAGEM -->
     <section class="bloco">
       <h2><i class="pi pi-image"></i> Foto da igreja</h2>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -45,6 +45,20 @@ h1 {
   }
 }
 
+.texto-auxiliar {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.lista-capelas {
+  margin: 0;
+  padding-left: 1.25rem;
+
+  li {
+    margin-bottom: 0.25rem;
+  }
+}
+
 .grid-contato {
   display: grid;
   grid-template-columns: 90px 1fr 90px 1fr;

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -16,7 +16,7 @@ import { AuthService } from "../../../../core/services/auth.service";
 import { ResponsavelService } from "../../../../core/services/responsavel.service";
 import { ChurchesService } from "../../../../core/services/churches.service";
 import { LoggerService } from "../../../../core/services/logger.service";
-import { MetricasIgreja } from "../../../../core/interfaces/responsavel.interface";
+import { MetricasIgreja, Circunscricao, CapelaComunidade } from "../../../../core/interfaces/responsavel.interface";
 import { STATES } from "../../../../core/constants/states";
 
 const REDES = [
@@ -89,6 +89,10 @@ export class EditarIgrejaComponent implements OnInit {
 
   /** Cards de métricas (últimos 30 dias). */
   metricas: MetricasIgreja | null = null;
+
+  /** Fase 2 (só leitura): diocese/arquidiocese efetiva + capelas/comunidades da paróquia. */
+  circunscricao: Circunscricao | null = null;
+  capelasComunidades: CapelaComunidade[] = [];
 
   /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
   private _localidadeOriginal = "";
@@ -182,6 +186,8 @@ export class EditarIgrejaComponent implements OnInit {
         this._latitude = dados.endereco.latitude ?? null;
         this._longitude = dados.endereco.longitude ?? null;
         this.imagemPreview = dados.imagemUrl ?? null;
+        this.circunscricao = dados.circunscricao;
+        this.capelasComunidades = dados.capelasComunidades ?? [];
 
         this.isLoading = false;
       },


### PR DESCRIPTION
## Summary
- Depende do PR do `buscamissa-api-public` (Fase 2 leitura) que expõe `circunscricao`/`capelasComunidades` no `DadosEdicaoResponse`.
- Tela "Editar Igreja" do responsável (`/meu-painel/.../editar-igreja`) ganha uma seção somente-leitura mostrando a diocese/arquidiocese efetiva da paróquia e a lista de capelas/comunidades vinculadas.
- Sem edição ainda — vem nas próximas fases.

## Test plan
- [ ] Acessar a edição de uma paróquia com diocese vinculada → mostra o nome da diocese (e arquidiocese, se houver)
- [ ] Paróquia sem vínculo → mostra "Nenhuma diocese/arquidiocese vinculada ainda"
- [ ] Paróquia com capelas → lista aparece