### PR TITLE
feat: adicionar Basílica e Catedral ao enum TipoIgreja

### DIFF
--- a/src/app/core/interfaces/church.interface.ts
+++ b/src/app/core/interfaces/church.interface.ts
@@ -20,6 +20,8 @@ export enum TipoIgreja {
   Capela = 2,
   Comunidade = 3,
   Santuario = 4,
+  Basilica = 5,
+  Catedral = 6,
   Outro = 99,
 }
 

--- a/src/app/modules/public/church/components/church-form/church-form.component.ts
+++ b/src/app/modules/public/church/components/church-form/church-form.component.ts
@@ -69,6 +69,8 @@ export class ChurchFormComponent implements OnInit, OnChanges {
     { name: "Capela", value: 2 },
     { name: "Comunidade", value: 3 },
     { name: "Santuário", value: 4 },
+    { name: "Basílica", value: 5 },
+    { name: "Catedral", value: 6 },
     { name: "Outro", value: 99 },
   ];
 


### PR DESCRIPTION
## Summary
- Adiciona os tipos Basílica (5) e Catedral (6) ao enum `TipoIgreja` e às opções do dropdown de tipo no formulário público de cadastro de igreja.

## Test plan
- [x] `npx tsc --noEmit` passou sem erros