### PR TITLE
fix(seo): /estados lista só UFs com paróquia (elimina soft-404 duplicado)

### DIFF
--- a/src/app/core/services/seo-paginas.service.ts
+++ b/src/app/core/services/seo-paginas.service.ts
@@ -28,6 +28,18 @@ export class SeoPaginasService {
   }
 
   /**
+   * Todas as UFs que têm paróquia — alimenta o índice `/estados`.
+   *
+   * É a MESMA fonte que o prerender usa para decidir quais hubs `/missas/{uf}`
+   * gerar, então o índice nunca linka um estado sem página. Não passa pelo
+   * interceptor de prerender (ele cobre só o por-item `/v2/seo/estado/{uf}`),
+   * mas `/estados` é uma página só: é uma requisição no build inteiro.
+   */
+  getEstados(): Observable<unknown> {
+    return this.http.get(`${this.base}/v2/seo/estados`);
+  }
+
+  /**
    * Árvore de um dia (hubs nacional/UF da intenção). O endpoint real sempre devolve
    * a árvore inteira (ignora `uf`) — o filtro por UF é feito no componente. O `uf`
    * aqui só marca a requisição para o interceptor SÓ-SERVER de prerender (ver

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -1,15 +1,30 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { STATES } from '../../../core/constants/states';
+import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
 
 const SITE = 'https://buscamissa.com.br';
 
+interface EstadoResumo {
+  uf: string;
+  estado: string;
+  totalCidades: number;
+  totalParoquias: number;
+}
+
 /**
- * Índice de ESTADOS (`/estados`) — paridade com `/cidades`. Lista os 26 estados +
- * DF e distribui autoridade para os hubs estaduais (`/missas/{uf}`). Estático
- * (constante STATES), prerenderizado. SEO + ItemList JSON-LD.
+ * Índice de ESTADOS (`/estados`) — paridade com `/cidades`. Distribui autoridade
+ * para os hubs estaduais (`/missas/{uf}`).
+ *
+ * Alimentado por `GET /v2/seo/estados`, NÃO pela constante STATES: aquela lista as
+ * 27 UFs sempre, mas só as UFs com paróquia viram hub prerenderizado. As demais
+ * caíam no catch-all do router e serviam a HOME — mesma página, URL diferente,
+ * `canonical` apontando para `/home` e `robots: index, follow`. Ou seja, conteúdo
+ * duplicado indexável gerado pelo próprio índice. Usando a API, o índice só lista
+ * o que existe.
  */
 @Component({
   selector: 'app-estados',
@@ -22,26 +37,76 @@ const SITE = 'https://buscamissa.com.br';
     icone="pi pi-map-marker"
     [itens]="itens"
   />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EstadosComponent implements OnInit, OnDestroy {
   private _seo = inject(SeoService);
+  private _api = inject(SeoPaginasService);
+  private _cdr = inject(ChangeDetectorRef);
+  private _destroyRef = inject(DestroyRef);
 
   readonly breadcrumb: HubBreadcrumb[] = [
     { label: 'Início', link: ['/home'] },
     { label: 'Estados' },
   ];
 
-  readonly itens: HubItem[] = STATES.map((e) => ({
-    nome: e.nome,
-    link: ['/missas', e.sigla.toLowerCase()],
-  }));
+  itens: HubItem[] = [];
+  private estados: EstadoResumo[] = [];
 
   ngOnInit(): void {
+    this.aplicarSeo();
+
+    this._api
+      .getEstados()
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe({
+        next: (data: any) => {
+          const lista: EstadoResumo[] = Array.isArray(data) ? data : (data?.data ?? []);
+          this.aplicar(lista.filter((e) => e?.uf));
+        },
+        // Degrada para a lista estática: um índice vazio é pior que um índice com
+        // um link a mais. O risco de link para hub sem página volta só neste caso.
+        error: () => this.aplicarFallbackEstatico(),
+      });
+  }
+
+  private aplicar(estados: EstadoResumo[]): void {
+    if (!estados.length) {
+      this.aplicarFallbackEstatico();
+      return;
+    }
+    this.estados = estados;
+    this.itens = estados.map((e) => ({
+      nome: e.estado,
+      meta: `${e.totalParoquias} paróquia(s) em ${e.totalCidades} cidade(s)`,
+      link: ['/missas', e.uf.toLowerCase()],
+    }));
+    this.aplicarJsonLd();
+    this._cdr.markForCheck();
+  }
+
+  private aplicarFallbackEstatico(): void {
+    this.estados = STATES.map((e) => ({
+      uf: e.sigla.toLowerCase(),
+      estado: e.nome,
+      totalCidades: 0,
+      totalParoquias: 0,
+    }));
+    this.itens = this.estados.map((e) => ({ nome: e.estado, link: ['/missas', e.uf] }));
+    this.aplicarJsonLd();
+    this._cdr.markForCheck();
+  }
+
+  private aplicarSeo(): void {
     this._seo.update({
       title: 'Missas por estado — horários de missa no Brasil | BuscaMissa',
-      description: 'Encontre horários de missa por estado. Escolha a UF e veja as cidades e paróquias com missas cadastradas.',
+      description:
+        'Encontre horários de missa por estado. Escolha a UF e veja as cidades e paróquias com missas cadastradas.',
       canonical: `${SITE}/estados`,
     });
+  }
+
+  private aplicarJsonLd(): void {
     this._seo.setJsonLd('breadcrumb', {
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
@@ -50,23 +115,24 @@ export class EstadosComponent implements OnInit, OnDestroy {
         { '@type': 'ListItem', position: 2, name: 'Estados', item: `${SITE}/estados` },
       ],
     });
+
     this._seo.setJsonLd('itemlist', {
       '@context': 'https://schema.org',
       '@type': 'ItemList',
       name: 'Estados do Brasil com missas',
-      numberOfItems: this.itens.length,
-      itemListElement: STATES.map((e, i) => ({
+      numberOfItems: this.estados.length,
+      itemListElement: this.estados.map((e, i) => ({
         '@type': 'ListItem',
         position: i + 1,
-        name: e.nome,
-        item: `${SITE}/missas/${e.sigla.toLowerCase()}`,
+        name: e.estado,
+        item: `${SITE}/missas/${e.uf.toLowerCase()}`,
       })),
     });
   }
 
   /**
    * Os ids do JSON-LD são um namespace global do documento — sem remover na saída,
-   * o ItemList dos 27 estados sobrevive na próxima rota que não o sobrescreva.
+   * o ItemList dos estados sobrevive na próxima rota que não o sobrescreva.
    */
   ngOnDestroy(): void {
     this._seo.removeJsonLd('breadcrumb');


### PR DESCRIPTION
Encontrado no reteste do ambiente de dev.

## Problema

O índice montava a lista a partir da constante `STATES`, que tem sempre as 27 UFs. Mas só as UFs com paróquia viram hub prerenderizado — as demais caem no catch-all do router e **servem a home**.

Não é um link morto, é pior:

| | |
|---|---|
| URL | `/missas/ap` (e `am`, `pa`, `ro`, …) |
| HTTP | **200** |
| conteúdo | idêntico ao da home |
| canonical | **`https://buscamissa.com.br/home`** |
| robots | **`index, follow`** |

Conteúdo duplicado indexável, com canonical cruzado, gerado pelo próprio índice do site.

## Correção

A lista passa a vir de `GET /v2/seo/estados` — a **mesma fonte** que o prerender usa para decidir quais hubs `/missas/{uf}` gerar. Assim o índice não pode divergir do que existe.

Cada item também mostra agora paróquias e cidades, que já vinham no payload (nenhuma agregação nova).

Em erro da API, degrada para `STATES`: um índice vazio é pior que um índice com um link a mais, e nesse caso voltamos ao comportamento atual.

## Verificado no build

- `/estados` lista **12 UFs** (as que têm dados em staging) em vez de 27
- **0 links quebrados**: os 12 têm hub prerenderizado e com cidades
- `ItemList` com `numberOfItems: 12`
- canonical próprio (`/estados`), `robots: index, follow`
- meta por item: "N paróquia(s) em M cidade(s)"

Em produção o impacto é menor — 26 das 27 UFs têm dados, então é 1 URL afetada em vez de 15 — mas o defeito é o mesmo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)