### PR TITLE
fix: mapear dropdown de tipo de igreja para o enum do backend

### DIFF
--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -29,7 +29,7 @@ import { LoggerService } from "../../../../../core/services/logger.service";
 
 interface TypeChurchOption {
   name: string;
-  value: string;
+  value: number;
 }
 
 @Component({
@@ -63,17 +63,13 @@ export class ChurchFormComponent implements OnInit, OnChanges {
   loading = false;
   imagePreview: string | null = null; // Só para exibir a imagem
 
+  // Espelha Enums/TipoIgrejaEnum.cs do backend — o banco persiste o int cru.
   typeChurchOptions: TypeChurchOption[] = [
-    { name: "Capela", value: "Capela" },
-    { name: "Comunidade", value: "Comunidade" },
-    { name: "Paróquia", value: "Paróquia" },
-    { name: "Santuário", value: "Santuário" },
-    { name: "Catedral", value: "Catedral" },
-    { name: "Basílica Maior", value: "Basílica Maior" },
-    { name: "Basílica Menor", value: "Basílica Menor" },
-    { name: "Arquidiocese", value: "Arquidiocese" },
-    { name: "Diocese", value: "Diocese" },
-    { name: "Outro", value: "" },
+    { name: "Paróquia", value: 1 },
+    { name: "Capela", value: 2 },
+    { name: "Comunidade", value: 3 },
+    { name: "Santuário", value: 4 },
+    { name: "Outro", value: 99 },
   ];
 
   diasSemana = [

--- a/src/app/modules/public/church/models/church.model.ts
+++ b/src/app/modules/public/church/models/church.model.ts
@@ -68,7 +68,7 @@ export interface ChurchApiData {
 // Modelo da Igreja para o Formulário (pode ter tipos diferentes, ex: Date para horário)
 export interface ChurchFormData {
   id?: number;
-  typeChurchValue?: string | null; // Campo separado para o tipo no form
+  typeChurchValue?: number | null; // Campo separado para o tipo no form (TipoIgrejaEnum)
   nomeIgreja: string; // Apenas o nome, sem o tipo
   nomeParoco: string;
   cep: string;

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -264,7 +264,8 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     const whatsappLimpo = formData.whatsapp?.replace(/\D/g, "") ?? "";
 
     const payload: Omit<ChurchApiData, "id"> = {
-      nome: `${formData.typeChurchValue} ${formData.nomeIgreja}`,
+      nome: formData.nomeIgreja,
+      tipoIgreja: formData.typeChurchValue ?? undefined,
       paroco: formData.nomeParoco,
       imagem: formData.imagem,
       missas: formData.missas?.map((missa: any) => ({


### PR DESCRIPTION
## Summary
- O dropdown "Tipo da Igreja" no cadastro tinha opções em texto livre ("Catedral", "Diocese", "Basílica Maior"...) que não existem no `TipoIgrejaEnum` do backend.
- O valor escolhido nunca era enviado como tipo — só concatenado como prefixo no nome da igreja (`"${tipo} ${nome}"`), então toda igreja criada caía no default do backend (Paroquia).
- Corrige as opções para os valores numéricos do enum (`Paroquia=1, Capela=2, Comunidade=3, Santuario=4, Outro=99`) e envia `tipoIgreja` no payload de criação.

Depende do PR correspondente em `buscamissa-api-public` que adiciona o campo `TipoIgreja` ao DTO de criação.

## Test plan
- [ ] `tsc --noEmit` (já validado localmente, sem erros novos)
- [ ] Cadastrar igreja pelo site escolhendo cada tipo do dropdown e conferir no admin que o tipo bate