### PR TITLE
fix: enviar token de sessão na criação de igreja e destacar igrejas pendentes no CEP

### DIFF
--- a/src/app/core/middleware/auth.interceptor.ts
+++ b/src/app/core/middleware/auth.interceptor.ts
@@ -10,13 +10,18 @@ export class AuthInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     // O JWT do usuário logado só tem papel Regular/Dono — só serve nas rotas
-    // do Responsável Verificado (api/v1/responsavel). Todo o resto do backend
-    // (busca de igreja, cadastro colaborativo etc.) exige role App/Admin, que
-    // só o token estático de config carrega. Usar o token de sessão fora de
-    // v1/responsavel derruba essas chamadas com 403 mesmo estando logado.
+    // do Responsável Verificado (api/v1/responsavel) e no cadastro de igreja
+    // (api/v1/Igreja, POST), que precisa saber se quem está criando é um
+    // Responsável logado (pula o fluxo de Controle/código validador — ver
+    // IgrejaEscritaController.CriarIgreja). Todo o resto do backend (busca de
+    // igreja, cadastro colaborativo etc.) exige role App/Admin, que só o token
+    // estático de config carrega. Usar o token de sessão fora dessas rotas
+    // derruba as chamadas com 403 mesmo estando logado.
     // req.url ainda é relativo aqui (AuthInterceptor roda antes do
     // ApiBaseUrlInterceptor, que só então prefixa a apiURL) — sem barra inicial.
-    const ehRotaDoResponsavel = req.url.includes('v1/responsavel/') || req.url.includes('v1/auth/');
+    const ehCriacaoDeIgreja = req.method === 'POST' && /^v1\/igreja\/?(\?.*)?$/i.test(req.url);
+    const ehRotaDoResponsavel =
+      req.url.includes('v1/responsavel/') || req.url.includes('v1/auth/') || ehCriacaoDeIgreja;
     const token = ehRotaDoResponsavel
       ? (this.authService.accessToken ?? environment.config.token)
       : environment.config.token;

--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -79,6 +79,10 @@ export class ChurchesService {
           nomeUnico?: string;
           slug?: string;
           endereco: { uf: string; cidadeSlug?: string };
+          /** "Ativa" (já validada) ou "EmProcesso" (aguardando código validador). */
+          status: "Ativa" | "EmProcesso";
+          /** Presente só quando status = "EmProcesso" — reenvio de validação. */
+          controleId?: number;
         }[];
         endereco: {
           cep: string;

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
@@ -22,20 +22,42 @@
       <div class="flex flex-col gap-3 py-1">
         <span class="font-medium">Já encontramos igreja(s) cadastrada(s) para este CEP. Confira se alguma é a sua:</span>
         <div class="flex flex-col gap-2">
-          <a
-            *ngFor="let igreja of igrejasDuplicadas"
-            [routerLink]="linkParoquia(igreja)"
-            target="_blank"
-            class="flex items-center justify-between gap-3 bg-white border border-surface-200 rounded-lg px-4 py-3 shadow-sm hover:shadow-md hover:border-primary transition-all no-underline"
-          >
-            <span class="flex items-center gap-2">
-              <i class="pi pi-map-marker text-primary"></i>
-              <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
-            </span>
-            <span class="flex items-center gap-1 text-sm text-primary font-medium shrink-0">
-              Ver detalhes <i class="pi pi-external-link text-xs"></i>
-            </span>
-          </a>
+          <ng-container *ngFor="let igreja of igrejasDuplicadas">
+            <!-- Em processo: ainda sem responsável/missas públicas, oferece retomar a validação em vez de ver detalhes -->
+            <div
+              *ngIf="igreja.status === 'EmProcesso'; else igrejaAtiva"
+              class="flex items-center justify-between gap-3 bg-amber-50 border border-amber-300 rounded-lg px-4 py-3 shadow-sm"
+            >
+              <span class="flex items-center gap-2">
+                <i class="pi pi-clock text-amber-600"></i>
+                <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
+                <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5">Cadastro em andamento</span>
+              </span>
+              <p-button
+                label="Retomar validação"
+                icon="pi pi-refresh"
+                size="small"
+                severity="warn"
+                [text]="true"
+                (click)="retomarValidacao(igreja.controleId!)"
+              ></p-button>
+            </div>
+            <ng-template #igrejaAtiva>
+              <a
+                [routerLink]="linkParoquia(igreja)"
+                target="_blank"
+                class="flex items-center justify-between gap-3 bg-white border border-surface-200 rounded-lg px-4 py-3 shadow-sm hover:shadow-md hover:border-primary transition-all no-underline"
+              >
+                <span class="flex items-center gap-2">
+                  <i class="pi pi-map-marker text-primary"></i>
+                  <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
+                </span>
+                <span class="flex items-center gap-1 text-sm text-primary font-medium shrink-0">
+                  Ver detalhes <i class="pi pi-external-link text-xs"></i>
+                </span>
+              </a>
+            </ng-template>
+          </ng-container>
         </div>
         <p-button
           label="Não é nenhuma destas - Informar uma Nova"

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -62,6 +62,8 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     nomeUnico?: string;
     slug?: string;
     endereco: { uf: string; cidadeSlug?: string };
+    status: "Ativa" | "EmProcesso";
+    controleId?: number;
   }[] = [];
   private enderecoPendente: any = null;
   // true depois que o usuário clica em "Não é nenhuma destas": vai no payload de
@@ -219,6 +221,13 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
         this.cd.markForCheck();
       },
     });
+  }
+
+  // Igreja "em processo" (Controle pendente) selecionada na lista do CEP: em vez
+  // de deixar o usuário criar uma duplicata, manda ele retomar a validação já
+  // existente daquela igreja (mesma tela usada logo após o cadastro).
+  retomarValidacao(controleId: number): void {
+    this.router.navigate(["/enviar-codigo", controleId]);
   }
 
   // Usuário confirmou, na lista de igrejas do CEP, que nenhuma delas é a sua —


### PR DESCRIPTION
## Summary

**BUG 01** — o `AuthInterceptor` só usava o token de sessão do usuário logado em rotas `v1/responsavel/*` e `v1/auth/*`. A criação de igreja (`POST v1/Igreja`) sempre ia com o token estático anônimo, então o backend nunca sabia que havia um usuário logado (mesmo o front já tratando esse caso na resposta). Agora `POST v1/Igreja` também usa o token de sessão quando disponível, caindo pro estático se anônimo.

**BUG 02 + melhoria** — a lista de igrejas do CEP (`consultarCep`) agora distingue `Status: "Ativa" | "EmProcesso"`. Igrejas em processo (cadastro pendente de validação) aparecem destacadas (cor âmbar, ícone de relógio, badge "Cadastro em andamento") com botão "Retomar validação", que navega para `/enviar-codigo/:controleId` — tela já existente, que reemite o código sem criar duplicata.

Depende do PR correspondente em `buscamissa-api-public` (retorno de `Status`/`ControleId` no `consultar-cep` e branch de criação por usuário logado).

## Test plan
- [ ] `tsc --noEmit` (já validado localmente, sem erros novos)
- [ ] Cadastrar igreja logado e conferir que vai direto pra página da igreja criada
- [ ] Cadastrar igreja anônimo e conferir que o fluxo de validação por email/desafio continua igual
- [ ] Consultar CEP 048954003 (DEV) e conferir o destaque da igreja em processo + botão de retomar validação