### PR TITLE
Fix: circunscrição eclesiástica - duplicação de texto e edição indevida em capela

### DIFF
--- a/src/app/modules/public/home/details/sections/details-header/details-header.component.html
+++ b/src/app/modules/public/home/details/sections/details-header/details-header.component.html
@@ -34,10 +34,7 @@
     <p *ngIf="igreja.circunscricao?.dioceseNome || igreja.circunscricao?.arquidioceseNome"
        class="flex items-center gap-1.5 text-sm text-gray-500">
       <i class="pi pi-sitemap text-gray-400 shrink-0"></i>
-      <ng-container *ngIf="igreja.circunscricao?.dioceseNome; else soArquidiocese">
-        Diocese de {{ igreja.circunscricao?.dioceseNome }}
-      </ng-container>
-      <ng-template #soArquidiocese>Arquidiocese de {{ igreja.circunscricao?.arquidioceseNome }}</ng-template>
+      {{ igreja.circunscricao?.dioceseNome || igreja.circunscricao?.arquidioceseNome }}
     </p>
     <div *ngIf="proximaMissa">
       <app-confidence-badge [mass]="proximaMissa" />

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -59,17 +59,23 @@
       <h2><i class="pi pi-sitemap"></i> Circunscrição eclesiástica</h2>
 
       <p *ngIf="circunscricao?.dioceseNome" class="texto-atual">
-        Diocese: <strong>{{ circunscricao?.dioceseNome }}</strong>
+        {{ circunscricao?.dioceseNome }}
         <span *ngIf="circunscricao?.arquidioceseNome"> (Arquidiocese: {{ circunscricao?.arquidioceseNome }})</span>
       </p>
       <p *ngIf="!circunscricao?.dioceseNome && circunscricao?.arquidioceseNome" class="texto-atual">
-        Arquidiocese: <strong>{{ circunscricao?.arquidioceseNome }}</strong>
+        {{ circunscricao?.arquidioceseNome }}
       </p>
-      <p *ngIf="circunscricao?.origem === 'Herdada'" class="texto-auxiliar">
-        Herdada da paróquia-sede — salvar aqui cria um vínculo direto só para esta unidade.
+      <p *ngIf="!circunscricao?.dioceseNome && !circunscricao?.arquidioceseNome" class="texto-auxiliar">
+        Nenhuma diocese/arquidiocese vinculada ainda.
       </p>
 
-      <div class="circunscricao-form">
+      <!-- Capela/comunidade: só herda da paróquia-sede, não edita aqui. -->
+      <p *ngIf="!ehParoquia" class="texto-auxiliar">
+        {{ circunscricao?.origem === 'Herdada' ? 'Herdada da paróquia-sede.' : 'Capelas/comunidades herdam a circunscrição da paróquia-sede.' }}
+      </p>
+
+      <!-- Paróquia: pode editar diretamente. -->
+      <div class="circunscricao-form" *ngIf="ehParoquia">
         <div class="p-selectbutton-wrapper">
           <button pButton type="button" label="Diocese" (click)="tipoCircunscricao = 'diocese'"
                   class="p-button-sm" [ngClass]="{'p-button-outlined': tipoCircunscricao !== 'diocese'}"></button>


### PR DESCRIPTION
## Summary
- Detalhe público: remove prefixo hardcoded "Diocese de"/"Arquidiocese de" que duplicava o nome (o cadastro já guarda o nome oficial completo).
- Meu Painel: capela/comunidade não mostra mais o formulário de edição de circunscrição — só o texto informativo de que é herdada da paróquia-sede.

## Test plan
- [ ] Detalhe de igreja com diocese vinculada mostra o nome uma única vez
- [ ] Editando uma capela/comunidade, não aparece seletor/botão de salvar circunscrição — só texto "herdada"