### PR TITLE
fix: revisar dados antes de continuar validação de igreja pendente

### DIFF
--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
@@ -34,12 +34,12 @@
                 <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5">Cadastro em andamento</span>
               </span>
               <p-button
-                label="Retomar validação"
-                icon="pi pi-refresh"
+                label="Revisar e continuar cadastro"
+                icon="pi pi-pencil"
                 size="small"
                 severity="warn"
                 [text]="true"
-                (click)="retomarValidacao(igreja.controleId!)"
+                (click)="revisarCadastroPendente(igreja.id)"
               ></p-button>
             </div>
             <ng-template #igrejaAtiva>

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -224,10 +224,12 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   }
 
   // Igreja "em processo" (Controle pendente) selecionada na lista do CEP: em vez
-  // de deixar o usuário criar uma duplicata, manda ele retomar a validação já
-  // existente daquela igreja (mesma tela usada logo após o cadastro).
-  retomarValidacao(controleId: number): void {
-    this.router.navigate(["/enviar-codigo", controleId]);
+  // de deixar o usuário criar uma duplicata, manda ele revisar/ajustar os dados
+  // já enviados (tela de edição) antes de seguir pra validação — o PUT de
+  // atualização reaproveita o mesmo Controle da criação e devolve o mesmo
+  // controleId, então a validação pendente não é perdida.
+  revisarCadastroPendente(igrejaId: number): void {
+    this.router.navigate(["/editar", igrejaId]);
   }
 
   // Usuário confirmou, na lista de igrejas do CEP, que nenhuma delas é a sua —


### PR DESCRIPTION
## Summary
- Follow-up do PR #153 (já mergeado).
- Ao clicar em uma igreja "em processo" na lista do CEP, agora leva para `/editar/{igrejaId}` (tela de edição já existente) em vez de ir direto pra validação — dá chance de ajustar os dados antes de continuar.
- O `PUT` de atualização reaproveita o mesmo `Controle`/`controleId` da criação original, então a validação pendente não é perdida.
- Botão renomeado de "Retomar validação" para "Revisar e continuar cadastro".

## Test plan
- [ ] `tsc --noEmit` (já validado localmente, sem erros novos)
- [ ] Consultar CEP com igreja em processo, clicar "Revisar e continuar cadastro", ajustar um campo e salvar — conferir que cai em `/enviar-codigo/:controleId` com o mesmo controleId de antes