### PR TITLE
Fix: Meu Painel esconde busca de paróquia quando já vinculada

### DIFF
--- a/src/app/core/interfaces/responsavel.interface.ts
+++ b/src/app/core/interfaces/responsavel.interface.ts
@@ -155,6 +155,8 @@ export interface DadosEdicao {
   capelasComunidades: CapelaComunidade[];
   /** "Paroquia" | "Capela" | "Comunidade" | "Santuario" | "Outro" — decide a direção do vínculo. */
   tipoIgreja: string;
+  /** Paróquia-sede desta capela/comunidade, se já vinculada. Null = ainda órfã. */
+  paroquiaSede?: { id: number; nome: string } | null;
 }
 
 export interface EditarDadosRequest {

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.html
@@ -128,7 +128,21 @@
         </ul>
       </ng-container>
 
-      <!-- Anexar/requerer vínculo (passa por aprovação do admin) -->
+      <!-- Capela/comunidade já vinculada a uma paróquia: mostra e permite desanexar, sem busca. -->
+      <ng-container *ngIf="!ehParoquia && paroquiaSede">
+        <h2><i class="pi pi-building"></i> Paróquia vinculada</h2>
+        <ul class="lista-capelas">
+          <li class="item-capela">
+            <span>{{ paroquiaSede.nome }}</span>
+            <button pButton type="button" label="Desanexar" icon="pi pi-times"
+                    class="p-button-sm p-button-text p-button-danger" [loading]="desanexandoParoquiaSede"
+                    (click)="desanexarParoquiaSede()"></button>
+          </li>
+        </ul>
+      </ng-container>
+
+      <!-- Anexar/requerer vínculo (passa por aprovação do admin) — só quando ainda não vinculada. -->
+      <ng-container *ngIf="ehParoquia || !paroquiaSede">
       <h2 [class.mt]="ehParoquia && capelasComunidades.length"><i class="pi pi-search"></i> {{ tituloBuscaVinculo }}</h2>
       <p class="texto-auxiliar">
         <ng-container *ngIf="ehParoquia; else textoCapela">
@@ -161,6 +175,7 @@
                   (click)="solicitarVinculoCapela(c)"></button>
         </li>
       </ul>
+      </ng-container>
     </section>
 
     <p-dialog header="Solicitar cadastro de diocese/arquidiocese" [(visible)]="mostrarSolicitarCircunscricao" [modal]="true" [style]="{width: '28rem', maxWidth: '92vw'}">

--- a/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
+++ b/src/app/modules/public/meu-painel/editar-igreja/editar-igreja.component.ts
@@ -108,6 +108,10 @@ export class EditarIgrejaComponent implements OnInit {
     return this.tipoIgreja === "Paroquia";
   }
 
+  /** Paróquia-sede desta capela/comunidade, se já vinculada. Null = ainda órfã (mostra busca/solicitação). */
+  paroquiaSede: { id: number; nome: string } | null = null;
+  desanexandoParoquiaSede = false;
+
   /** Fase 4: anexar/desanexar capelas/comunidades (ou, se for capela, buscar a própria paróquia). */
   buscaCapelaOrfa = "";
   resultadosCapelaOrfa: CapelaOrfa[] = [];
@@ -324,6 +328,27 @@ export class EditarIgrejaComponent implements OnInit {
     });
   }
 
+  /** Quando a igreja editada é a própria capela/comunidade já vinculada — desanexa a si mesma. */
+  desanexarParoquiaSede(): void {
+    this.desanexandoParoquiaSede = true;
+    this._responsavel.desanexarCapela(this.igrejaId).subscribe({
+      next: (mensagem) => {
+        this._message.add({ severity: "success", summary: "Desanexada", detail: mensagem });
+        this.desanexandoParoquiaSede = false;
+        this.paroquiaSede = null;
+      },
+      error: (error) => {
+        this.desanexandoParoquiaSede = false;
+        this._message.add({
+          severity: "error",
+          summary: "Não foi possível desanexar",
+          detail: error?.error?.data?.mensagemTela ?? "Tente novamente.",
+        });
+        this._logger.logError(error, "editar-igreja:desanexarParoquiaSede");
+      },
+    });
+  }
+
   salvarCircunscricao(): void {
     const dioceseId = this.tipoCircunscricao === "diocese" ? this.dioceseSelecionada : null;
     const arquidioceseId = this.tipoCircunscricao === "arquidiocese" ? this.arquidioceseSelecionada : null;
@@ -391,6 +416,7 @@ export class EditarIgrejaComponent implements OnInit {
         this.circunscricao = dados.circunscricao;
         this.capelasComunidades = dados.capelasComunidades ?? [];
         this.tipoIgreja = dados.tipoIgreja ?? "Paroquia";
+        this.paroquiaSede = dados.paroquiaSede ?? null;
 
         if (dados.circunscricao?.dioceseId) {
           this.tipoCircunscricao = "diocese";


### PR DESCRIPTION
## Summary
- Depende do PR de mesma branch no `buscamissa-api-public`.
- Capela/comunidade com `paroquiaSede` já definida mostra o nome da paróquia + botão "Desanexar", em vez do formulário de busca/solicitação (que continuava aparecendo mesmo depois do vínculo aprovado).

## Test plan
- [ ] Capela sem pai: mostra busca de paróquia
- [ ] Capela com pai (aprovado): mostra "Paróquia vinculada: X" + Desanexar, sem busca
- [ ] Desanexar volta a mostrar a busca