### PR TITLE
Fase 3: responsável escolhe diocese/arquidiocese da própria paróquia

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -98,6 +98,18 @@ export interface CapelaComunidade {
   tipoIgreja: string;
 }
 
+export interface CircunscricaoOpcao {
+  id: number;
+  nome: string;
+  uf: string;
+}
+
+/** Exatamente um dos dois preenchido. */
+export interface AtualizarCircunscricaoRequest {
+  dioceseId?: number | null;
+  arquidioceseId?: number | null;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -7,6 +7,8 @@ import {
   MinhaResponsabilidade,
   SolicitarResponsabilidadeRequest,
   MetricasIgreja,
+  CircunscricaoOpcao,
+  AtualizarCircunscricaoRequest,
 } from "../interfaces/responsavel.interface";
 
 /**
@@ -73,6 +75,27 @@ export class ResponsavelService {
   editarDados(igrejaId: number, request: EditarDadosRequest): Observable<string> {
     return this.http
       .put<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${igrejaId}/dados`, request)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  /** Fase 3: opções ativas para o seletor de Diocese. */
+  listarDioceses(): Observable<CircunscricaoOpcao[]> {
+    return this.http
+      .get<{ data: CircunscricaoOpcao[] }>("v1/responsavel/dioceses")
+      .pipe(map((r) => r.data));
+  }
+
+  /** Fase 3: opções ativas para o seletor de Arquidiocese. */
+  listarArquidioceses(): Observable<CircunscricaoOpcao[]> {
+    return this.http
+      .get<{ data: CircunscricaoOpcao[] }>("v1/responsavel/arquidioceses")
+      .pipe(map((r) => r.data));
+  }
+
+  /** Fase 3: responsável escolhe a diocese OU arquidiocese direta da própria paróquia. */
+  atualizarCircunscricao(igrejaId: number, request: AtualizarCircunscricaoRequest): Observable<string> {
+    return this.http
+      .put<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${igrejaId}/diocese`, request)
       .pipe(map((r) => r.data.mensagemTela));
   }
 }

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -54,25 +54,43 @@
       </div>
     </section>
 
-    <!-- DIOCESE/ARQUIDIOCESE + CAPELAS/COMUNIDADES (Fase 2: só leitura) -->
-    <section class="bloco" *ngIf="circunscricao || capelasComunidades.length">
+    <!-- DIOCESE/ARQUIDIOCESE (Fase 3: editável) + CAPELAS/COMUNIDADES (só leitura) -->
+    <section class="bloco">
       <h2><i class="pi pi-sitemap"></i> Circunscrição eclesiástica</h2>
-      <p *ngIf="circunscricao?.origem === 'Nenhuma'" class="texto-auxiliar">
-        Nenhuma diocese/arquidiocese vinculada ainda.
-      </p>
-      <p *ngIf="circunscricao?.dioceseNome">
+
+      <p *ngIf="circunscricao?.dioceseNome" class="texto-atual">
         Diocese: <strong>{{ circunscricao?.dioceseNome }}</strong>
         <span *ngIf="circunscricao?.arquidioceseNome"> (Arquidiocese: {{ circunscricao?.arquidioceseNome }})</span>
       </p>
-      <p *ngIf="!circunscricao?.dioceseNome && circunscricao?.arquidioceseNome">
+      <p *ngIf="!circunscricao?.dioceseNome && circunscricao?.arquidioceseNome" class="texto-atual">
         Arquidiocese: <strong>{{ circunscricao?.arquidioceseNome }}</strong>
       </p>
       <p *ngIf="circunscricao?.origem === 'Herdada'" class="texto-auxiliar">
-        Herdada da paróquia-sede.
+        Herdada da paróquia-sede — salvar aqui cria um vínculo direto só para esta unidade.
       </p>
 
+      <div class="circunscricao-form">
+        <div class="p-selectbutton-wrapper">
+          <button pButton type="button" label="Diocese" (click)="tipoCircunscricao = 'diocese'"
+                  class="p-button-sm" [ngClass]="{'p-button-outlined': tipoCircunscricao !== 'diocese'}"></button>
+          <button pButton type="button" label="Direto na Arquidiocese" (click)="tipoCircunscricao = 'arquidiocese'"
+                  class="p-button-sm" [ngClass]="{'p-button-outlined': tipoCircunscricao !== 'arquidiocese'}"></button>
+        </div>
+
+        <p-select *ngIf="tipoCircunscricao === 'diocese'" [options]="dioceses" [(ngModel)]="dioceseSelecionada"
+                  [ngModelOptions]="{standalone: true}" optionLabel="nome" optionValue="id"
+                  placeholder="Selecione a diocese" styleClass="w-full" appendTo="body"></p-select>
+        <p-select *ngIf="tipoCircunscricao === 'arquidiocese'" [options]="arquidioceses" [(ngModel)]="arquidioceseSelecionada"
+                  [ngModelOptions]="{standalone: true}" optionLabel="nome" optionValue="id"
+                  placeholder="Selecione a arquidiocese" styleClass="w-full" appendTo="body"></p-select>
+
+        <button pButton type="button" label="Salvar circunscrição" icon="pi pi-check"
+                class="p-button-sm" [loading]="salvandoCircunscricao"
+                (click)="salvarCircunscricao()"></button>
+      </div>
+
       <ng-container *ngIf="capelasComunidades.length">
-        <h2><i class="pi pi-building"></i> Capelas / comunidades</h2>
+        <h2 class="mt"><i class="pi pi-building"></i> Capelas / comunidades</h2>
         <ul class="lista-capelas">
           <li *ngFor="let c of capelasComunidades">{{ c.nome }} <span class="texto-auxiliar">({{ c.tipoIgreja }})</span></li>
         </ul>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -50,6 +50,10 @@ h1 {
   color: #6b7280;
 }
 
+.texto-atual {
+  margin: 0 0 0.5rem;
+}
+
 .lista-capelas {
   margin: 0;
   padding-left: 1.25rem;
@@ -57,6 +61,23 @@ h1 {
   li {
     margin-bottom: 0.25rem;
   }
+}
+
+.circunscricao-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 420px;
+  margin-top: 0.5rem;
+
+  .p-selectbutton-wrapper {
+    display: flex;
+    gap: 0.5rem;
+  }
+}
+
+h2.mt {
+  margin-top: 1.5rem;
 }
 
 .grid-contato {

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -16,7 +16,7 @@ import { AuthService } from "../../../../core/services/auth.service";
 import { ResponsavelService } from "../../../../core/services/responsavel.service";
 import { ChurchesService } from "../../../../core/services/churches.service";
 import { LoggerService } from "../../../../core/services/logger.service";
-import { MetricasIgreja, Circunscricao, CapelaComunidade } from "../../../../core/interfaces/responsavel.interface";
+import { MetricasIgreja, Circunscricao, CapelaComunidade, CircunscricaoOpcao } from "../../../../core/interfaces/responsavel.interface";
 import { STATES } from "../../../../core/constants/states";
 
 const REDES = [
@@ -90,9 +90,17 @@ export class EditarIgrejaComponent implements OnInit {
   /** Cards de métricas (últimos 30 dias). */
   metricas: MetricasIgreja | null = null;
 
-  /** Fase 2 (só leitura): diocese/arquidiocese efetiva + capelas/comunidades da paróquia. */
+  /** Diocese/arquidiocese efetiva + capelas/comunidades da paróquia. */
   circunscricao: Circunscricao | null = null;
   capelasComunidades: CapelaComunidade[] = [];
+
+  /** Fase 3: seleção editável de diocese/arquidiocese. */
+  dioceses: CircunscricaoOpcao[] = [];
+  arquidioceses: CircunscricaoOpcao[] = [];
+  tipoCircunscricao: "diocese" | "arquidiocese" = "diocese";
+  dioceseSelecionada: number | null = null;
+  arquidioceseSelecionada: number | null = null;
+  salvandoCircunscricao = false;
 
   /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
   private _localidadeOriginal = "";
@@ -148,6 +156,42 @@ export class EditarIgrejaComponent implements OnInit {
       next: (m) => (this.metricas = m),
       error: () => {}, // cards são informativos — falha não bloqueia a edição
     });
+    this._responsavel.listarDioceses().subscribe({
+      next: (lista) => (this.dioceses = lista),
+      error: () => {},
+    });
+    this._responsavel.listarArquidioceses().subscribe({
+      next: (lista) => (this.arquidioceses = lista),
+      error: () => {},
+    });
+  }
+
+  salvarCircunscricao(): void {
+    const dioceseId = this.tipoCircunscricao === "diocese" ? this.dioceseSelecionada : null;
+    const arquidioceseId = this.tipoCircunscricao === "arquidiocese" ? this.arquidioceseSelecionada : null;
+
+    if (!dioceseId && !arquidioceseId) {
+      this._message.add({ severity: "warn", summary: "Selecione uma opção", detail: "Escolha uma diocese ou arquidiocese." });
+      return;
+    }
+
+    this.salvandoCircunscricao = true;
+    this._responsavel.atualizarCircunscricao(this.igrejaId, { dioceseId, arquidioceseId }).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Salvo", detail: mensagem });
+        this.salvandoCircunscricao = false;
+        this.carregar();
+      },
+      error: (error) => {
+        this.salvandoCircunscricao = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível salvar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:salvarCircunscricao");
+      },
+    });
   }
 
   carregar(): void {
@@ -188,6 +232,14 @@ export class EditarIgrejaComponent implements OnInit {
         this.imagemPreview = dados.imagemUrl ?? null;
         this.circunscricao = dados.circunscricao;
         this.capelasComunidades = dados.capelasComunidades ?? [];
+
+        if (dados.circunscricao?.dioceseId) {
+          this.tipoCircunscricao = "diocese";
+          this.dioceseSelecionada = dados.circunscricao.dioceseId;
+        } else if (dados.circunscricao?.arquidioceseId) {
+          this.tipoCircunscricao = "arquidiocese";
+          this.arquidioceseSelecionada = dados.circunscricao.arquidioceseId;
+        }
 
         this.isLoading = false;
       },


### PR DESCRIPTION
## Summary
- ⚠️ Empilhado sobre a Fase 2 (`feature/igreja-diocese-fase2-leitura-responsavel`, PR #145) — precisa mergear a Fase 2 primeiro.
- Depende do PR de Fase 3 do `buscamissa-api-public` (endpoint self-service).
- Tela "Editar Igreja" do responsável ganha um seletor editável (Diocese OU direto na Arquidiocese) com salvamento próprio, independente do form principal.

## Test plan
- [ ] Selecionar uma diocese e salvar → mensagem de sucesso, valor refletido após recarregar
- [ ] Trocar pra "Direto na Arquidiocese", selecionar e salvar → funciona
- [ ] Tentar salvar sem selecionar nada → aviso, sem chamar a API