### PR TITLE
Release: dropdown de tipo de igreja + fixes de criação/CEP pendente

### DIFF
--- a/src/app/core/middleware/auth.interceptor.ts
+++ b/src/app/core/middleware/auth.interceptor.ts
@@ -10,13 +10,18 @@ export class AuthInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     // O JWT do usuário logado só tem papel Regular/Dono — só serve nas rotas
-    // do Responsável Verificado (api/v1/responsavel). Todo o resto do backend
-    // (busca de igreja, cadastro colaborativo etc.) exige role App/Admin, que
-    // só o token estático de config carrega. Usar o token de sessão fora de
-    // v1/responsavel derruba essas chamadas com 403 mesmo estando logado.
+    // do Responsável Verificado (api/v1/responsavel) e no cadastro de igreja
+    // (api/v1/Igreja, POST), que precisa saber se quem está criando é um
+    // Responsável logado (pula o fluxo de Controle/código validador — ver
+    // IgrejaEscritaController.CriarIgreja). Todo o resto do backend (busca de
+    // igreja, cadastro colaborativo etc.) exige role App/Admin, que só o token
+    // estático de config carrega. Usar o token de sessão fora dessas rotas
+    // derruba as chamadas com 403 mesmo estando logado.
     // req.url ainda é relativo aqui (AuthInterceptor roda antes do
     // ApiBaseUrlInterceptor, que só então prefixa a apiURL) — sem barra inicial.
-    const ehRotaDoResponsavel = req.url.includes('v1/responsavel/') || req.url.includes('v1/auth/');
+    const ehCriacaoDeIgreja = req.method === 'POST' && /^v1\/igreja\/?(\?.*)?$/i.test(req.url);
+    const ehRotaDoResponsavel =
+      req.url.includes('v1/responsavel/') || req.url.includes('v1/auth/') || ehCriacaoDeIgreja;
     const token = ehRotaDoResponsavel
       ? (this.authService.accessToken ?? environment.config.token)
       : environment.config.token;

--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -79,6 +79,10 @@ export class ChurchesService {
           nomeUnico?: string;
           slug?: string;
           endereco: { uf: string; cidadeSlug?: string };
+          /** "Ativa" (já validada) ou "EmProcesso" (aguardando código validador). */
+          status: "Ativa" | "EmProcesso";
+          /** Presente só quando status = "EmProcesso" — reenvio de validação. */
+          controleId?: number;
         }[];
         endereco: {
           cep: string;

--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -29,7 +29,7 @@ import { LoggerService } from "../../../../../core/services/logger.service";
 
 interface TypeChurchOption {
   name: string;
-  value: string;
+  value: number;
 }
 
 @Component({
@@ -63,17 +63,13 @@ export class ChurchFormComponent implements OnInit, OnChanges {
   loading = false;
   imagePreview: string | null = null; // Só para exibir a imagem
 
+  // Espelha Enums/TipoIgrejaEnum.cs do backend — o banco persiste o int cru.
   typeChurchOptions: TypeChurchOption[] = [
-    { name: "Capela", value: "Capela" },
-    { name: "Comunidade", value: "Comunidade" },
-    { name: "Paróquia", value: "Paróquia" },
-    { name: "Santuário", value: "Santuário" },
-    { name: "Catedral", value: "Catedral" },
-    { name: "Basílica Maior", value: "Basílica Maior" },
-    { name: "Basílica Menor", value: "Basílica Menor" },
-    { name: "Arquidiocese", value: "Arquidiocese" },
-    { name: "Diocese", value: "Diocese" },
-    { name: "Outro", value: "" },
+    { name: "Paróquia", value: 1 },
+    { name: "Capela", value: 2 },
+    { name: "Comunidade", value: 3 },
+    { name: "Santuário", value: 4 },
+    { name: "Outro", value: 99 },
   ];
 
   diasSemana = [

--- a/src/app/modules/public/church/models/church.model.ts
+++ b/src/app/modules/public/church/models/church.model.ts
@@ -68,7 +68,7 @@ export interface ChurchApiData {
 // Modelo da Igreja para o Formulário (pode ter tipos diferentes, ex: Date para horário)
 export interface ChurchFormData {
   id?: number;
-  typeChurchValue?: string | null; // Campo separado para o tipo no form
+  typeChurchValue?: number | null; // Campo separado para o tipo no form (TipoIgrejaEnum)
   nomeIgreja: string; // Apenas o nome, sem o tipo
   nomeParoco: string;
   cep: string;

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
@@ -34,12 +34,12 @@
                 <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5">Cadastro em andamento</span>
               </span>
               <p-button
-                label="Retomar validação"
-                icon="pi pi-refresh"
+                label="Revisar e continuar cadastro"
+                icon="pi pi-pencil"
                 size="small"
                 severity="warn"
                 [text]="true"
-                (click)="retomarValidacao(igreja.controleId!)"
+                (click)="revisarCadastroPendente(igreja.id)"
               ></p-button>
             </div>
             <ng-template #igrejaAtiva>

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.html
@@ -22,20 +22,42 @@
       <div class="flex flex-col gap-3 py-1">
         <span class="font-medium">Já encontramos igreja(s) cadastrada(s) para este CEP. Confira se alguma é a sua:</span>
         <div class="flex flex-col gap-2">
-          <a
-            *ngFor="let igreja of igrejasDuplicadas"
-            [routerLink]="linkParoquia(igreja)"
-            target="_blank"
-            class="flex items-center justify-between gap-3 bg-white border border-surface-200 rounded-lg px-4 py-3 shadow-sm hover:shadow-md hover:border-primary transition-all no-underline"
-          >
-            <span class="flex items-center gap-2">
-              <i class="pi pi-map-marker text-primary"></i>
-              <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
-            </span>
-            <span class="flex items-center gap-1 text-sm text-primary font-medium shrink-0">
-              Ver detalhes <i class="pi pi-external-link text-xs"></i>
-            </span>
-          </a>
+          <ng-container *ngFor="let igreja of igrejasDuplicadas">
+            <!-- Em processo: ainda sem responsável/missas públicas, oferece retomar a validação em vez de ver detalhes -->
+            <div
+              *ngIf="igreja.status === 'EmProcesso'; else igrejaAtiva"
+              class="flex items-center justify-between gap-3 bg-amber-50 border border-amber-300 rounded-lg px-4 py-3 shadow-sm"
+            >
+              <span class="flex items-center gap-2">
+                <i class="pi pi-clock text-amber-600"></i>
+                <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
+                <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5">Cadastro em andamento</span>
+              </span>
+              <p-button
+                label="Retomar validação"
+                icon="pi pi-refresh"
+                size="small"
+                severity="warn"
+                [text]="true"
+                (click)="retomarValidacao(igreja.controleId!)"
+              ></p-button>
+            </div>
+            <ng-template #igrejaAtiva>
+              <a
+                [routerLink]="linkParoquia(igreja)"
+                target="_blank"
+                class="flex items-center justify-between gap-3 bg-white border border-surface-200 rounded-lg px-4 py-3 shadow-sm hover:shadow-md hover:border-primary transition-all no-underline"
+              >
+                <span class="flex items-center gap-2">
+                  <i class="pi pi-map-marker text-primary"></i>
+                  <span class="font-semibold text-gray-800">{{ igreja.nome }}</span>
+                </span>
+                <span class="flex items-center gap-1 text-sm text-primary font-medium shrink-0">
+                  Ver detalhes <i class="pi pi-external-link text-xs"></i>
+                </span>
+              </a>
+            </ng-template>
+          </ng-container>
         </div>
         <p-button
           label="Não é nenhuma destas - Informar uma Nova"

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -264,7 +264,8 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     const whatsappLimpo = formData.whatsapp?.replace(/\D/g, "") ?? "";
 
     const payload: Omit<ChurchApiData, "id"> = {
-      nome: `${formData.typeChurchValue} ${formData.nomeIgreja}`,
+      nome: formData.nomeIgreja,
+      tipoIgreja: formData.typeChurchValue ?? undefined,
       paroco: formData.nomeParoco,
       imagem: formData.imagem,
       missas: formData.missas?.map((missa: any) => ({

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -62,6 +62,8 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
     nomeUnico?: string;
     slug?: string;
     endereco: { uf: string; cidadeSlug?: string };
+    status: "Ativa" | "EmProcesso";
+    controleId?: number;
   }[] = [];
   private enderecoPendente: any = null;
   // true depois que o usuário clica em "Não é nenhuma destas": vai no payload de
@@ -219,6 +221,13 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
         this.cd.markForCheck();
       },
     });
+  }
+
+  // Igreja "em processo" (Controle pendente) selecionada na lista do CEP: em vez
+  // de deixar o usuário criar uma duplicata, manda ele retomar a validação já
+  // existente daquela igreja (mesma tela usada logo após o cadastro).
+  retomarValidacao(controleId: number): void {
+    this.router.navigate(["/enviar-codigo", controleId]);
   }
 
   // Usuário confirmou, na lista de igrejas do CEP, que nenhuma delas é a sua —

--- a/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
+++ b/src/app/modules/public/church/pages/church-registration-page/church-registration-page.component.ts
@@ -224,10 +224,12 @@ export class ChurchRegistrationPageComponent implements AfterViewInit {
   }
 
   // Igreja "em processo" (Controle pendente) selecionada na lista do CEP: em vez
-  // de deixar o usuário criar uma duplicata, manda ele retomar a validação já
-  // existente daquela igreja (mesma tela usada logo após o cadastro).
-  retomarValidacao(controleId: number): void {
-    this.router.navigate(["/enviar-codigo", controleId]);
+  // de deixar o usuário criar uma duplicata, manda ele revisar/ajustar os dados
+  // já enviados (tela de edição) antes de seguir pra validação — o PUT de
+  // atualização reaproveita o mesmo Controle da criação e devolve o mesmo
+  // controleId, então a validação pendente não é perdida.
+  revisarCadastroPendente(igrejaId: number): void {
+    this.router.navigate(["/editar", igrejaId]);
   }
 
   // Usuário confirmou, na lista de igrejas do CEP, que nenhuma delas é a sua —


### PR DESCRIPTION
## Summary
Promove pra master o que já está validado em dev nesta leva:
- Dropdown "Tipo da Igreja" mapeado corretamente para o `TipoIgrejaEnum` do backend (antes tinha opções soltas que não existiam no enum).
- Envio de `tipoIgreja` no cadastro (antes só era concatenado no nome, nunca persistido).
- Token de sessão passa a ser enviado na criação de igreja quando o usuário está logado, permitindo pular o fluxo de validação por e-mail/desafio.
- Lista de igrejas do CEP agora mostra também as "em processo" (Controle pendente), destacadas visualmente, com opção de revisar os dados antes de continuar a validação (em vez de criar duplicata).

## Test plan
- [ ] Já testado manualmente em DEV (CEP 048954003) pelo usuário
- [ ] Conferir build/deploy de produção após o merge