### PR TITLE
fix(estado): impede download do hero em mobile (srcset vazio não funcionava)

### DIFF
--- a/src/app/modules/public/estado/estado.component.html
+++ b/src/app/modules/public/estado/estado.component.html
@@ -83,11 +83,23 @@
 
       <!-- Decorativa: em telas estreitas o <source> vazio impede o download. -->
       <div class="estado-hero__foto" aria-hidden="true">
+        <!--
+          O <source> só casa a partir de 900px, que é onde a foto aparece; abaixo
+          disso o `img` cai no GIF transparente inline e NÃO há requisição de rede.
+
+          Um `<source media="(max-width:899px)" srcset="">` não serve: srcset vazio
+          invalida aquele source, o browser cai no `img src` e baixa os 70 KB mesmo
+          com o container em display:none — foi o que aconteceu (currentSrc apontava
+          para o .webp num viewport de 390px).
+
+          O `img` continua sendo <img> (e não background-image no CSS) para o
+          preload scanner achar a imagem cedo no desktop, onde ela é o LCP.
+        -->
         <picture>
-          <source media="(max-width: 899px)" srcset="" />
-          <source type="image/webp" srcset="assets/images/catedral-estado.webp" />
-          <img src="assets/images/catedral-estado.webp" alt="" fetchpriority="high"
-               width="1200" height="1801" decoding="async" />
+          <source media="(min-width: 900px)" type="image/webp"
+                  srcset="assets/images/catedral-estado.webp" />
+          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+               alt="" fetchpriority="high" width="1200" height="1801" decoding="async" />
         </picture>
       </div>
     </div>


### PR DESCRIPTION
Encontrado testando o ambiente de dev publicado.

## Problema

O `<source media="(max-width: 899px)" srcset="" />` que eu tinha usado para "não baixar em mobile" **não impedia nada**. `srcset` vazio invalida aquele `<source>`, o browser cai no `img src` e baixa os 70 KB — e `display:none` no container **não** impede o carregamento de imagem.

Evidência: num viewport de 390px, `img.currentSrc` apontava para `catedral-estado.webp`. O browser tinha selecionado e carregado a foto só para escondê-la.

## Correção

O `<source>` agora só casa a partir de 900px (onde a foto realmente aparece), e o `img` cai num GIF transparente inline (43 bytes em base64), que não gera requisição de rede.

Mantido como `<img>` em vez de virar `background-image` no CSS de propósito: o preload scanner precisa achar a imagem cedo no desktop, onde ela é o elemento de LCP.

## Verificado

| viewport | requisições da foto | currentSrc |
|---|---|---|
| 390×844 | **0** | `data:` (GIF inline) |
| 1280×900 | 1 (71 KB) | `catedral-estado.webp`, renderizando 554×420 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)