### PR TITLE
fix(seo): noindex em página de "não encontrado" (elimina soft-404)

### DIFF
--- a/src/app/modules/public/estado/estado.component.ts
+++ b/src/app/modules/public/estado/estado.component.ts
@@ -158,6 +158,7 @@ export class EstadoComponent implements OnInit, OnDestroy {
         next: (data: any) => {
           if (!data) {
             this.naoEncontrado = true;
+            this.aplicarSeoNaoEncontrado();
             return;
           }
           this.estadoNome = data.estado ?? '';
@@ -170,10 +171,35 @@ export class EstadoComponent implements OnInit, OnDestroy {
           this._cdr.markForCheck();
         },
         error: (err) => {
-          if (err?.status === 404) this.naoEncontrado = true;
-          else this.erroCarregar = true;
+          if (err?.status === 404) {
+            this.naoEncontrado = true;
+            this.aplicarSeoNaoEncontrado();
+          } else {
+            // Falha transitória (rede/500) NÃO vira noindex: a página pode ser
+            // válida e estar apenas indisponível no momento.
+            this.erroCarregar = true;
+          }
         },
       });
+  }
+
+  /**
+   * UF inexistente (`/missas/xx`): a rota casa, mas não há hub prerenderizado, então
+   * o SWA serve o shell (que carrega o title/canonical da HOME) e só depois a
+   * hidratação mostra "Estado não encontrado" — uma página de "não encontrado"
+   * marcada como indexável, ou seja um soft-404. Aqui damos identidade própria à
+   * URL e a tiramos do índice.
+   *
+   * Só no 404 da API. No `erroCarregar` seria perigoso: uma indisponibilidade
+   * momentânea marcaria noindex numa página válida.
+   */
+  private aplicarSeoNaoEncontrado(): void {
+    this._seo.update({
+      title: 'Estado não encontrado | BuscaMissa',
+      description: 'Não encontramos paróquias cadastradas para esta UF.',
+      canonical: `${SITE}/missas/${this.uf}`,
+      noindex: true,
+    });
   }
 
   tentarNovamente(): void {

--- a/src/app/modules/public/home/city/city.component.ts
+++ b/src/app/modules/public/home/city/city.component.ts
@@ -172,6 +172,15 @@ export class CityComponent implements OnInit, OnDestroy {
           title: seo?.title ?? `Missas em ${this.cidadeNome}/${ufUpper} — Horários atualizados | BuscaMissa`,
           description: seo?.description ?? descFallback,
           canonical: seo?.canonicalUrl,
+          // Cidade sem nenhuma paróquia = slug inválido (o prerender só gera cidade
+          // COM paróquia), então é página vazia e sai do índice — evita soft-404.
+          //
+          // O critério é `igrejas.length`, e não a flag `naoEncontrado`: aquela é
+          // sobrecarregada e também fica true quando um FILTRO não retorna nada
+          // (ver _aplicarFiltros). Usar a flag deindexaria cidade válida só porque
+          // o usuário filtrou. Aqui roda só no carregamento, e o erro de rede cai
+          // no `error:` abaixo, sem virar noindex.
+          noindex: this.igrejas.length === 0,
         });
 
         if (this.igrejas.length) {

--- a/src/app/modules/public/intencao/intencao.component.ts
+++ b/src/app/modules/public/intencao/intencao.component.ts
@@ -94,7 +94,7 @@ export class IntencaoComponent implements OnInit {
       .pipe(takeUntilDestroyed(this._destroyRef), finalize(() => (this.isLoading = false)))
       .subscribe({
         next: (data: any) => {
-          if (!data) return void (this.naoEncontrado = true);
+          if (!data) return void this.marcarNaoEncontrado();
           this.cidadeNome = data.cidade ?? '';
           this.paroquias = data.paroquias ?? [];
           this.aplicarSeo(data.seo);
@@ -114,7 +114,7 @@ export class IntencaoComponent implements OnInit {
       .pipe(takeUntilDestroyed(this._destroyRef), finalize(() => (this.isLoading = false)))
       .subscribe({
         next: (arvore: any) => {
-          if (!arvore?.estados) return void (this.naoEncontrado = true);
+          if (!arvore?.estados) return void this.marcarNaoEncontrado();
           if (this.nivel === 'nacional') {
             this.estados = arvore.estados.map((e: any) => ({ uf: e.uf, estado: e.estado }));
             this.aplicarSeo(arvore.seo);
@@ -125,7 +125,7 @@ export class IntencaoComponent implements OnInit {
             );
           } else {
             const estado = arvore.estados.find((e: any) => e.uf?.toLowerCase() === this.uf);
-            if (!estado) return void (this.naoEncontrado = true);
+            if (!estado) return void this.marcarNaoEncontrado();
             this.estadoNome = estado.estado ?? '';
             this.cidades = estado.cidades ?? [];
             this.aplicarSeo(estado.seo);
@@ -141,8 +141,28 @@ export class IntencaoComponent implements OnInit {
   }
 
   private tratarErro(err: any): void {
-    if (err?.status === 404) this.naoEncontrado = true;
+    if (err?.status === 404) this.marcarNaoEncontrado();
+    // Falha transitória (rede/500) NÃO vira noindex: a página pode ser válida e
+    // estar apenas indisponível no momento.
     else this.erroCarregar = true;
+  }
+
+  /**
+   * Dia/UF/cidade sem missa (`/missa-domingo/xx`): a rota casa mas não há página
+   * prerenderizada, então o SWA serve o shell (que traz title/canonical da HOME) e
+   * a hidratação mostra "nenhuma missa encontrada" — página de "não encontrado"
+   * marcada como indexável, isto é, um soft-404. Aqui damos identidade própria à
+   * URL e a tiramos do índice.
+   */
+  private marcarNaoEncontrado(): void {
+    this.naoEncontrado = true;
+    const caminho = ['missa-' + this.dia, this.uf, this.cidadeSlug].filter(Boolean).join('/');
+    this._seo.update({
+      title: `Missa de ${this.rotulo} não encontrada | BuscaMissa`,
+      description: `Não encontramos paróquias com missa de ${this.rotulo} cadastradas aqui.`,
+      canonical: `${SITE}/${caminho}`,
+      noindex: true,
+    });
   }
 
   tentarNovamente(): void {


### PR DESCRIPTION
## Problema

URL com parâmetro inválido — `/missas/xx`, `/missas/uf/cidade-inexistente`, `/missa-{dia}/uf-sem-missa` — casa a rota mas não tem página prerenderizada. O SWA serve o shell (que traz `title`/`canonical` da **home**) e só a hidratação mostra o "não encontrado". Resultado: página de erro marcada como **`index, follow`** — soft-404.

## Correção

`estado`, `city` e `intencao` passam a dar identidade própria à URL (title/description/canonical) e a marcá-la `noindex` quando o conteúdo não existe.

**Só no 404 definitivo da API.** No `erroCarregar` (rede/500) seria perigoso: uma indisponibilidade momentânea marcaria `noindex` numa página válida.

**Em `city.component` o critério é `igrejas.length === 0`, não a flag `naoEncontrado`** — aquela é sobrecarregada e também fica `true` quando um **filtro** não retorna nada (`_aplicarFiltros`). Usá-la deindexaria cidade válida só porque o usuário filtrou por bairro ou horário. O trecho alterado roda apenas no carregamento.

## Verificado

- `tsc` e build limpos
- **60/60 páginas válidas amostradas seguem `index, follow`** (`/missas/sp`, `/missas/sp/sao-paulo`, `/missa-domingo/sp`, `/estados` entre elas) — nenhuma deindexação indevida

## Ainda NÃO verificado

Que o `noindex` **dispara** na página inválida.

A API só libera CORS para a origem do site publicado. De `localhost` e de **preview de PR** toda chamada é bloqueada (`TypeError: Failed to fetch`), então o componente cai em `erroCarregar` em vez do 404 e o caminho novo não é exercido. Confirmei por `curl` que a resposta 404 carrega `Access-Control-Allow-Origin` para a origem do dev publicado — então lá deve funcionar, mas só dá para comprovar **depois do merge**.

Efeito colateral que vale registrar: **previews de PR não conseguem falar com a API**, o que limita bastante o valor deles para páginas com dados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)