### PR TITLE
feat(seo): pontos de entrada na Home + linkagem Cidade→Dias

### DIFF
--- a/src/app/core/constants/dias-intencao.ts
+++ b/src/app/core/constants/dias-intencao.ts
@@ -1,0 +1,19 @@
+/**
+ * Dias da semana da árvore de INTENÇÃO (`/missa-{slug}`). Slugs idênticos aos das
+ * rotas (`app.routes.ts`) e ao `DiaDaSemanaHelper` do backend. Usado pelos pontos
+ * de entrada da Home. "hoje" não entra aqui (é redirect client-side pro dia local).
+ */
+export interface DiaIntencao {
+  slug: string;
+  nome: string;
+}
+
+export const DIAS_INTENCAO: DiaIntencao[] = [
+  { slug: 'domingo', nome: 'Domingo' },
+  { slug: 'segunda-feira', nome: 'Segunda-feira' },
+  { slug: 'terca-feira', nome: 'Terça-feira' },
+  { slug: 'quarta-feira', nome: 'Quarta-feira' },
+  { slug: 'quinta-feira', nome: 'Quinta-feira' },
+  { slug: 'sexta-feira', nome: 'Sexta-feira' },
+  { slug: 'sabado', nome: 'Sábado' },
+];

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -197,6 +197,23 @@
     }
   }
 
+  <!-- ══ MISSAS POR DIA DA SEMANA / POR ESTADO (pontos de entrada — indexáveis) ══ -->
+  <!-- SEM @defer de propósito: precisam entrar no HTML do prerender p/ descoberta/SEO. -->
+  @if (!resultsMode) {
+    <app-home-chips
+      titulo="Missas por dia da semana"
+      subtitulo="Encontre horários de missa para qualquer dia da semana."
+      icone="pi pi-calendar"
+      [itens]="chipsDias"
+    />
+    <app-home-chips
+      titulo="Missas por estado"
+      subtitulo="Explore as igrejas e horários de missa em cada estado do Brasil."
+      icone="pi pi-map"
+      [itens]="chipsEstados"
+    />
+  }
+
   <!-- ══ RESULTADOS: carregando / vazio ══ -->
   <div *ngIf="resultsMode && isLoading" class="resultados-feedback">
     <i class="pi pi-spin pi-spinner"></i>

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -34,6 +34,8 @@ import { HomeStatsComponent } from "./sections/home-stats/home-stats.component";
 import { HomeComoFuncionaComponent } from "./sections/home-como-funciona/home-como-funciona.component";
 import { HomeFavoritosComponent } from "./sections/home-favoritos/home-favoritos.component";
 import { HomeCidadesComponent } from "./sections/home-cidades/home-cidades.component";
+import { HomeChipsComponent, ChipLink } from "./sections/home-chips/home-chips.component";
+import { DIAS_INTENCAO } from "../../../core/constants/dias-intencao";
 import { HomeMissasMapaComponent } from "./sections/home-missas-mapa/home-missas-mapa.component";
 import { linkParoquia } from "../../../shared/utils/church-link.utils";
 import { SeoService } from "../../../core/services/seo.service";
@@ -59,6 +61,7 @@ interface AddressData {
     HomeFavoritosComponent,
     HomeCidadesComponent,
     HomeMissasMapaComponent,
+    HomeChipsComponent,
   ],
   providers: [MessageService, DatePipe],
   templateUrl: "./home.component.html",
@@ -91,6 +94,16 @@ export class HomeComponent {
 
   /** Cidades populares — exibidas quando sem geoloc */
   readonly cidadesFallback = CIDADES_POPULARES;
+
+  /** Pontos de entrada (Fase Final): "Missas por dia" e "Missas por estado". */
+  readonly chipsDias: ChipLink[] = DIAS_INTENCAO.map((d) => ({
+    label: d.nome,
+    link: ['/missa-' + d.slug],
+  }));
+  readonly chipsEstados: ChipLink[] = STATES.map((e) => ({
+    label: e.nome,
+    link: ['/missas', e.sigla.toLowerCase()],
+  }));
 
   get cidadesExibidas() {
     return this.geoStatus === 'found' && this.cidadesGrid.length

--- a/src/app/modules/public/home/sections/home-chips/home-chips.component.html
+++ b/src/app/modules/public/home/sections/home-chips/home-chips.component.html
@@ -1,0 +1,18 @@
+<section class="cidades-chips">
+  <div class="sec-header">
+    <div class="flex items-center gap-2">
+      <i [class]="icone" style="color: #bc5d10;"></i>
+      <h2 class="sec-header__titulo">{{ titulo }}</h2>
+    </div>
+  </div>
+
+  @if (subtitulo) {
+    <p class="sec-header__sub">{{ subtitulo }}</p>
+  }
+
+  <div class="cidades-chips__lista">
+    @for (it of itens; track it.link.join('/')) {
+      <a [routerLink]="it.link" class="cidade-chip">{{ it.label }}</a>
+    }
+  </div>
+</section>

--- a/src/app/modules/public/home/sections/home-chips/home-chips.component.ts
+++ b/src/app/modules/public/home/sections/home-chips/home-chips.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+export interface ChipLink {
+  label: string;
+  /** routerLink em forma de array (ex.: ['/missa-domingo'] ou ['/missas', 'sp']). */
+  link: string[];
+}
+
+/**
+ * Seção genérica de "chips" de navegação da Home — reusa EXATAMENTE o visual da
+ * seção "Explore por cidade" (mesmas classes .cidades-chips/.sec-header/.cidade-chip,
+ * via styleUrls compartilhado). Usada para os pontos de entrada "Missas por dia da
+ * semana" e "Missas por estado" (Fase Final — descoberta/linkagem interna).
+ */
+@Component({
+  selector: 'app-home-chips',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './home-chips.component.html',
+  styleUrls: ['../home-cidades/home-cidades.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HomeChipsComponent {
+  @Input({ required: true }) titulo = '';
+  @Input() subtitulo?: string;
+  /** Classe do ícone PrimeIcons (ex.: 'pi pi-calendar'). */
+  @Input() icone = 'pi pi-map-marker';
+  @Input({ required: true }) itens: ChipLink[] = [];
+}

--- a/src/app/modules/public/intencao/intencao.component.html
+++ b/src/app/modules/public/intencao/intencao.component.html
@@ -78,6 +78,16 @@
           </li>
         }
       </ul>
+
+      <!-- Linkagem interna: missa em outros dias na mesma cidade (links HTML puros). -->
+      <nav class="outros-dias" aria-label="Missa em outros dias">
+        <h2>Missa em {{ cidadeNome }} em outros dias</h2>
+        <ul role="list">
+          @for (d of outrosDias; track d.slug) {
+            <li><a [routerLink]="['/missa-' + d.slug, uf, cidadeSlug]">Missa de {{ d.nome }} em {{ cidadeNome }}</a></li>
+          }
+        </ul>
+      </nav>
     }
   }
 </section>

--- a/src/app/modules/public/intencao/intencao.component.scss
+++ b/src/app/modules/public/intencao/intencao.component.scss
@@ -83,5 +83,30 @@
   }
 }
 
+.outros-dias {
+  margin-top: 2rem;
+
+  h2 { font-size: 1.1rem; margin: 0 0 0.75rem; }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  a {
+    display: inline-block;
+    padding: 0.5rem 0.9rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 999px;
+    text-decoration: none;
+    color: #2563eb;
+    font-size: 0.9rem;
+  }
+  a:hover { background: #eff6ff; border-color: #93c5fd; }
+}
+
 .mb-3 { margin-bottom: 0.75rem; }
 .mb-4 { margin-bottom: 1.25rem; }

--- a/src/app/modules/public/intencao/intencao.component.ts
+++ b/src/app/modules/public/intencao/intencao.component.ts
@@ -7,6 +7,7 @@ import { finalize } from 'rxjs/operators';
 import { SkeletonModule } from 'primeng/skeleton';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
+import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -52,6 +53,11 @@ export class IntencaoComponent implements OnInit {
 
   get rotulo(): string {
     return ROTULO[this.dia] ?? this.dia;
+  }
+
+  /** Demais dias (para linkagem "outros dias" na mesma cidade). */
+  get outrosDias() {
+    return DIAS_INTENCAO.filter((d) => d.slug !== this.dia);
   }
 
   // Dados por nível.


### PR DESCRIPTION
## Contexto
Fase final de SEO/UX — **descoberta**. As páginas de Estado e da árvore de intenção existem, mas o usuário só chega nelas pelo Google. Esta PR cria pontos de entrada visíveis na Home e reforça a linkagem interna. **Não** altera arquitetura, prerender/SSR, hydration, cache, interceptors, próxima missa/countdown nem o JSON-LD existente.

## O que muda
- **`home-chips`** — componente apresentacional que **reusa exatamente** o visual de `home-cidades` (mesmas classes, `styleUrls` compartilhado). Sem layout novo.
- **2 blocos permanentes e indexáveis na Home** (SEM `@defer`, para entrarem no HTML do prerender), logo após "Explore por cidade":
  - **Missas por dia da semana** → 7 links `/missa-{dia}`.
  - **Missas por estado** → 27 links `/missas/{uf}` (reusa `STATES`).
- **`core/constants/dias-intencao.ts`** (slugs iguais aos das rotas/backend).
- **Linkagem Cidade→Dias**: bloco "Missa em {cidade} em outros dias" na folha de intenção (links HTML puros).

## Página estática — sem regressão
- Blocos renderizam de **constantes determinísticas** dentro de `@if (!resultsMode)` → HTML idêntico server/client → **sem mismatch de hidratação** (confirmado no HTML prerenderizado, `ngh` presente, 0 erro).
- Mudança **puramente aditiva**: seções dinâmicas (stats/próxima missa) e o SWR intactos.
- Folha de intenção segue CSR (decisão anterior do time) → sempre ao vivo.

## Verificação
- `build:dev`: exit 0, **1521 rotas**; home prerenderizada contém os 2 blocos (7 dias + 27 estados).
- Guard-rail: **0% erro**. dist **pós-dedupe 92.7 MB** (folga sob o limite de 250 MB do SWA Free).

## Pré-requisito
Backend PR (sitemap de intenção) e os endpoints Fase 3 em prod antes do `build:prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)