### PR TITLE
Vínculo Igreja-Diocese: melhorias de UX (feedback)

### DIFF
--- a/src/app/core/interfaces/church.interface.ts
+++ b/src/app/core/interfaces/church.interface.ts
@@ -36,6 +36,14 @@ export interface Church {
   tipoIgreja?: TipoIgreja;
   /** Paróquia-sede quando esta unidade é capela/comunidade; null para paróquias. */
   igrejaPaiId?: number | null;
+  /** Diocese/arquidiocese efetiva (direta ou herdada) — presente só no detalhe. */
+  circunscricao?: {
+    dioceseId?: number | null;
+    dioceseNome?: string | null;
+    arquidioceseId?: number | null;
+    arquidioceseNome?: string | null;
+    origem: string;
+  } | null;
 }
 
 export interface UpdateChurch {

--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -136,6 +136,12 @@ export interface SolicitarVinculoCapelaRequest {
   observacao?: string | null;
 }
 
+/** Variante reversa: a própria capela solicita vínculo com uma paróquia. */
+export interface SolicitarVinculoParoquiaRequest {
+  paroquiaId: number;
+  observacao?: string | null;
+}
+
 export interface DadosEdicao {
   igrejaId: number;
   igrejaNome: string;
@@ -147,6 +153,8 @@ export interface DadosEdicao {
   sessoes: SessaoEdicao[];
   circunscricao: Circunscricao;
   capelasComunidades: CapelaComunidade[];
+  /** "Paroquia" | "Capela" | "Comunidade" | "Santuario" | "Outro" — decide a direção do vínculo. */
+  tipoIgreja: string;
 }
 
 export interface EditarDadosRequest {

--- a/src/app/core/services/responsavel.service.ts
+++ b/src/app/core/services/responsavel.service.ts
@@ -12,6 +12,7 @@ import {
   CapelaOrfa,
   MinhaSolicitacaoVinculo,
   SolicitarVinculoCapelaRequest,
+  SolicitarVinculoParoquiaRequest,
 } from "../interfaces/responsavel.interface";
 
 /**
@@ -102,11 +103,39 @@ export class ResponsavelService {
       .pipe(map((r) => r.data.mensagemTela));
   }
 
-  /** Fase 4: busca capelas/comunidades sem paróquia-pai (candidatas a vínculo), por nome. */
-  buscarCapelasOrfas(q: string): Observable<CapelaOrfa[]> {
+  /** Remove o vínculo direto de diocese/arquidiocese (self-service). */
+  desvincularCircunscricao(igrejaId: number): Observable<string> {
     return this.http
-      .get<{ data: CapelaOrfa[] }>("v1/responsavel/capelas-orfas", { params: { q } })
+      .delete<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${igrejaId}/diocese`)
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  /** Não achou a diocese/arquidiocese na lista — abre solicitação pro admin cadastrar. */
+  solicitarCircunscricao(mensagem: string): Observable<string> {
+    return this.http
+      .post<{ data: { mensagemTela: string } }>("v1/responsavel/solicitar-circunscricao", { mensagem })
+      .pipe(map((r) => r.data.mensagemTela));
+  }
+
+  /** Fase 4: busca capelas/comunidades sem paróquia-pai (candidatas a vínculo), por nome, restrito à UF. */
+  buscarCapelasOrfas(uf: string, q: string): Observable<CapelaOrfa[]> {
+    return this.http
+      .get<{ data: CapelaOrfa[] }>("v1/responsavel/capelas-orfas", { params: { uf, q } })
       .pipe(map((r) => r.data));
+  }
+
+  /** Fase 4 (reversa): busca paróquias por nome, restrito à UF — usado quando quem edita é a capela. */
+  buscarParoquias(uf: string, q: string): Observable<CapelaOrfa[]> {
+    return this.http
+      .get<{ data: CapelaOrfa[] }>("v1/responsavel/paroquias", { params: { uf, q } })
+      .pipe(map((r) => r.data));
+  }
+
+  /** Fase 4 (reversa): a própria capela solicita vínculo com uma paróquia. */
+  solicitarVinculoParoquia(capelaId: number, request: SolicitarVinculoParoquiaRequest): Observable<string> {
+    return this.http
+      .post<{ data: { mensagemTela: string } }>(`v1/responsavel/igreja/${capelaId}/solicitar-paroquia`, request)
+      .pipe(map((r) => r.data.mensagemTela));
   }
 
   /** Fase 4: minhas solicitações de vínculo (qualquer status) — evita pedido duplicado. */

--- a/src/app/modules/public/home/details/sections/details-header/details-header.component.html
+++ b/src/app/modules/public/home/details/sections/details-header/details-header.component.html
@@ -31,6 +31,14 @@
       <i class="pi pi-user text-gray-400 shrink-0"></i>
       {{ igreja.paroco }}
     </p>
+    <p *ngIf="igreja.circunscricao?.dioceseNome || igreja.circunscricao?.arquidioceseNome"
+       class="flex items-center gap-1.5 text-sm text-gray-500">
+      <i class="pi pi-sitemap text-gray-400 shrink-0"></i>
+      <ng-container *ngIf="igreja.circunscricao?.dioceseNome; else soArquidiocese">
+        Diocese de {{ igreja.circunscricao?.dioceseNome }}
+      </ng-container>
+      <ng-template #soArquidiocese>Arquidiocese de {{ igreja.circunscricao?.arquidioceseNome }}</ng-template>
+    </p>
     <div *ngIf="proximaMissa">
       <app-confidence-badge [mass]="proximaMissa" />
     </div>

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -54,7 +54,7 @@
       </div>
     </section>
 
-    <!-- DIOCESE/ARQUIDIOCESE (Fase 3: editável) + CAPELAS/COMUNIDADES (só leitura) -->
+    <!-- DIOCESE/ARQUIDIOCESE (editável) + CAPELAS/COMUNIDADES / PARÓQUIA (vínculo) -->
     <section class="bloco">
       <h2><i class="pi pi-sitemap"></i> Circunscrição eclesiástica</h2>
 
@@ -78,19 +78,40 @@
         </div>
 
         <p-select *ngIf="tipoCircunscricao === 'diocese'" [options]="dioceses" [(ngModel)]="dioceseSelecionada"
-                  [ngModelOptions]="{standalone: true}" optionLabel="nome" optionValue="id"
-                  placeholder="Selecione a diocese" styleClass="w-full" appendTo="body"></p-select>
+                  [ngModelOptions]="{standalone: true}" optionValue="id"
+                  [filter]="true" filterBy="nome,uf" placeholder="Digite para buscar a diocese"
+                  styleClass="w-full" appendTo="body">
+          <ng-template let-d pTemplate="item">{{ d.nome }} ({{ d.uf }})</ng-template>
+          <ng-template let-d pTemplate="selectedItem">{{ d.nome }} ({{ d.uf }})</ng-template>
+        </p-select>
         <p-select *ngIf="tipoCircunscricao === 'arquidiocese'" [options]="arquidioceses" [(ngModel)]="arquidioceseSelecionada"
-                  [ngModelOptions]="{standalone: true}" optionLabel="nome" optionValue="id"
-                  placeholder="Selecione a arquidiocese" styleClass="w-full" appendTo="body"></p-select>
+                  [ngModelOptions]="{standalone: true}" optionValue="id"
+                  [filter]="true" filterBy="nome,uf" placeholder="Digite para buscar a arquidiocese"
+                  styleClass="w-full" appendTo="body">
+          <ng-template let-a pTemplate="item">{{ a.nome }} ({{ a.uf }})</ng-template>
+          <ng-template let-a pTemplate="selectedItem">{{ a.nome }} ({{ a.uf }})</ng-template>
+        </p-select>
 
-        <button pButton type="button" label="Salvar circunscrição" icon="pi pi-check"
-                class="p-button-sm" [loading]="salvandoCircunscricao"
-                (click)="salvarCircunscricao()"></button>
+        <div class="circunscricao-acoes">
+          <button pButton type="button" label="Salvar circunscrição" icon="pi pi-check"
+                  class="p-button-sm" [loading]="salvandoCircunscricao"
+                  (click)="salvarCircunscricao()"></button>
+          <button *ngIf="circunscricao?.origem === 'Direta'" pButton type="button" label="Desvincular" icon="pi pi-times"
+                  class="p-button-sm p-button-outlined p-button-danger" [loading]="salvandoCircunscricao"
+                  (click)="desvincularCircunscricao()"></button>
+        </div>
+
+        <p class="texto-auxiliar">
+          Não achou a diocese/arquidiocese?
+          <a href="javascript:void(0)" (click)="abrirSolicitarCircunscricao()">Solicitar cadastro ao admin</a>.
+        </p>
       </div>
+    </section>
 
-      <ng-container *ngIf="capelasComunidades.length">
-        <h2 class="mt"><i class="pi pi-building"></i> Capelas / comunidades</h2>
+    <!-- CAPELAS/COMUNIDADES (só paróquia) ou PARÓQUIA-SEDE (só capela/comunidade) -->
+    <section class="bloco">
+      <ng-container *ngIf="ehParoquia && capelasComunidades.length">
+        <h2><i class="pi pi-building"></i> Capelas / comunidades</h2>
         <ul class="lista-capelas">
           <li *ngFor="let c of capelasComunidades" class="item-capela">
             <span>{{ c.nome }} <span class="texto-auxiliar">({{ c.tipoIgreja }})</span></span>
@@ -101,13 +122,19 @@
         </ul>
       </ng-container>
 
-      <!-- Fase 4: anexar/requerer capela órfã (passa por aprovação do admin) -->
-      <h2 class="mt"><i class="pi pi-search"></i> Anexar capela/comunidade órfã</h2>
+      <!-- Anexar/requerer vínculo (passa por aprovação do admin) -->
+      <h2 [class.mt]="ehParoquia && capelasComunidades.length"><i class="pi pi-search"></i> {{ tituloBuscaVinculo }}</h2>
       <p class="texto-auxiliar">
-        Busque uma capela ou comunidade que ainda não pertence a nenhuma paróquia. O pedido passa por aprovação do admin.
+        <ng-container *ngIf="ehParoquia; else textoCapela">
+          Busque uma capela ou comunidade que ainda não pertence a nenhuma paróquia. O pedido passa por aprovação do admin.
+        </ng-container>
+        <ng-template #textoCapela>
+          Busque a paróquia à qual esta capela/comunidade pertence. O pedido passa por aprovação do admin.
+        </ng-template>
       </p>
       <div class="busca-capela-orfa">
-        <input pInputText type="text" placeholder="Nome da capela/comunidade (mín. 3 letras)"
+        <input pInputText type="text"
+               [placeholder]="ehParoquia ? 'Nome da capela/comunidade (mín. 3 letras)' : 'Nome da paróquia (mín. 3 letras)'"
                [(ngModel)]="buscaCapelaOrfa" [ngModelOptions]="{standalone: true}"
                (keyup.enter)="buscarCapelaOrfa()" />
         <button pButton type="button" label="Buscar" icon="pi pi-search" class="p-button-sm"
@@ -129,6 +156,17 @@
         </li>
       </ul>
     </section>
+
+    <p-dialog header="Solicitar cadastro de diocese/arquidiocese" [(visible)]="mostrarSolicitarCircunscricao" [modal]="true" [style]="{width: '28rem', maxWidth: '92vw'}">
+      <p class="texto-auxiliar">Descreva o nome e a UF da diocese/arquidiocese que não está na lista. Nossa equipe vai analisar e cadastrar.</p>
+      <textarea pTextarea rows="4" style="width: 100%" [(ngModel)]="mensagemSolicitarCircunscricao"
+                [ngModelOptions]="{standalone: true}" placeholder="Ex.: Diocese de Exemplo, SP"></textarea>
+      <ng-template pTemplate="footer">
+        <button pButton type="button" label="Cancelar" class="p-button-text" (click)="mostrarSolicitarCircunscricao = false"></button>
+        <button pButton type="button" label="Enviar" icon="pi pi-send" [loading]="enviandoSolicitarCircunscricao"
+                [disabled]="!mensagemSolicitarCircunscricao.trim()" (click)="enviarSolicitarCircunscricao()"></button>
+      </ng-template>
+    </p-dialog>
 
     <!-- IMAGEM -->
     <section class="bloco">

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.scss
@@ -74,6 +74,17 @@ h1 {
     display: flex;
     gap: 0.5rem;
   }
+
+  .circunscricao-acoes {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  a {
+    color: var(--p-primary-color, #2563eb);
+    cursor: pointer;
+  }
 }
 
 h2.mt {

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -102,13 +102,24 @@ export class EditarIgrejaComponent implements OnInit {
   arquidioceseSelecionada: number | null = null;
   salvandoCircunscricao = false;
 
-  /** Fase 4: anexar/desanexar capelas/comunidades órfãs. */
+  /** "Paroquia" | "Capela" | "Comunidade" | "Santuario" | "Outro" — decide a direção do vínculo. */
+  tipoIgreja = "Paroquia";
+  get ehParoquia(): boolean {
+    return this.tipoIgreja === "Paroquia";
+  }
+
+  /** Fase 4: anexar/desanexar capelas/comunidades (ou, se for capela, buscar a própria paróquia). */
   buscaCapelaOrfa = "";
   resultadosCapelaOrfa: CapelaOrfa[] = [];
   buscandoCapelaOrfa = false;
   solicitandoCapelaId: number | null = null;
   minhasSolicitacoesVinculo: MinhaSolicitacaoVinculo[] = [];
   desanexandoCapelaId: number | null = null;
+
+  /** Solicitação de cadastro de diocese/arquidiocese que não está na lista. */
+  mostrarSolicitarCircunscricao = false;
+  mensagemSolicitarCircunscricao = "";
+  enviandoSolicitarCircunscricao = false;
 
   /** Cidade/UF originais — usado para exibir o aviso só quando o usuário muda. */
   private _localidadeOriginal = "";
@@ -187,13 +198,25 @@ export class EditarIgrejaComponent implements OnInit {
     return this.minhasSolicitacoesVinculo.some((s) => s.capelaId === capelaId && s.status === "Pendente");
   }
 
+  /** UF da própria igreja (form já preenchido) — restringe a busca, evita varrer a base nacional. */
+  private get _uf(): string {
+    return (this.form.get("endereco.uf")?.value ?? "").trim();
+  }
+
   buscarCapelaOrfa(): void {
     if (this.buscaCapelaOrfa.trim().length < 3) {
       this.resultadosCapelaOrfa = [];
       return;
     }
+    if (!this._uf) {
+      this._message.add({ severity: "warn", summary: "UF não definida", detail: "Preencha o endereço da igreja antes de buscar." });
+      return;
+    }
     this.buscandoCapelaOrfa = true;
-    this._responsavel.buscarCapelasOrfas(this.buscaCapelaOrfa.trim()).subscribe({
+    const busca$ = this.ehParoquia
+      ? this._responsavel.buscarCapelasOrfas(this._uf, this.buscaCapelaOrfa.trim())
+      : this._responsavel.buscarParoquias(this._uf, this.buscaCapelaOrfa.trim());
+    busca$.subscribe({
       next: (lista) => {
         this.resultadosCapelaOrfa = lista;
         this.buscandoCapelaOrfa = false;
@@ -204,9 +227,17 @@ export class EditarIgrejaComponent implements OnInit {
     });
   }
 
-  solicitarVinculoCapela(capela: CapelaOrfa): void {
-    this.solicitandoCapelaId = capela.id;
-    this._responsavel.solicitarVinculoCapela(this.igrejaId, { capelaId: capela.id }).subscribe({
+  /** Nome da ação de busca, conforme a direção do vínculo. */
+  get tituloBuscaVinculo(): string {
+    return this.ehParoquia ? "Anexar capela/comunidade órfã" : "Anexar à paróquia";
+  }
+
+  solicitarVinculoCapela(alvo: CapelaOrfa): void {
+    this.solicitandoCapelaId = alvo.id;
+    const solicitar$ = this.ehParoquia
+      ? this._responsavel.solicitarVinculoCapela(this.igrejaId, { capelaId: alvo.id })
+      : this._responsavel.solicitarVinculoParoquia(this.igrejaId, { paroquiaId: alvo.id });
+    solicitar$.subscribe({
       next: (mensagem) => {
         this._message.add({ severity: "success", summary: "Solicitação enviada", detail: mensagem });
         this.solicitandoCapelaId = null;
@@ -220,6 +251,55 @@ export class EditarIgrejaComponent implements OnInit {
           detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
         });
         this._logger.logError(error, "editar-igreja:solicitarVinculoCapela");
+      },
+    });
+  }
+
+  desvincularCircunscricao(): void {
+    this.salvandoCircunscricao = true;
+    this._responsavel.desvincularCircunscricao(this.igrejaId).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Desvinculado", detail: mensagem });
+        this.salvandoCircunscricao = false;
+        this.dioceseSelecionada = null;
+        this.arquidioceseSelecionada = null;
+        this.carregar();
+      },
+      error: (error) => {
+        this.salvandoCircunscricao = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível desvincular",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:desvincularCircunscricao");
+      },
+    });
+  }
+
+  abrirSolicitarCircunscricao(): void {
+    this.mostrarSolicitarCircunscricao = true;
+    this.mensagemSolicitarCircunscricao = "";
+  }
+
+  enviarSolicitarCircunscricao(): void {
+    if (!this.mensagemSolicitarCircunscricao.trim()) return;
+
+    this.enviandoSolicitarCircunscricao = true;
+    this._responsavel.solicitarCircunscricao(this.mensagemSolicitarCircunscricao.trim()).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Solicitação enviada", detail: mensagem });
+        this.enviandoSolicitarCircunscricao = false;
+        this.mostrarSolicitarCircunscricao = false;
+      },
+      error: (error) => {
+        this.enviandoSolicitarCircunscricao = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível enviar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:enviarSolicitarCircunscricao");
       },
     });
   }
@@ -310,6 +390,7 @@ export class EditarIgrejaComponent implements OnInit {
         this.imagemPreview = dados.imagemUrl ?? null;
         this.circunscricao = dados.circunscricao;
         this.capelasComunidades = dados.capelasComunidades ?? [];
+        this.tipoIgreja = dados.tipoIgreja ?? "Paroquia";
 
         if (dados.circunscricao?.dioceseId) {
           this.tipoCircunscricao = "diocese";


### PR DESCRIPTION
## Summary
- Depende do PR de mesma branch no `buscamissa-api-public`.
- Detalhe da igreja mostra diocese/arquidiocese no header.
- Meu Painel: dropdown pesquisável (`[filter]`), UF entre parênteses, botão "Desvincular", link de "solicitar cadastro" (modal), busca com UF, fluxo invertido pra capela (busca paróquia), seções separadas em cards pra melhorar o espaçamento.

## Test plan
- [ ] Página de detalhe de igreja com diocese vinculada mostra "Diocese de X"
- [ ] Meu Painel: buscar diocese digitando parte do nome funciona
- [ ] Desvincular remove o vínculo direto
- [ ] "Solicitar cadastro ao admin" abre modal, envia e fecha
- [ ] Editando uma capela (sem pai), a seção mostra "Anexar à paróquia" e busca paróquias