### PR TITLE
Fase 4: responsável anexa/desanexa capelas da própria paróquia

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -110,6 +110,32 @@ export interface AtualizarCircunscricaoRequest {
   arquidioceseId?: number | null;
 }
 
+// ---- Fase 4 (capelas/comunidades órfãs) ----
+
+export interface CapelaOrfa {
+  id: number;
+  nome: string;
+  slug?: string | null;
+  uf?: string | null;
+  localidade?: string | null;
+  tipoIgreja: string;
+}
+
+export interface MinhaSolicitacaoVinculo {
+  id: number;
+  capelaId: number;
+  capelaNome: string;
+  /** "Pendente" | "Aprovado" | "Rejeitado" */
+  status: string;
+  dataSolicitacao: string;
+  motivoRevisao?: string | null;
+}
+
+export interface SolicitarVinculoCapelaRequest {
+  capelaId: number;
+  observacao?: string | null;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -9,6 +9,9 @@ import {
   MetricasIgreja,
   CircunscricaoOpcao,
   AtualizarCircunscricaoRequest,
+  CapelaOrfa,
+  MinhaSolicitacaoVinculo,
+  SolicitarVinculoCapelaRequest,
 } from "../interfaces/responsavel.interface";
 
 /**
@@ -96,6 +99,34 @@ export class ResponsavelService {
   atualizarCircunscricao(igrejaId: number, request: AtualizarCircunscricaoRequest): Observable<string> {
     return this.http
       .put<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${igrejaId}/diocese`, request)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  /** Fase 4: busca capelas/comunidades sem paróquia-pai (candidatas a vínculo), por nome. */
+  buscarCapelasOrfas(q: string): Observable<CapelaOrfa[]> {
+    return this.http
+      .get<{ data: CapelaOrfa[] }>("v1/responsavel/capelas-orfas", { params: { q } })
+      .pipe(map((r) => r.data));
+  }
+
+  /** Fase 4: minhas solicitações de vínculo (qualquer status) — evita pedido duplicado. */
+  minhasSolicitacoesVinculo(): Observable<MinhaSolicitacaoVinculo[]> {
+    return this.http
+      .get<{ data: MinhaSolicitacaoVinculo[] }>("v1/responsavel/minhas-solicitacoes-vinculo")
+      .pipe(map((r) => r.data));
+  }
+
+  /** Fase 4: solicita vínculo de uma capela órfã à paróquia (passa por aprovação do admin). */
+  solicitarVinculoCapela(paroquiaId: number, request: SolicitarVinculoCapelaRequest): Observable<string> {
+    return this.http
+      .post<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${paroquiaId}/solicitar-capela`, request)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  /** Fase 4: desanexa uma capela já vinculada à própria paróquia (self-service). */
+  desanexarCapela(capelaId: number): Observable<string> {
+    return this.http
+      .delete<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${capelaId}/vinculo-paroquia`)
       .pipe(map((r) => r.data.mensagemTela));
   }
 }

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -92,9 +92,42 @@
       <ng-container *ngIf="capelasComunidades.length">
         <h2 class="mt"><i class="pi pi-building"></i> Capelas / comunidades</h2>
         <ul class="lista-capelas">
-          <li *ngFor="let c of capelasComunidades">{{ c.nome }} <span class="texto-auxiliar">({{ c.tipoIgreja }})</span></li>
+          <li *ngFor="let c of capelasComunidades" class="item-capela">
+            <span>{{ c.nome }} <span class="texto-auxiliar">({{ c.tipoIgreja }})</span></span>
+            <button pButton type="button" label="Desanexar" icon="pi pi-times"
+                    class="p-button-sm p-button-text p-button-danger" [loading]="desanexandoCapelaId === c.id"
+                    (click)="desanexarCapela(c)"></button>
+          </li>
         </ul>
       </ng-container>
+
+      <!-- Fase 4: anexar/requerer capela órfã (passa por aprovação do admin) -->
+      <h2 class="mt"><i class="pi pi-search"></i> Anexar capela/comunidade órfã</h2>
+      <p class="texto-auxiliar">
+        Busque uma capela ou comunidade que ainda não pertence a nenhuma paróquia. O pedido passa por aprovação do admin.
+      </p>
+      <div class="busca-capela-orfa">
+        <input pInputText type="text" placeholder="Nome da capela/comunidade (mín. 3 letras)"
+               [(ngModel)]="buscaCapelaOrfa" [ngModelOptions]="{standalone: true}"
+               (keyup.enter)="buscarCapelaOrfa()" />
+        <button pButton type="button" label="Buscar" icon="pi pi-search" class="p-button-sm"
+                [loading]="buscandoCapelaOrfa" (click)="buscarCapelaOrfa()"></button>
+      </div>
+
+      <ul class="lista-capelas" *ngIf="resultadosCapelaOrfa.length">
+        <li *ngFor="let c of resultadosCapelaOrfa" class="item-capela">
+          <span>
+            {{ c.nome }}
+            <span class="texto-auxiliar">({{ c.tipoIgreja }}{{ c.localidade ? ' — ' + c.localidade + '/' + c.uf : '' }})</span>
+          </span>
+          <button pButton type="button"
+                  [label]="jaSolicitouCapela(c.id) ? 'Solicitação pendente' : 'Solicitar vínculo'"
+                  icon="pi pi-link" class="p-button-sm"
+                  [disabled]="jaSolicitouCapela(c.id)"
+                  [loading]="solicitandoCapelaId === c.id"
+                  (click)="solicitarVinculoCapela(c)"></button>
+        </li>
+      </ul>
     </section>
 
     <!-- IMAGEM -->

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -80,6 +80,24 @@ h2.mt {
   margin-top: 1.5rem;
 }
 
+.item-capela {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.busca-capela-orfa {
+  display: flex;
+  gap: 0.5rem;
+  max-width: 480px;
+  margin-bottom: 0.75rem;
+
+  input {
+    flex: 1;
+  }
+}
+
 .grid-contato {
   display: grid;
   grid-template-columns: 90px 1fr 90px 1fr;

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -16,7 +16,7 @@ import { AuthService } from "../../../../core/services/auth.service";
 import { ResponsavelService } from "../../../../core/services/responsavel.service";
 import { ChurchesService } from "../../../../core/services/churches.service";
 import { LoggerService } from "../../../../core/services/logger.service";
-import { MetricasIgreja, Circunscricao, CapelaComunidade, CircunscricaoOpcao } from "../../../../core/interfaces/responsavel.interface";
+import { MetricasIgreja, Circunscricao, CapelaComunidade, CircunscricaoOpcao, CapelaOrfa, MinhaSolicitacaoVinculo } from "../../../../core/interfaces/responsavel.interface";
 import { STATES } from "../../../../core/constants/states";
 
 const REDES = [
@@ -102,6 +102,14 @@ export class EditarIgrejaComponent implements OnInit {
   arquidioceseSelecionada: number | null = null;
   salvandoCircunscricao = false;
 
+  /** Fase 4: anexar/desanexar capelas/comunidades órfãs. */
+  buscaCapelaOrfa = "";
+  resultadosCapelaOrfa: CapelaOrfa[] = [];
+  buscandoCapelaOrfa = false;
+  solicitandoCapelaId: number | null = null;
+  minhasSolicitacoesVinculo: MinhaSolicitacaoVinculo[] = [];
+  desanexandoCapelaId: number | null = null;
+
   /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
   private _localidadeOriginal = "";
   private _ufOriginal = "";
@@ -163,6 +171,76 @@ export class EditarIgrejaComponent implements OnInit {
     this._responsavel.listarArquidioceses().subscribe({
       next: (lista) => (this.arquidioceses = lista),
       error: () => {},
+    });
+    this._carregarMinhasSolicitacoesVinculo();
+  }
+
+  private _carregarMinhasSolicitacoesVinculo(): void {
+    this._responsavel.minhasSolicitacoesVinculo().subscribe({
+      next: (lista) => (this.minhasSolicitacoesVinculo = lista),
+      error: () => {},
+    });
+  }
+
+  /** True quando já existe solicitação pendente para esta capela (evita duplicar). */
+  jaSolicitouCapela(capelaId: number): boolean {
+    return this.minhasSolicitacoesVinculo.some((s) => s.capelaId === capelaId && s.status === "Pendente");
+  }
+
+  buscarCapelaOrfa(): void {
+    if (this.buscaCapelaOrfa.trim().length < 3) {
+      this.resultadosCapelaOrfa = [];
+      return;
+    }
+    this.buscandoCapelaOrfa = true;
+    this._responsavel.buscarCapelasOrfas(this.buscaCapelaOrfa.trim()).subscribe({
+      next: (lista) => {
+        this.resultadosCapelaOrfa = lista;
+        this.buscandoCapelaOrfa = false;
+      },
+      error: () => {
+        this.buscandoCapelaOrfa = false;
+      },
+    });
+  }
+
+  solicitarVinculoCapela(capela: CapelaOrfa): void {
+    this.solicitandoCapelaId = capela.id;
+    this._responsavel.solicitarVinculoCapela(this.igrejaId, { capelaId: capela.id }).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Solicitação enviada", detail: mensagem });
+        this.solicitandoCapelaId = null;
+        this._carregarMinhasSolicitacoesVinculo();
+      },
+      error: (error) => {
+        this.solicitandoCapelaId = null;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível solicitar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:solicitarVinculoCapela");
+      },
+    });
+  }
+
+  desanexarCapela(capela: CapelaComunidade): void {
+    this.desanexandoCapelaId = capela.id;
+    this._responsavel.desanexarCapela(capela.id).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Desanexada", detail: mensagem });
+        this.desanexandoCapelaId = null;
+        this.capelasComunidades = this.capelasComunidades.filter((c) => c.id !== capela.id);
+      },
+      error: (error) => {
+        this.desanexandoCapelaId = null;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível desanexar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:desanexarCapela");
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- Depende do PR de Fase 4 do `buscamissa-api-public`.
- Painel "Editar Igreja": botão "Desanexar" em cada capela/comunidade já vinculada.
- Nova seção "Anexar capela/comunidade órfã": busca por nome + botão "Solicitar vínculo" por resultado, desabilitado quando já existe solicitação pendente para aquela capela (consulta `minhas-solicitacoes-vinculo`).

## Test plan
- [ ] Desanexar uma capela → some da lista, mensagem de sucesso
- [ ] Buscar capela órfã por nome (3+ letras) → lista resultados
- [ ] Solicitar vínculo → mensagem de sucesso, botão vira "Solicitação pendente" (desabilitado) ao reabrir a busca