### PR TITLE
fix(sitemap): restaura geração estática como contorno do proxy quebrado

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "build": "ng build",
     "build:dev": "ng build --configuration=development",
     "postbuild:dev": "node scripts/copiar-index-csr.mjs",
-    "prebuild:staging": "node scripts/baixar-bulk-prerender.mjs staging",
+    "prebuild:staging": "node scripts/baixar-bulk-prerender.mjs staging && node scripts/gerar-sitemap.mjs staging",
     "build:staging": "ng build --configuration=staging",
     "postbuild:staging": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs && node scripts/verificar-dist-size.mjs",
     "build:prod": "ng build --configuration=production",
-    "prebuild:prod": "node scripts/baixar-bulk-prerender.mjs prod",
+    "prebuild:prod": "node scripts/baixar-bulk-prerender.mjs prod && node scripts/gerar-sitemap.mjs prod",
     "postbuild:prod": "node scripts/copiar-index-csr.mjs && node scripts/dedupe-prerender-css.mjs && node scripts/verificar-prerender.mjs && node scripts/verificar-dist-size.mjs",
     "watch": "ng build --watch --configuration=development",
     "test": "ng test"

--- a/scripts/gerar-sitemap.mjs
+++ b/scripts/gerar-sitemap.mjs
@@ -1,0 +1,70 @@
+/**
+ * Gera public/sitemap.xml ESTÁTICO no prebuild — contorno temporário enquanto o
+ * proxy Node em frente ao domínio canônico (buscamissa.com.br, fora destes repos)
+ * não repassa corretamente /sitemap.xml para a API (bug de infra separado, fora do
+ * nosso alcance nesta sessão: o domínio resolve direto pra uma VM cujo código não
+ * está versionado em nenhum repo acessível).
+ *
+ * Histórico: até 2026-07-25 o site gerava esse arquivo no build (ver commit
+ * 2d89b5d "remove geração do sitemap estático — agora é dinâmico"); a ideia era o
+ * proxy buscar a versão fresca direto da API a cada request. Como isso não está
+ * funcionando (GSC reportando 404 em buscamissa.com.br/sitemap.xml, mesmo com a
+ * API respondendo 200), este script busca o XML JÁ PRONTO do endpoint /sitemap.xml
+ * da API (fonte única — sem duplicar a lógica de montagem/anti-thin/prioridades
+ * que já vive no SitemapController) e grava como arquivo estático no dist.
+ *
+ * Trade-off: frescor = do último deploy, não em tempo real (paróquia nova só
+ * aparece no próximo build/deploy). Aceitável como contorno; reverter quando o
+ * proxy for corrigido (ver memória `topologia-proxy-node-buscamissa`).
+ *
+ * Best-effort: se a API estiver fora, NÃO grava o arquivo e segue o build
+ * (exit 0) — melhor não ter sitemap novo do que travar o deploy por causa disso.
+ */
+import { writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { normalizarBaseUrl } from './lib/seo-routes.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const TIMEOUT_MS = 30_000;
+
+// Argumento: "staging" ou "prod" (default: prod) — mesmo contrato dos outros scripts.
+const ENV = process.argv[2] ?? 'prod';
+
+function lerApiUrl() {
+  if (process.env.API_URL) return normalizarBaseUrl(process.env.API_URL);
+  const envFile = ENV === 'staging'
+    ? join(ROOT, 'src/environments/environment.staging.ts')
+    : join(ROOT, 'src/environments/environment.production.ts');
+  const conteudo = readFileSync(envFile, 'utf-8');
+  const match = conteudo.match(/apiURL\s*:\s*["']([^"']+)["']/);
+  if (!match) throw new Error(`apiURL não encontrado em ${envFile}`);
+  return normalizarBaseUrl(match[1]);
+}
+
+async function main() {
+  const base = lerApiUrl();
+  const url = `${base}/sitemap.xml`;
+  const inicio = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    const xml = await res.text();
+    if (!xml.includes('<urlset')) throw new Error('resposta não parece um sitemap XML válido');
+
+    mkdirSync(join(ROOT, 'public'), { recursive: true });
+    writeFileSync(join(ROOT, 'public', 'sitemap.xml'), xml, 'utf-8');
+
+    const total = (xml.match(/<loc>/g) ?? []).length;
+    console.log(`[sitemap-estatico] ${total} URLs de ${url} → public/sitemap.xml (${Date.now() - inicio}ms).`);
+  } catch (err) {
+    console.warn(`[sitemap-estatico] falha ao buscar ${url} (${err?.message ?? err}) — build segue sem regenerar o sitemap.`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+main();


### PR DESCRIPTION
## 🔴 Contexto — GSC "Sitemap could not be read" (404)

Diagnóstico completo:
- `https://buscamissa.com.br/sitemap.xml` → 404.
- Backend de prod direto → **200** (já corrigido em api-public#49, que resolvia um 500 anterior).
- `buscamissa.com.br` resolve por **DNS direto para uma VM (52.252.23.178)** rodando um proxy Node — não passa pela Azure SWA, não tem relação com `staticwebapp.config.json`.
- O código desse proxy **não está em nenhum dos repos** que temos acesso (nem `buscamissa-infra`, que é só Terraform da API). Não dá pra corrigir a causa raiz nesta sessão.

## Contorno aplicado
Como o sitemap **dinâmico** depende de uma camada que não conseguimos consertar agora, restauramos a geração **estática** (removida em `2d89b5d`, quando o site passou a depender 100% do proxy buscar da API em tempo real):

- `scripts/gerar-sitemap.mjs`: busca o XML **já pronto** do endpoint `/sitemap.xml` da própria API (fonte única — não duplica a lógica de montagem/anti-thin que já vive no `SitemapController`) e grava em `public/sitemap.xml`.
- Reintroduzido no `prebuild:staging`/`prebuild:prod`.
- Best-effort: se a API estiver fora no momento do build, não quebra o build (loga e segue).

**Trade-off**: frescor = do último deploy (não mais em tempo real). Aceitável como contorno — reverter quando o proxy for corrigido.

## Verificação
- `build:staging` completo: exit 0.
- `dist/.../browser/sitemap.xml` gerado: 714KB, **3785 URLs** (incluindo os 1063 blocos de intenção).
- Guard-rail 0% erro, dist-size 75.6 MB.

## Pendência separada (fora deste PR)
A causa raiz (proxy na VM não repassando `/sitemap.xml` dinamicamente) continua sem correção — alguém com acesso à VM `52.252.23.178` precisa investigar o código do proxy lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)