### PR TITLE
feat: hero unificado nas páginas do menu Explorar

### DIFF
--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -106,6 +106,15 @@ export class ChurchesService {
     return this.addressRange$;
   }
 
+  /**
+   * Descarta o cache de `addressRange()`. Necessário para "Tentar novamente" ter
+   * efeito: o `shareReplay` guarda também o ERRO, então sem limpar, toda nova
+   * assinatura recebe a mesma falha na hora, sem tocar na rede.
+   */
+  public limparCacheEnderecos(): void {
+    this.addressRange$ = undefined;
+  }
+
   /** Busca igrejas filtradas pelos parâmetros informados */
   searchByFilters(filters: FilterSearchChurch) {
     let params = new HttpParams();

--- a/src/app/modules/public/cidades/cidades.component.html
+++ b/src/app/modules/public/cidades/cidades.component.html
@@ -1,63 +1,55 @@
-<div class="cidades-page max-w-4xl mx-auto px-3 sm:px-4 pb-12">
-
-  <!-- Hero -->
-  <div class="hero-section">
-    <div class="flex-1">
-      <h1 class="text-2xl font-extrabold text-gray-900 leading-tight">Todas as cidades</h1>
-      <p class="text-gray-500 text-sm mt-1">Encontre horários de missas em sua cidade.</p>
-
-      <!-- Busca -->
-      <div class="search-box mt-4">
-        <i class="pi pi-search search-box__icon"></i>
-        <input
-          type="text"
-          [(ngModel)]="busca"
-          placeholder="Buscar por cidade, estado ou diocese..."
-          class="search-box__input"
-          autocomplete="off">
-      </div>
-    </div>
-    <div class="hero-section__art" aria-hidden="true">
-      <svg viewBox="0 0 120 100" xmlns="http://www.w3.org/2000/svg">
-        <ellipse cx="60" cy="95" rx="58" ry="5" fill="#f3d5ba" opacity="0.4"/>
-        <rect x="34" y="50" width="52" height="42" rx="3" fill="#f0e2d3"/>
-        <rect x="52" y="22" width="16" height="70" rx="2" fill="#f5ede3"/>
-        <polygon points="34,50 60,32 86,50" fill="#e6c9a8"/>
-        <polygon points="60,10 50,24 70,24" fill="#e6c9a8"/>
-        <rect x="58" y="3" width="4" height="9" rx="1" fill="#d4a97a"/>
-        <rect x="55" y="7" width="10" height="3.5" rx="1" fill="#d4a97a"/>
-        <rect x="57" y="66" width="6" height="26" rx="1" fill="#d4a97a"/>
-        <rect x="38" y="58" width="8" height="12" rx="2" fill="#d4a97a"/>
-        <rect x="74" y="58" width="8" height="12" rx="2" fill="#d4a97a"/>
-        <circle cx="60" cy="45" r="4" fill="#d4a97a"/>
-      </svg>
-    </div>
+<app-page-hero
+  [breadcrumb]="breadcrumb"
+  [titulo]="TITULO_HERO"
+  tituloDestaque="Cidade"
+  subtitulo="Encontre horários de missas em sua cidade."
+  [tiles]="tiles"
+  [tilesCarregando]="isLoading"
+  hint="Digite o nome da cidade ou do estado."
+>
+  <div class="busca" hero-busca>
+    <i class="pi pi-search" aria-hidden="true"></i>
+    <input
+      type="search"
+      [(ngModel)]="busca"
+      placeholder="Buscar por cidade ou estado..."
+      aria-label="Buscar cidade"
+      autocomplete="off">
   </div>
 
-  <!-- Stats -->
-  <div class="stats-row">
-    <div class="stat-item">
-      <i class="pi pi-map stat-item__icon"></i>
-      <div>
-        <p class="stat-item__value">{{ estados.length }}</p>
-        <p class="stat-item__label">estados e o DF</p>
-      </div>
-    </div>
-    <div class="stat-item">
-      <i class="pi pi-building stat-item__icon"></i>
-      <div>
-        <p class="stat-item__value">{{ totalCidades }}+</p>
-        <p class="stat-item__label">cidades cadastradas</p>
-      </div>
-    </div>
-    <div class="stat-item">
-      <i class="pi pi-users stat-item__icon"></i>
-      <div>
-        <p class="stat-item__value">700+</p>
-        <p class="stat-item__label">paróquias e comunidades</p>
-      </div>
-    </div>
-  </div>
+  <!--
+    A igreja que já ilustrava esta página, redesenhada para a caixa do hero.
+    Preenchimento claro + contorno #e6c9a8 é a mesma gramática do mapa de /estados
+    e do calendário de /dias: sem o contorno, bege sobre bege desaparecia no fundo.
+    Um único acento laranja (a cruz), como o pin de /estados e o dia de /dias.
+  -->
+  <svg class="cidades-arte" hero-arte viewBox="0 0 240 300" preserveAspectRatio="xMidYMid meet"
+       xmlns="http://www.w3.org/2000/svg">
+    <ellipse cx="120" cy="254" rx="84" ry="9" fill="#e6c9a8" opacity="0.35" />
+
+    <!-- nave -->
+    <rect x="62" y="150" width="116" height="100" rx="4" fill="#f7efe5" stroke="#e6c9a8" stroke-width="2" />
+    <polygon points="58,152 120,110 182,152" fill="#e6c9a8" />
+
+    <!-- torre -->
+    <rect x="103" y="86" width="34" height="164" rx="3" fill="#fdf9f4" stroke="#e6c9a8" stroke-width="2" />
+    <polygon points="120,48 99,88 141,88" fill="#e6c9a8" />
+
+    <!-- cruz: o acento -->
+    <rect x="117" y="22" width="6" height="22" rx="3" fill="#e2761b" />
+    <rect x="110" y="29" width="20" height="6" rx="3" fill="#e2761b" />
+
+    <!-- rosácea e porta -->
+    <circle cx="120" cy="128" r="9" fill="#d4a97a" />
+    <path d="M110 250 v-38 a10 10 0 0 1 20 0 v38 z" fill="#d4a97a" />
+
+    <!-- janelas laterais -->
+    <path d="M80 196 v-18 a7 7 0 0 1 14 0 v18 z" fill="#d4a97a" />
+    <path d="M146 196 v-18 a7 7 0 0 1 14 0 v18 z" fill="#d4a97a" />
+  </svg>
+</app-page-hero>
+
+<div class="cidades-page">
 
   <!-- Skeleton -->
   <div *ngIf="isLoading" class="flex flex-col gap-3 mt-6">
@@ -71,7 +63,16 @@
       Cidades por estado
     </h2>
 
-    <div *ngIf="estadosFiltrados.length === 0" class="text-center py-10 text-gray-400">
+    <!-- Falha de carga e busca sem resultado são coisas diferentes: com a lista
+         vazia por erro de rede, dizer que a BUSCA não encontrou nada é mentira
+         (e ainda por cima com aspas vazias, já que não há termo buscado). -->
+    <div *ngIf="semDados" class="text-center py-10 text-gray-500">
+      <i class="pi pi-exclamation-circle text-3xl mb-3 block"></i>
+      Não foi possível carregar a lista de cidades.
+      <button type="button" class="cidades-retry" (click)="recarregar()">Tentar novamente</button>
+    </div>
+
+    <div *ngIf="!semDados && estadosFiltrados.length === 0" class="text-center py-10 text-gray-400">
       <i class="pi pi-search text-3xl mb-3 block"></i>
       Nenhuma cidade encontrada para "{{ busca }}"
     </div>

--- a/src/app/modules/public/cidades/cidades.component.scss
+++ b/src/app/modules/public/cidades/cidades.component.scss
@@ -1,88 +1,42 @@
+// Campo de busca projetado no slot [hero-busca].
+@use '../../../shared/styles/hero-busca' as *;
+
 // ── Hero ───────────────────────────────────────────────────────────────────────
-.hero-section {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.5rem 0 0.5rem;
+// A casca (faixa, breadcrumb, H1, subtítulo, tiles) é do <app-page-hero>. Aqui
+// ficam só a ilustração projetada e o container do conteúdo abaixo do hero.
 
-  &__art {
-    width: 8rem;
-    flex-shrink: 0;
-    display: none;
-    @media (min-width: 480px) { display: block; }
-
-    svg { width: 100%; height: auto; }
-  }
+.cidades-arte {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: linear-gradient(160deg, #fdeee2 0%, #f7e0cc 100%);
+  // Mesma curva elíptica da foto em /missas/:uf.
+  border-top-left-radius: 38% 62%;
+  border-bottom-left-radius: 14% 24%;
 }
 
-// ── Busca ──────────────────────────────────────────────────────────────────────
-.search-box {
-  position: relative;
-  max-width: 26rem;
-
-  &__icon {
-    position: absolute;
-    left: 0.875rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: #9ca3af;
-    font-size: 0.875rem;
-    pointer-events: none;
-  }
-
-  &__input {
-    width: 100%;
-    padding: 0.625rem 1rem 0.625rem 2.5rem;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.625rem;
-    font-size: 0.875rem;
-    color: #374151;
-    background: #fff;
-    outline: none;
-    transition: border-color 0.15s;
-
-    &:focus { border-color: #bc5d10; }
-    &::placeholder { color: #9ca3af; }
-  }
+// Mesmo container do hero (72rem / 1.5rem): com o `.card` em full-bleed, é ele
+// que alinha a lista com o breadcrumb e o título logo acima.
+.cidades-page {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
 }
 
-// ── Stats ──────────────────────────────────────────────────────────────────────
-.stats-row {
-  display: flex;
-  gap: 1rem;
-  margin-top: 1.5rem;
-  flex-wrap: wrap;
-}
-
-.stat-item {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  padding: 0.75rem 1rem;
+// Saída do estado de erro de carga.
+.cidades-retry {
+  display: inline-block;
+  margin-top: 0.9rem;
+  padding: 0.55rem 1.1rem;
   background: #fff;
-  border: 1px solid #f3f4f6;
-  border-radius: 0.75rem;
-  flex: 1;
-  min-width: 9rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.625rem;
+  color: #bc5d10;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
 
-  &__icon {
-    font-size: 1.5rem;
-    color: #bc5d10;
-    opacity: 0.7;
-  }
-
-  &__value {
-    font-size: 1rem;
-    font-weight: 700;
-    color: #1f2937;
-    line-height: 1.1;
-  }
-
-  &__label {
-    font-size: 0.7rem;
-    color: #9ca3af;
-    line-height: 1.2;
-  }
+  &:hover { background: #fdf6f0; border-color: #f3b989; }
 }
 
 // ── Card de estado ─────────────────────────────────────────────────────────────

--- a/src/app/modules/public/cidades/cidades.component.ts
+++ b/src/app/modules/public/cidades/cidades.component.ts
@@ -5,6 +5,8 @@ import { FormsModule } from '@angular/forms';
 import { ChurchesService } from '../../../core/services/churches.service';
 import { MetricasService, PaginaMetrica } from '../../../core/services/metricas.service';
 import { STATES } from '../../../core/constants/states';
+import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
+import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
 
 interface CidadeItem { nome: string; slug: string; }
 interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expandido: boolean; }
@@ -12,7 +14,7 @@ interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expan
 @Component({
   selector: 'app-cidades',
   standalone: true,
-  imports: [CommonModule, RouterLink, FormsModule],
+  imports: [CommonModule, RouterLink, FormsModule, PageHeroComponent],
   templateUrl: './cidades.component.html',
   styleUrl: './cidades.component.scss',
 })
@@ -23,6 +25,34 @@ export class CidadesComponent implements OnInit {
   isLoading = true;
   busca = '';
   estados: EstadoItem[] = [];
+
+  readonly breadcrumb: HubBreadcrumb[] = [
+    { label: 'Início', link: ['/home'] },
+    { label: 'Cidades' },
+  ];
+
+  /** `\n` vira quebra de linha (o hero usa `white-space: pre-line`). */
+  readonly TITULO_HERO = 'Horários de Missa\npor';
+
+  /**
+   * Os números saem de `addressRange()` (estados/cidades) e de `getInfo()`
+   * (paróquias). Nada é fixo no template: o "700+" que vivia aqui era um chute
+   * que envelhecia sozinho numa página indexada.
+   */
+  tiles: HeroTile[] = [
+    { icone: 'pi pi-map', numero: 0, rotulo: 'estados e o DF' },
+    { icone: 'pi pi-building', numero: 0, rotulo: 'cidades cadastradas' },
+    { icone: 'pi pi-users', numero: 0, rotulo: 'paróquias e comunidades' },
+  ];
+
+  /** Contagem global de paróquias; `null` enquanto não chega — o tile só entra com número. */
+  private totalParoquias: number | null = null;
+  /**
+   * `addressRange()` falhou. Distingue "não carregou" de "a busca não achou": sem
+   * isso a página exibia "Nenhuma cidade encontrada" com aspas vazias em cima de
+   * um erro de rede. Também zera os tiles — hero sem número é melhor que zeros.
+   */
+  semDados = false;
 
   // Cores por estado (sigla → classe CSS)
   readonly estadoCores: Record<string, string> = {
@@ -49,6 +79,24 @@ export class CidadesComponent implements OnInit {
 
   ngOnInit(): void {
     this._metricas.registrarVisualizacaoPagina(PaginaMetrica.Cidades);
+    this.carregarCidades();
+    this.carregarTotalParoquias();
+  }
+
+  /**
+   * Refaz a carga depois de uma falha. O cache precisa ser descartado antes: o
+   * `shareReplay` de `addressRange()` guarda o erro e devolveria a mesma falha
+   * na hora, sem nova requisição — o botão viraria enfeite.
+   */
+  recarregar(): void {
+    if (this.isLoading) return;
+    this.isLoading = true;
+    this.semDados = false;
+    this._church.limparCacheEnderecos();
+    this.carregarCidades();
+  }
+
+  private carregarCidades(): void {
     this._church.addressRange().subscribe({
       next: ({ data }: any) => {
         this.estados = Object.entries(data)
@@ -64,9 +112,53 @@ export class CidadesComponent implements OnInit {
 
         if (this.estados.length) this.estados[0].expandido = true;
         this.isLoading = false;
+        this.montarTiles();
       },
-      error: () => { this.isLoading = false; },
+      error: () => {
+        this.isLoading = false;
+        // Sem dado, sem tile: "0 estados e o DF" é tão falso quanto o "700+" fixo
+        // que vivia aqui. Melhor não afirmar número nenhum.
+        this.semDados = true;
+        this.montarTiles();
+      },
     });
+  }
+
+  /**
+   * Contagem global de paróquias — mesmo endpoint que a Home usa. Página CSR
+   * (catch-all no `app.routes.server.ts`), então não há prerender para depender
+   * de rede: o número é sempre o de agora. Falhando, o tile sai em vez de exibir
+   * um número inventado.
+   */
+  private carregarTotalParoquias(): void {
+    this._church.getInfo().subscribe({
+      next: (res: any) => {
+        const d = res?.data ?? res ?? {};
+        this.totalParoquias = d.quantidadesIgrejas ?? d.quantidadeIgrejas ?? d.totalIgrejas ?? null;
+        this.montarTiles();
+      },
+      error: () => { this.montarTiles(); },
+    });
+  }
+
+  /**
+   * Sempre um ARRAY NOVO: `PageHeroComponent` é OnPush e só re-renderiza quando a
+   * referência do input muda — mutar `tiles` no lugar não repintaria nada. Mesmo
+   * cuidado que a Home documenta para o `HomeStatsComponent`.
+   */
+  private montarTiles(): void {
+    if (this.semDados) {
+      this.tiles = [];
+      return;
+    }
+    const tiles: HeroTile[] = [
+      { icone: 'pi pi-map', numero: this.estados.length, rotulo: 'estados e o DF' },
+      { icone: 'pi pi-building', numero: this.totalCidades, rotulo: 'cidades cadastradas' },
+    ];
+    if (this.totalParoquias) {
+      tiles.push({ icone: 'pi pi-users', numero: this.totalParoquias, rotulo: 'paróquias e comunidades' });
+    }
+    this.tiles = tiles;
   }
 
   toggleEstado(e: EstadoItem): void { e.expandido = !e.expandido; }

--- a/src/app/modules/public/dias/dias.component.html
+++ b/src/app/modules/public/dias/dias.component.html
@@ -1,0 +1,62 @@
+<app-page-hero
+  [breadcrumb]="breadcrumb"
+  [titulo]="TITULO_HERO"
+  tituloDestaque="Dia da Semana"
+  subtitulo="Encontre horários de missa para qualquer dia da semana, em todo o Brasil."
+  [tiles]="tiles"
+>
+  <!--
+    Sem slot [hero-busca]: são 7 itens, todos visíveis na grade abaixo. Campo de
+    busca aqui seria decoração. O hero não reserva espaço para slot vazio.
+
+    Ilustração leve em vez de foto — mesma razão de /estados.
+  -->
+  <svg class="dias-arte" hero-arte viewBox="0 0 240 300" preserveAspectRatio="xMidYMid meet"
+       xmlns="http://www.w3.org/2000/svg">
+    <ellipse cx="120" cy="252" rx="82" ry="9" fill="#e6c9a8" opacity="0.35" />
+
+    <!-- argolas -->
+    <rect x="78" y="46" width="7" height="26" rx="3.5" fill="#d4a97a" />
+    <rect x="155" y="46" width="7" height="26" rx="3.5" fill="#d4a97a" />
+
+    <!-- folha do calendário -->
+    <rect x="44" y="60" width="152" height="176" rx="14" fill="#f7efe5" stroke="#e6c9a8" stroke-width="2" />
+    <path d="M44 96 h152" stroke="#e6c9a8" stroke-width="2" />
+
+    <!-- cabeçalho: 7 colunas -->
+    <g fill="#d4a97a">
+      <rect x="58" y="74" width="12" height="6" rx="3" />
+      <rect x="78" y="74" width="12" height="6" rx="3" />
+      <rect x="98" y="74" width="12" height="6" rx="3" />
+      <rect x="118" y="74" width="12" height="6" rx="3" />
+      <rect x="138" y="74" width="12" height="6" rx="3" />
+      <rect x="158" y="74" width="12" height="6" rx="3" />
+      <rect x="178" y="74" width="8" height="6" rx="3" />
+    </g>
+
+    <!-- grade de dias, com um destacado -->
+    <g fill="#f0e2d3">
+      <rect x="58" y="110" width="20" height="20" rx="5" />
+      <rect x="86" y="110" width="20" height="20" rx="5" />
+      <rect x="114" y="110" width="20" height="20" rx="5" />
+      <rect x="142" y="110" width="20" height="20" rx="5" />
+      <rect x="170" y="110" width="20" height="20" rx="5" />
+      <rect x="58" y="140" width="20" height="20" rx="5" />
+      <rect x="114" y="140" width="20" height="20" rx="5" />
+      <rect x="142" y="140" width="20" height="20" rx="5" />
+      <rect x="170" y="140" width="20" height="20" rx="5" />
+      <rect x="58" y="170" width="20" height="20" rx="5" />
+      <rect x="86" y="170" width="20" height="20" rx="5" />
+      <rect x="114" y="170" width="20" height="20" rx="5" />
+    </g>
+    <rect x="86" y="140" width="20" height="20" rx="5" fill="#e2761b" />
+
+    <!-- sino: o dia escolhido é dia de missa -->
+    <path d="M150 186 c 0-9 6-16 14-16 s 14 7 14 16 c 0 10 4 13 4 16 h-36 c 0-3 4-6 4-16 z"
+          fill="#d4a97a" />
+    <circle cx="164" cy="166" r="3.4" fill="#d4a97a" />
+    <path d="M160 206 h8 a4 4 0 0 1-8 0 z" fill="#d4a97a" />
+  </svg>
+</app-page-hero>
+
+<app-hub-lista icone="pi pi-calendar" [itens]="itens" />

--- a/src/app/modules/public/dias/dias.component.scss
+++ b/src/app/modules/public/dias/dias.component.scss
@@ -1,0 +1,11 @@
+// Ilustração projetada em [hero-arte]. A caixa é do <app-page-hero>; o
+// preenchimento e o recorte são desta página.
+.dias-arte {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: linear-gradient(160deg, #fdeee2 0%, #f7e0cc 100%);
+  // Mesma curva elíptica da foto em /missas/:uf.
+  border-top-left-radius: 38% 62%;
+  border-bottom-left-radius: 14% 24%;
+}

--- a/src/app/modules/public/dias/dias.component.ts
+++ b/src/app/modules/public/dias/dias.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
+import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -18,14 +19,9 @@ const SITE = 'https://buscamissa.com.br';
 @Component({
   selector: 'app-dias',
   standalone: true,
-  imports: [CommonModule, HubListaComponent],
-  template: `<app-hub-lista
-    [breadcrumb]="breadcrumb"
-    titulo="Missas por dia da semana"
-    subtitulo="Encontre horários de missa para qualquer dia da semana, em todo o Brasil."
-    icone="pi pi-calendar"
-    [itens]="itens"
-  />`,
+  imports: [CommonModule, HubListaComponent, PageHeroComponent],
+  templateUrl: './dias.component.html',
+  styleUrl: './dias.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DiasComponent implements OnInit, OnDestroy {
@@ -34,6 +30,20 @@ export class DiasComponent implements OnInit, OnDestroy {
   readonly breadcrumb: HubBreadcrumb[] = [
     { label: 'Início', link: ['/home'] },
     { label: 'Dias da semana' },
+  ];
+
+  /** `\n` vira quebra de linha (o hero usa `white-space: pre-line`). */
+  readonly TITULO_HERO = 'Horários de Missa\npor';
+
+  /**
+   * Números FIXOS, de constante — nada de rede. `ChurchesService.getInfo()`
+   * (`v1/Igreja/infos`) não tem StateKey em `prerender-state-keys.ts`, então
+   * nenhum interceptor de prerender o escreve: usá-lo aqui faria o prerender
+   * desta rota depender da API estar acessível na máquina de build, e assaria no
+   * HTML indexado um número que envelhece. Contagem global é papel da Home.
+   */
+  readonly tiles: HeroTile[] = [
+    { icone: 'pi pi-calendar', numero: DIAS_INTENCAO.length, rotulo: 'dias da semana' },
   ];
 
   readonly itens: HubItem[] = DIAS_INTENCAO.map((d) => ({

--- a/src/app/modules/public/estado/estado.component.html
+++ b/src/app/modules/public/estado/estado.component.html
@@ -20,89 +20,63 @@
     </div>
   } @else {
     <!-- ================= HERO ================= -->
-    <div class="estado-hero">
-      <div class="estado-hero__conteudo">
-        <nav class="breadcrumb" aria-label="Trilha de navegação">
-          <a routerLink="/home">Início</a><span aria-hidden="true">›</span>
-          <a routerLink="/estados">Estados</a><span aria-hidden="true">›</span>
-          <span aria-current="page">{{ estadoNome }}</span>
-        </nav>
-
-        <h1 class="estado-hero__titulo">
-          Horários de Missa no<br />Estado de <span class="estado-hero__uf">{{ estadoNome }}</span>
-        </h1>
-
-        <p class="estado-hero__sub">
-          Encontre igrejas, paróquias e horários de missa<br />em todo o estado de {{ estadoNome }}.
-        </p>
-
-        <div class="tiles">
-          <div class="tile">
-            <span class="tile__ico" aria-hidden="true"><i class="pi pi-building"></i></span>
-            <span class="tile__dados">
-              <span class="tile__num">{{ totalParoquias }}</span>
-              <span class="tile__lbl">paróquias</span>
-            </span>
-          </div>
-          <div class="tile">
-            <span class="tile__ico" aria-hidden="true"><i class="pi pi-map-marker"></i></span>
-            <span class="tile__dados">
-              <span class="tile__num">{{ totalCidades }}</span>
-              <span class="tile__lbl">cidades</span>
-            </span>
-          </div>
+    <app-page-hero
+      [breadcrumb]="breadcrumb"
+      [titulo]="TITULO_HERO"
+      [tituloDestaque]="estadoNome"
+      [subtitulo]="subtituloHero"
+      [tiles]="tilesHero"
+      hint="Digite o nome da cidade para encontrar os horários de missa."
+    >
+      <!-- Autocomplete: atalho para a cidade, não filtro do índice lá embaixo. -->
+      <div class="busca-hero" hero-busca>
+        <div class="busca">
+          <i class="pi pi-search" aria-hidden="true"></i>
+          <input type="search" [(ngModel)]="buscaHero" (ngModelChange)="aoDigitarNoHero()"
+                 (keydown.enter)="aoConfirmarHero()"
+                 [attr.placeholder]="'Buscar cidade em ' + estadoNome + '...'"
+                 aria-label="Buscar cidade" autocomplete="off" role="combobox"
+                 [attr.aria-expanded]="sugestoes.length > 0" aria-controls="sugestoes-cidade" />
         </div>
 
-        <!-- Autocomplete: atalho para a cidade, não filtro do índice lá embaixo. -->
-        <div class="busca-hero">
-          <div class="busca">
-            <i class="pi pi-search" aria-hidden="true"></i>
-            <input type="search" [(ngModel)]="buscaHero" (ngModelChange)="aoDigitarNoHero()"
-                   (keydown.enter)="aoConfirmarHero()"
-                   [attr.placeholder]="'Buscar cidade em ' + estadoNome + '...'"
-                   aria-label="Buscar cidade" autocomplete="off" role="combobox"
-                   [attr.aria-expanded]="sugestoes.length > 0" aria-controls="sugestoes-cidade" />
-          </div>
-
-          @if (sugestoes.length) {
-            <ul class="sugestoes" id="sugestoes-cidade" role="listbox">
-              @for (s of sugestoes; track s.cidadeSlug) {
-                <li role="option" [attr.aria-selected]="false">
-                  <a [routerLink]="['/missas', uf, s.cidadeSlug]" (click)="irParaCidade(s)">
-                    <i class="pi pi-map-marker" aria-hidden="true"></i>
-                    <span class="sugestoes__nome">{{ s.cidade }}</span>
-                    <span class="sugestoes__meta">{{ s.totalParoquias }} paróquias</span>
-                  </a>
-                </li>
-              }
-            </ul>
-          }
-        </div>
-        <p class="busca__hint">Digite o nome da cidade para encontrar os horários de missa.</p>
+        @if (sugestoes.length) {
+          <ul class="sugestoes" id="sugestoes-cidade" role="listbox">
+            @for (s of sugestoes; track s.cidadeSlug) {
+              <li role="option" [attr.aria-selected]="false">
+                <a [routerLink]="['/missas', uf, s.cidadeSlug]" (click)="irParaCidade(s)">
+                  <i class="pi pi-map-marker" aria-hidden="true"></i>
+                  <span class="sugestoes__nome">{{ s.cidade }}</span>
+                  <span class="sugestoes__meta">{{ s.totalParoquias }} paróquias</span>
+                </a>
+              </li>
+            }
+          </ul>
+        }
       </div>
 
-      <!-- Decorativa: em telas estreitas o <source> vazio impede o download. -->
-      <div class="estado-hero__foto" aria-hidden="true">
-        <!--
-          O <source> só casa a partir de 900px, que é onde a foto aparece; abaixo
-          disso o `img` cai no GIF transparente inline e NÃO há requisição de rede.
+      <!--
+        Decorativa: em telas estreitas o <source> vazio impede o download.
 
-          Um `<source media="(max-width:899px)" srcset="">` não serve: srcset vazio
-          invalida aquele source, o browser cai no `img src` e baixa os 70 KB mesmo
-          com o container em display:none — foi o que aconteceu (currentSrc apontava
-          para o .webp num viewport de 390px).
+        O <source> só casa a partir de 900px, que é onde a foto aparece; abaixo
+        disso o `img` cai no GIF transparente inline e NÃO há requisição de rede.
 
-          O `img` continua sendo <img> (e não background-image no CSS) para o
-          preload scanner achar a imagem cedo no desktop, onde ela é o LCP.
-        -->
-        <picture>
-          <source media="(min-width: 900px)" type="image/webp"
-                  srcset="assets/images/catedral-estado.webp" />
-          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-               alt="" fetchpriority="high" width="1200" height="1801" decoding="async" />
-        </picture>
-      </div>
-    </div>
+        Um `<source media="(max-width:899px)" srcset="">` não serve: srcset vazio
+        invalida aquele source, o browser cai no `img src` e baixa os 70 KB mesmo
+        com o container em display:none — foi o que aconteceu (currentSrc apontava
+        para o .webp num viewport de 390px).
+
+        O `img` continua sendo <img> (e não background-image no CSS) para o
+        preload scanner achar a imagem cedo no desktop, onde ela é o LCP.
+
+        O `aria-hidden` fica na caixa do hero (.ph-hero__arte), não aqui.
+      -->
+      <picture class="estado-foto" hero-arte>
+        <source media="(min-width: 900px)" type="image/webp"
+                srcset="assets/images/catedral-estado.webp" />
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+             alt="" fetchpriority="high" width="1200" height="1801" decoding="async" />
+      </picture>
+    </app-page-hero>
 
     <!-- ============ PRINCIPAIS CIDADES ============ -->
     @if (principaisCidades.length) {

--- a/src/app/modules/public/estado/estado.component.scss
+++ b/src/app/modules/public/estado/estado.component.scss
@@ -1,3 +1,6 @@
+// Campo de busca do hero: markup desta página, projetado em [hero-busca].
+@use '../../../shared/styles/hero-busca' as *;
+
 $laranja: #bc5d10;
 $laranja-vivo: #e2761b;
 $creme: #fdf6f0;
@@ -19,118 +22,21 @@ $muted: #6b7280;
 .centro { display: flex; justify-content: center; margin-top: 1.25rem; }
 
 /* ================= HERO ================= */
-/* Faixa creme full-bleed; a foto ocupa a direita e "sangra" até a borda da
-   viewport, com o lado esquerdo curvo (elíptico) sobre o creme. */
-.estado-hero {
-  position: relative;
-  background: $creme;
-  overflow: hidden;
-  padding: 1.5rem 0 2.5rem;
-  margin-bottom: 2.75rem;
-  /* Sangra de borda a borda porque o .card desta página não limita a largura
-     (ver styles.scss). Sem 100vw de propósito: ele inclui a barra de rolagem. */
-  width: 100%;
-  /* .hero global (styles.scss) centraliza texto; aqui o alinhamento é à esquerda. */
-  text-align: left;
-}
-@media (min-width: 900px) {
-  /* altura maior deixa a fachada da catedral respirar (object-fit: cover recorta) */
-  .estado-hero { min-height: 30rem; display: flex; align-items: center; }
-}
-.estado-hero__conteudo {
-  position: relative;
-  z-index: 2;
-  width: 100%;
-  max-width: 72rem;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-}
-@media (min-width: 900px) {
-  /* reserva a faixa da foto para o texto nunca correr por baixo da imagem */
-  .estado-hero__conteudo { padding-right: calc(42% + 1.5rem); }
-}
+/* A casca (faixa creme, breadcrumb, título, subtítulo, tiles) é do
+   <app-page-hero>. Aqui ficam só os elementos projetados nos slots, porque com
+   encapsulação emulada eles carregam o atributo DESTE componente. */
 
-.estado-hero__foto { display: none; }
-@media (min-width: 900px) {
-  .estado-hero__foto {
-    display: block;
-    position: absolute;
-    top: 0; right: 0; bottom: 0;
-    width: 44%;
-    z-index: 1;
-    img {
-      width: 100%; height: 100%;
-      object-fit: cover;
-      object-position: center 35%;
-      display: block;
-      /* curva elíptica suave no lado esquerdo, avançando sobre o creme */
-      border-top-left-radius: 38% 62%;
-      border-bottom-left-radius: 14% 24%;
-    }
-  }
+/* FOTO projetada em [hero-arte]. A caixa (posição/tamanho/ocultar no mobile) é do
+   hero; o recorte elíptico é específico da fachada da catedral e mora aqui. */
+.estado-foto img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  object-position: center 35%;
+  display: block;
+  /* curva elíptica suave no lado esquerdo, avançando sobre o creme */
+  border-top-left-radius: 38% 62%;
+  border-bottom-left-radius: 14% 24%;
 }
-
-.breadcrumb {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem;
-  font-size: 0.85rem; color: $muted; margin-bottom: 1.25rem;
-  a { color: #2563eb; text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  span[aria-current] { color: #374151; font-weight: 600; }
-}
-
-.estado-hero__titulo {
-  font-size: 1.75rem;
-  font-weight: 800;
-  line-height: 1.18;
-  letter-spacing: -0.01em;
-  margin: 0 0 0.9rem;
-  color: $titulo;
-  @media (min-width: 640px) { font-size: 2.25rem; }
-  @media (min-width: 1024px) { font-size: 2.5rem; }
-}
-.estado-hero__uf { color: $laranja-vivo; }
-
-.estado-hero__sub {
-  color: $texto;
-  margin: 0 0 1.5rem;
-  font-size: 1rem;
-  line-height: 1.55;
-}
-
-/* STAT TILES — cards brancos com borda, como no layout */
-.tiles { display: flex; flex-wrap: wrap; gap: 0.9rem; margin-bottom: 1.75rem; }
-.tile {
-  display: flex; align-items: center; gap: 0.7rem;
-  background: #fff; border: 1px solid #f0e2d6; border-radius: 14px;
-  padding: 0.85rem 1.15rem; min-width: 140px;
-}
-.tile__ico {
-  display: grid; place-items: center;
-  width: 34px; height: 34px; flex: 0 0 34px;
-  background: $creme-forte; border-radius: 10px;
-  i { color: $laranja-vivo; font-size: 1.05rem; }
-}
-.tile__dados { display: block; }
-.tile__num {
-  display: block; font-size: 1.375rem; font-weight: 800; color: $titulo;
-  line-height: 1.1; font-variant-numeric: tabular-nums;
-}
-.tile__lbl { display: block; font-size: 0.8125rem; color: $muted; }
-
-/* BUSCA do hero */
-.busca {
-  display: flex; align-items: center; gap: 0.7rem;
-  background: #fff; border: 1px solid #ecdccd; border-radius: 14px; padding: 0 1.1rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,.03);
-  i { color: #9ca3af; font-size: 1.05rem; }
-  input {
-    flex: 1; border: 0; outline: none; background: transparent;
-    padding: 1rem 0; font-size: 1rem; color: $texto; min-width: 0;
-  }
-  input::placeholder { color: #9ca3af; }
-  &:focus-within { border-color: #f3b989; box-shadow: 0 0 0 3px rgba(226,118,27,.12); }
-}
-.busca__hint { color: $muted; font-size: 0.85rem; margin: 0.6rem 0 0; }
 
 /* AUTOCOMPLETE do hero */
 .busca-hero { position: relative; }

--- a/src/app/modules/public/estado/estado.component.ts
+++ b/src/app/modules/public/estado/estado.component.ts
@@ -17,6 +17,8 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
+import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
+import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -55,7 +57,7 @@ interface DiaLink {
 @Component({
   selector: 'app-estado',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, SkeletonModule],
+  imports: [CommonModule, FormsModule, RouterLink, SkeletonModule, PageHeroComponent],
   templateUrl: './estado.component.html',
   styleUrl: './estado.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -85,6 +87,15 @@ export class EstadoComponent implements OnInit, OnDestroy {
   estadoNome = '';
   totalCidades = 0;
   totalParoquias = 0;
+
+  // --- Hero (app-page-hero). Como os demais derivados abaixo, é montado UMA vez
+  // por carga: com OnPush e 26 UFs prerenderizadas, getter de template sairia caro. ---
+
+  /** `\n` vira quebra de linha — o hero renderiza o título com `white-space: pre-line`. */
+  readonly TITULO_HERO = 'Horários de Missa no\nEstado de';
+  breadcrumb: HubBreadcrumb[] = [];
+  subtituloHero = '';
+  tilesHero: HeroTile[] = [];
 
   // --- Derivados calculados UMA vez ao carregar (não são getters de template:
   // com 100+ cidades, refazer filter/sort/groupBy a cada ciclo de change
@@ -137,6 +148,20 @@ export class EstadoComponent implements OnInit, OnDestroy {
     this._seo.removeJsonLd('itemlist');
   }
 
+  /** Monta os dados do `app-page-hero`. Chamado uma vez por carga. */
+  private montarHero(): void {
+    this.breadcrumb = [
+      { label: 'Início', link: ['/home'] },
+      { label: 'Estados', link: ['/estados'] },
+      { label: this.estadoNome },
+    ];
+    this.subtituloHero = `Encontre igrejas, paróquias e horários de missa\nem todo o estado de ${this.estadoNome}.`;
+    this.tilesHero = [
+      { icone: 'pi pi-building', numero: this.totalParoquias, rotulo: 'paróquias' },
+      { icone: 'pi pi-map-marker', numero: this.totalCidades, rotulo: 'cidades' },
+    ];
+  }
+
   // ============================ carga ============================
 
   private carregar(): void {
@@ -166,6 +191,9 @@ export class EstadoComponent implements OnInit, OnDestroy {
           this.totalParoquias = data.totalParoquias ?? 0;
           this.indexarCidades(data.cidades ?? []);
           this.dias = this.montarDias(data.dias);
+          // Depois de indexarCidades: é lá que `totalCidades` é reconciliado com o
+          // número de cidades realmente listadas.
+          this.montarHero();
           this.aplicarSeo(data.seo);
           this.aplicarJsonLd();
           this._cdr.markForCheck();

--- a/src/app/modules/public/estados/estados.component.html
+++ b/src/app/modules/public/estados/estados.component.html
@@ -1,0 +1,51 @@
+<app-page-hero
+  [breadcrumb]="breadcrumb"
+  [titulo]="TITULO_HERO"
+  tituloDestaque="Estado"
+  subtitulo="Explore as igrejas e horários de missa em cada estado do Brasil."
+  [tiles]="tiles"
+  [tilesCarregando]="carregando"
+  hint="Digite o nome do estado para ir direto ao hub dele."
+>
+  <div class="busca" hero-busca>
+    <i class="pi pi-search" aria-hidden="true"></i>
+    <input type="search" [(ngModel)]="busca" (ngModelChange)="aoFiltrar()"
+           placeholder="Buscar estado..." aria-label="Buscar estado" autocomplete="off" />
+  </div>
+
+  <!-- Ilustração leve, não foto: esta página abre em 27 URLs indexadas e não vale
+       pagar bytes de imagem por uma peça puramente decorativa. -->
+  <svg class="estados-arte" hero-arte viewBox="0 0 240 300" preserveAspectRatio="xMidYMid meet"
+       xmlns="http://www.w3.org/2000/svg">
+    <ellipse cx="120" cy="268" rx="88" ry="9" fill="#e6c9a8" opacity="0.35" />
+
+    <!-- folha de mapa com dobras -->
+    <path d="M42 74 L98 56 L154 76 L206 58 L206 216 L154 234 L98 214 L42 232 Z"
+          fill="#f7efe5" stroke="#e6c9a8" stroke-width="2" stroke-linejoin="round" />
+    <path d="M98 56 L98 214 M154 76 L154 234" stroke="#e6c9a8" stroke-width="2"
+          stroke-dasharray="7 6" fill="none" />
+
+    <!-- rota entre duas cidades -->
+    <path d="M74 168 C 104 150, 122 128, 160 118" stroke="#d4a97a" stroke-width="2.5"
+          stroke-dasharray="5 7" stroke-linecap="round" fill="none" />
+
+    <!-- pins -->
+    <path d="M160 90 c 11 0 20 9 20 20 0 15-20 34-20 34 0 0-20-19-20-34 0-11 9-20 20-20 z"
+          fill="#e2761b" />
+    <circle cx="160" cy="110" r="7.5" fill="#fdf6f0" />
+
+    <path d="M74 146 c 8 0 14 6 14 14 0 11-14 24-14 24 0 0-14-13-14-24 0-8 6-14 14-14 z"
+          fill="#d4a97a" />
+    <circle cx="74" cy="160" r="5" fill="#fdf6f0" />
+
+    <path d="M118 186 c 7 0 12 5 12 12 0 9-12 20-12 20 0 0-12-11-12-20 0-7 5-12 12-12 z"
+          fill="#e6c9a8" />
+    <circle cx="118" cy="198" r="4.2" fill="#fdf6f0" />
+  </svg>
+</app-page-hero>
+
+<app-hub-lista icone="pi pi-map-marker" [itens]="itensVisiveis" />
+
+@if (busca && !itensVisiveis.length) {
+  <p class="estados-vazio">Nenhum estado encontrado para "{{ busca }}".</p>
+}

--- a/src/app/modules/public/estados/estados.component.scss
+++ b/src/app/modules/public/estados/estados.component.scss
@@ -1,0 +1,23 @@
+// Campo de busca projetado no slot [hero-busca].
+@use '../../../shared/styles/hero-busca' as *;
+
+// Ilustração projetada em [hero-arte]. A caixa (posição, largura, ocultar abaixo
+// de 900px) é do <app-page-hero>; o preenchimento e o recorte são desta página.
+.estados-arte {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: linear-gradient(160deg, #fdeee2 0%, #f7e0cc 100%);
+  // Mesma curva elíptica da foto em /missas/:uf — é o que faz as duas páginas
+  // parecerem do mesmo produto.
+  border-top-left-radius: 38% 62%;
+  border-bottom-left-radius: 14% 24%;
+}
+
+.estados-vazio {
+  max-width: 72rem;
+  margin: -1rem auto 0;
+  padding: 0 1.5rem 2rem;
+  color: #6b7280;
+  text-align: center;
+}

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -1,10 +1,12 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { STATES } from '../../../core/constants/states';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
+import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -29,14 +31,9 @@ interface EstadoResumo {
 @Component({
   selector: 'app-estados',
   standalone: true,
-  imports: [CommonModule, HubListaComponent],
-  template: `<app-hub-lista
-    [breadcrumb]="breadcrumb"
-    titulo="Missas por estado"
-    subtitulo="Explore as igrejas e horários de missa em cada estado do Brasil."
-    icone="pi pi-map-marker"
-    [itens]="itens"
-  />`,
+  imports: [CommonModule, FormsModule, HubListaComponent, PageHeroComponent],
+  templateUrl: './estados.component.html',
+  styleUrl: './estados.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EstadosComponent implements OnInit, OnDestroy {
@@ -50,8 +47,35 @@ export class EstadosComponent implements OnInit, OnDestroy {
     { label: 'Estados' },
   ];
 
+  /** `\n` vira quebra de linha (o hero usa `white-space: pre-line`). */
+  readonly TITULO_HERO = 'Horários de Missa\npor';
+
   itens: HubItem[] = [];
+  /** O que o hub-lista renderiza — igual a `itens` enquanto não há filtro. */
+  itensVisiveis: HubItem[] = [];
+  tiles: HeroTile[] = [];
+  carregando = true;
+  busca = '';
   private estados: EstadoResumo[] = [];
+
+  /**
+   * Filtro LOCAL sobre os 27 itens já carregados — não vai à API. No prerender a
+   * busca está vazia, então o HTML assado continua com todos os `<a href>` de UF.
+   */
+  aoFiltrar(): void {
+    const q = this.normalizar(this.busca);
+    this.itensVisiveis = q
+      ? this.itens.filter((i) => this.normalizar(i.nome).includes(q))
+      : this.itens;
+  }
+
+  private normalizar(v: string): string {
+    return v
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
+      .toLowerCase()
+      .trim();
+  }
 
   ngOnInit(): void {
     this.aplicarSeo();
@@ -81,6 +105,18 @@ export class EstadosComponent implements OnInit, OnDestroy {
       meta: `${e.totalParoquias} paróquia(s) em ${e.totalCidades} cidade(s)`,
       link: ['/missas', e.uf.toLowerCase()],
     }));
+    this.itensVisiveis = this.itens;
+
+    // Somas do payload que já foi carregado — nenhuma requisição a mais.
+    const paroquias = estados.reduce((s, e) => s + (e.totalParoquias ?? 0), 0);
+    const cidades = estados.reduce((s, e) => s + (e.totalCidades ?? 0), 0);
+    this.tiles = [
+      { icone: 'pi pi-building', numero: paroquias, rotulo: 'paróquias' },
+      { icone: 'pi pi-map-marker', numero: cidades, rotulo: 'cidades' },
+      { icone: 'pi pi-map', numero: estados.length, rotulo: 'estados' },
+    ];
+    this.carregando = false;
+
     this.aplicarJsonLd();
     this._cdr.markForCheck();
   }
@@ -93,6 +129,11 @@ export class EstadosComponent implements OnInit, OnDestroy {
       totalParoquias: 0,
     }));
     this.itens = this.estados.map((e) => ({ nome: e.estado, link: ['/missas', e.uf] }));
+    this.itensVisiveis = this.itens;
+    // Sem tiles: neste caminho os totais são 0 (a lista estática não os tem), e
+    // "0 paróquias" numa página indexada é pior que não mostrar número nenhum.
+    this.tiles = [];
+    this.carregando = false;
     this.aplicarJsonLd();
     this._cdr.markForCheck();
   }

--- a/src/app/shared/components/hub-lista/hub-lista.component.scss
+++ b/src/app/shared/components/hub-lista/hub-lista.component.scss
@@ -1,10 +1,14 @@
 $laranja: #bc5d10;
 $borda: #e5e7eb;
 
+// Mesmo container do <app-page-hero> (72rem / 1.5rem): as duas páginas que usam
+// este hub abrem com o hero, e medidas diferentes deixavam a grade desalinhada
+// com o breadcrumb e o título logo acima. Sem padding-top: o respiro depois do
+// hero já vem do `margin-bottom` dele.
 .hub {
-  max-width: 1080px;
+  max-width: 72rem;
   margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  padding: 0 1.5rem 3rem;
 }
 
 .hub__breadcrumb {

--- a/src/app/shared/components/hub-lista/hub-lista.component.ts
+++ b/src/app/shared/components/hub-lista/hub-lista.component.ts
@@ -31,7 +31,11 @@ export interface HubItem {
 })
 export class HubListaComponent {
   @Input() breadcrumb: HubBreadcrumb[] = [];
-  @Input({ required: true }) titulo = '';
+  /**
+   * Opcional: nas páginas que abrem com `<app-page-hero>` o H1, o subtítulo e o
+   * breadcrumb são do hero, e o hub-lista entra só como grade de cards.
+   */
+  @Input() titulo = '';
   @Input() subtitulo?: string;
   /** Ícone PrimeIcons dos cards (ex.: 'pi pi-map-marker'). */
   @Input() icone = 'pi pi-map-marker';

--- a/src/app/shared/components/page-hero/page-hero.component.html
+++ b/src/app/shared/components/page-hero/page-hero.component.html
@@ -1,0 +1,63 @@
+<div class="ph-hero">
+  <div class="ph-hero__conteudo">
+    @if (breadcrumb.length) {
+      <nav class="ph-hero__breadcrumb" aria-label="Trilha de navegação">
+        @for (b of breadcrumb; track b.label; let last = $last) {
+          @if (b.link && !last) {
+            <a [routerLink]="b.link">{{ b.label }}</a>
+            <span aria-hidden="true">›</span>
+          } @else {
+            <span aria-current="page">{{ b.label }}</span>
+          }
+        }
+      </nav>
+    }
+
+    <h1 class="ph-hero__titulo">{{ titulo }}@if (tituloDestaque) {<span class="ph-hero__destaque"> {{ tituloDestaque }}</span>}</h1>
+
+    @if (subtitulo) {
+      <p class="ph-hero__sub">{{ subtitulo }}</p>
+    }
+
+    @if (tiles.length) {
+      <div class="ph-hero__tiles">
+        @for (t of tiles; track t.rotulo) {
+          <div class="ph-tile">
+            <span class="ph-tile__ico" aria-hidden="true"><i [class]="t.icone"></i></span>
+            <span class="ph-tile__dados">
+              @if (tilesCarregando) {
+                <span class="ph-tile__num"><p-skeleton width="2.5rem" height="1.375rem" /></span>
+              } @else {
+                <span class="ph-tile__num">{{ t.numero }}</span>
+              }
+              <span class="ph-tile__lbl">{{ t.rotulo }}</span>
+            </span>
+          </div>
+        }
+      </div>
+    }
+
+    <!--
+      Sem margem própria: o espaçamento vem do bloco anterior (.ph-hero__tiles).
+      Assim uma página sem busca (ex.: /dias) não ganha um buraco reservado.
+    -->
+    <div class="ph-hero__busca">
+      <ng-content select="[hero-busca]"></ng-content>
+    </div>
+
+    @if (hint) {
+      <p class="ph-hero__hint">{{ hint }}</p>
+    }
+  </div>
+
+  <!--
+    Caixa da arte: o hero só POSICIONA (oculta abaixo de 900px, ancora à direita).
+    O estilo do que vai dentro — <picture>/<svg> — é da página, que é dona daquele
+    markup: com encapsulação emulada o filho projetado carrega o atributo da página,
+    não o do hero. Deixar assim evita ::ng-deep e evita o hero depender de estilo
+    interno de quem o consome.
+  -->
+  <div class="ph-hero__arte" aria-hidden="true">
+    <ng-content select="[hero-arte]"></ng-content>
+  </div>
+</div>

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -1,0 +1,110 @@
+$laranja-vivo: #e2761b;
+$creme: #fdf6f0;
+$creme-forte: #fdeee2;
+$titulo: #1f2937;
+$texto: #374151;
+$muted: #6b7280;
+
+/* ================= HERO ================= */
+/* Faixa creme full-bleed; a arte ocupa a direita e "sangra" até a borda da
+   viewport, com o lado esquerdo curvo sobre o creme. */
+.ph-hero {
+  position: relative;
+  background: $creme;
+  overflow: hidden;
+  padding: 1.5rem 0 2.5rem;
+  margin-bottom: 2.75rem;
+  /* Sangra de borda a borda porque `.card:has(.ph-hero)` remove o limite de
+     largura do layout (ver styles.scss). Sem 100vw de propósito: ele inclui a
+     barra de rolagem e criaria scroll lateral. */
+  width: 100%;
+  /* .hero global (styles.scss) centraliza texto; aqui o alinhamento é à esquerda. */
+  text-align: left;
+}
+@media (min-width: 900px) {
+  /* altura maior deixa a arte respirar (object-fit: cover recorta) */
+  .ph-hero { min-height: 30rem; display: flex; align-items: center; }
+}
+
+.ph-hero__conteudo {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+@media (min-width: 900px) {
+  /* reserva a faixa da arte para o texto nunca correr por baixo dela */
+  .ph-hero__conteudo { padding-right: calc(42% + 1.5rem); }
+}
+
+/* Só a CAIXA da arte é do hero; o conteúdo projetado é estilizado pela página. */
+.ph-hero__arte { display: none; }
+@media (min-width: 900px) {
+  .ph-hero__arte {
+    display: block;
+    position: absolute;
+    top: 0; right: 0; bottom: 0;
+    width: 44%;
+    z-index: 1;
+  }
+}
+
+.ph-hero__breadcrumb {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem;
+  font-size: 0.85rem; color: $muted; margin-bottom: 1.25rem;
+  a { color: #2563eb; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  span[aria-current] { color: #374151; font-weight: 600; }
+}
+
+.ph-hero__titulo {
+  font-size: 1.75rem;
+  font-weight: 800;
+  line-height: 1.18;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.9rem;
+  color: $titulo;
+  /* Quebras vêm como `\n` no input `titulo` — preserva o <br> do layout original
+     sem innerHTML. `pre-line` colapsa espaços, então só a quebra sobrevive. */
+  white-space: pre-line;
+  @media (min-width: 640px) { font-size: 2.25rem; }
+  @media (min-width: 1024px) { font-size: 2.5rem; }
+}
+.ph-hero__destaque { color: $laranja-vivo; }
+
+.ph-hero__sub {
+  color: $texto;
+  margin: 0 0 1.5rem;
+  font-size: 1rem;
+  line-height: 1.55;
+  white-space: pre-line;
+}
+
+/* STAT TILES — cards brancos com borda */
+.ph-hero__tiles { display: flex; flex-wrap: wrap; gap: 0.9rem; margin-bottom: 1.75rem; }
+.ph-tile {
+  display: flex; align-items: center; gap: 0.7rem;
+  background: #fff; border: 1px solid #f0e2d6; border-radius: 14px;
+  padding: 0.85rem 1.15rem; min-width: 140px;
+}
+.ph-tile__ico {
+  display: grid; place-items: center;
+  width: 34px; height: 34px; flex: 0 0 34px;
+  background: $creme-forte; border-radius: 10px;
+  i { color: $laranja-vivo; font-size: 1.05rem; }
+}
+.ph-tile__dados { display: block; }
+.ph-tile__num {
+  display: block; font-size: 1.375rem; font-weight: 800; color: $titulo;
+  line-height: 1.1; font-variant-numeric: tabular-nums;
+  /* Mesma caixa com número ou com skeleton — o tile não muda de altura. */
+  min-height: 1.5125rem;
+}
+.ph-tile__lbl { display: block; font-size: 0.8125rem; color: $muted; }
+
+/* Slot da busca: sem margem própria (ver comentário no template). */
+.ph-hero__busca { position: relative; }
+
+.ph-hero__hint { color: $muted; font-size: 0.85rem; margin: 0.6rem 0 0; }

--- a/src/app/shared/components/page-hero/page-hero.component.ts
+++ b/src/app/shared/components/page-hero/page-hero.component.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { SkeletonModule } from 'primeng/skeleton';
+import { HubBreadcrumb } from '../hub-lista/hub-lista.component';
+
+/** Número em destaque do hero (ex.: "3 paróquias"). */
+export interface HeroTile {
+  /** Classe PrimeIcons (ex.: 'pi pi-building'). */
+  icone: string;
+  numero: string | number;
+  rotulo: string;
+}
+
+/**
+ * HERO de página reutilizável — a casca visual dos hubs de navegação (`/missas/:uf`,
+ * `/estados`, `/dias`, `/cidades`). Extraído do hero de `/missas/:uf`, que continua
+ * sendo a referência: faixa creme sangrando de borda a borda, breadcrumb, H1 com o
+ * termo em destaque, subtítulo, tiles de números e os lugares da busca e da arte.
+ *
+ * É PRESENTACIONAL de propósito. A busca de cada página tem lógica própria
+ * (autocomplete de cidade em `/missas/:uf`, filtro local em `/estados` e `/cidades`,
+ * nenhuma em `/dias`) e entra por `ng-content`, não por input — o hero não pode virar
+ * componente de negócio. SEO, JSON-LD e carga de dados também ficam na página.
+ *
+ * O full-bleed depende de `.layout-main > .card:has(.ph-hero)` em `styles.scss`:
+ * o `.card` do layout limita as páginas a 640px, e a presença de `.ph-hero` é o
+ * gatilho que libera a largura. Por isso a classe raiz não pode ser renomeada sem
+ * atualizar aquela regra.
+ */
+@Component({
+  selector: 'app-page-hero',
+  standalone: true,
+  imports: [CommonModule, RouterModule, SkeletonModule],
+  templateUrl: './page-hero.component.html',
+  styleUrls: ['./page-hero.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageHeroComponent {
+  @Input() breadcrumb: HubBreadcrumb[] = [];
+
+  /**
+   * Texto do `<h1>`. Quebras de linha vão como `\n` (o título é renderizado com
+   * `white-space: pre-line`) — preserva o `<br>` do layout original sem precisar
+   * de innerHTML.
+   */
+  @Input({ required: true }) titulo = '';
+
+  /** Trecho final do título pintado em laranja (ex.: o nome do estado). */
+  @Input() tituloDestaque?: string;
+
+  /** Também aceita `\n` para quebra de linha. */
+  @Input() subtitulo?: string;
+
+  /** Lista vazia remove a faixa de tiles inteira — sem reservar espaço. */
+  @Input() tiles: HeroTile[] = [];
+
+  /**
+   * Troca SÓ os números por skeleton, preservando a altura do tile (anti-CLS).
+   * Deliberadamente estreito: um `carregando` genérico convidaria a esconder
+   * breadcrumb/título/subtítulo, que são estáticos e devem aparecer de imediato.
+   */
+  @Input() tilesCarregando = false;
+
+  /** Linha de ajuda abaixo da busca. Só aparece se houver texto. */
+  @Input() hint?: string;
+}

--- a/src/app/shared/styles/_hero-busca.scss
+++ b/src/app/shared/styles/_hero-busca.scss
@@ -1,0 +1,24 @@
+// Campo de busca projetado no slot [hero-busca] do <app-page-hero>.
+//
+// Mora aqui, e não no SCSS do hero, por causa da encapsulação emulada: o markup
+// da busca pertence à PÁGINA (cada uma tem lógica própria — autocomplete de
+// cidade, filtro local...), então só o SCSS da página alcança aqueles elementos.
+// O partial evita repetir estas regras em cada consumidor sem acoplar o hero.
+//
+// Uso: `@use '../../../shared/styles/hero-busca' as *;` no topo do SCSS da página.
+
+$hb-texto: #374151;
+$hb-muted: #6b7280;
+
+.busca {
+  display: flex; align-items: center; gap: 0.7rem;
+  background: #fff; border: 1px solid #ecdccd; border-radius: 14px; padding: 0 1.1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+  i { color: #9ca3af; font-size: 1.05rem; }
+  input {
+    flex: 1; border: 0; outline: none; background: transparent;
+    padding: 1rem 0; font-size: 1rem; color: $hb-texto; min-width: 0;
+  }
+  input::placeholder { color: #9ca3af; }
+  &:focus-within { border-color: #f3b989; box-shadow: 0 0 0 3px rgba(226, 118, 27, 0.12); }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -54,9 +54,14 @@ button:focus-visible,
   max-width: 72rem;
 }
 
-/* O hub de Estado tem faixa de hero sangrando de borda a borda: o .card não pode
-   limitar a largura. O próprio componente centraliza o conteúdo (.wrap, 72rem).
-   Evita o truque de 100vw, que somaria a barra de rolagem e criaria scroll lateral. */
+/* Páginas com <app-page-hero> têm faixa sangrando de borda a borda: o .card não
+   pode limitar a largura. O próprio hero centraliza o conteúdo (72rem). Evita o
+   truque de 100vw, que somaria a barra de rolagem e criaria scroll lateral.
+
+   `app-estado` continua na lista porque naquela página o hero só existe depois da
+   carga: durante o skeleton não há `.ph-hero` no DOM, e sem o seletor de elemento
+   o `.card` nasceria em 640px e pularia para full-bleed ao chegar o dado. */
+.layout-main > .card:has(.ph-hero),
 .layout-main > .card:has(app-estado) {
   max-width: none;
   padding-left: 0;


### PR DESCRIPTION
## Contexto

O menu **Explorar** (header, footer e o bloco "Encontre do seu jeito" da Home) leva a `/cidades`, `/estados` e `/dias`, e cada uma abria com um acabamento diferente. O problema não era só estilo — eram **três larguras de leitura diferentes**:

| Página | Antes | Depois |
|---|---|---|
| `/missas/:uf` | full-bleed, 72rem | referência (inalterada) |
| `/cidades` | **640px** | full-bleed, 72rem |
| `/estados` | **640px**, sem hero | full-bleed, 72rem |
| `/dias` | **640px**, sem hero | full-bleed, 72rem |

A causa estava em `styles.scss`: só um punhado de páginas escapava do `.card` de 640px, listadas uma a uma por `:has()`.

**Objetivo:** unificar a linguagem visual dos hubs usando `/missas/:uf` como referência, **sem transformar o `PageHero` em componente de negócio**. Não é fazer quatro páginas idênticas — é fazer parecer que pertencem ao mesmo produto.

## O que muda

`app-page-hero` compartilhado — faixa, breadcrumb, H1, subtítulo, tiles, slots, espaçamento e responsividade. A lógica específica continua em cada página:

- `/missas/:uf` → autocomplete de cidade + foto da catedral
- `/estados` → filtro local + SVG, tiles somados do payload já carregado
- `/dias` → sem busca, tile de constante
- `/cidades` → busca local + SVG, contagem real de paróquias

A regra global vira `.card:has(.ph-hero)`: adotar o hero traz a largura junto.

**Sem `::ng-deep`.** O hero estiliza só os wrappers do próprio template; o conteúdo projetado fica a cargo da página, que é dona daquele markup. Assim o componente compartilhado não passa a depender de estilo interno de quem o consome.

## Correções que vieram junto

- **`700+` paróquias fixo no template do `/cidades`** — número inventado numa página indexada, agora vem de `getInfo()`.
- **`/cidades` mentia no erro de rede** — dizia `Nenhuma cidade encontrada para ""`, culpando uma busca que nunca aconteceu. Agora tem estado de erro de verdade, com retry que funciona (o `shareReplay` de `addressRange()` guardava o erro; daí o `limparCacheEnderecos()`).
- **"diocese" no placeholder de busca** — o filtro nunca comparou diocese, só cidade e estado.
- **Ilustração do `/cidades` invisível** — bege chapado sobre fundo bege; ganhou contorno e acento laranja como as irmãs.
- **Zeros em vez de silêncio** — quando a carga falha, os tiles somem em vez de afirmar "0 paróquias".

## Verificação

- **Regressão do golden master**: `/missas/sp` equivalente em ≥900px e 375px — autocomplete, ancoragem do dropdown e ocultação da arte no mobile.
- **Alinhamento medido**: breadcrumb, H1, busca e lista todos em 210px nas quatro páginas.
- **`npm test`**: 27/27.
- **`npm run build:prod`**: 4177 rotas prerenderizadas, guard-rail em 0% de erro, dist **163,6 MB / 200 MB**.
- **SEO intacto**: exatamente um `<h1>` por página; `title`, `description`, `canonical`, `robots` e JSON-LD inalterados — `aplicarSeo`/`aplicarJsonLd` não foram tocados.
- **`/dias` sem rede**: HTML prerenderizado sem nenhuma referência a `Igreja/infos`.
- **`700+`**: some de todo o dist. `/estados` assa 4727 paróquias / 988 cidades / 26 estados reais.

## Pontos para revisão

1. **`:has(app-estado)` continua no `styles.scss`.** Em `/missas/:uf` o hero só existe depois da carga — durante o skeleton não há `.ph-hero` no DOM e o card pularia de 640px para full-bleed na navegação entre UFs. Ficaram dois seletores, com o porquê comentado.
2. **O `<h1>` de `/estados` e `/dias` mudou** ("Missas por estado" → "Horários de Missa por Estado"). É a única mudança de conteúdo indexado além do breadcrumb novo do `/cidades`; `title`/`meta`/`canonical`/JSON-LD ficaram intactos. Reverter é uma linha em cada componente.
3. **`/dias` tem um tile só.** Um segundo ("Todo o Brasil") não cabe no desenho do número e afirmaria uma cobertura que a base não garante — produção tem 26 UFs com paróquia, não 27.

## Fora deste PR

- **`/estados` rebaixa dado bom quando a revalidação falha** — `/v2/seo/estados` não passa pelo TransferState (a regex `RE_ESTADO` exige barra depois de "estado"), então o `catchError(() => EMPTY)` que protege as outras páginas não cobre esta. Pré-existente; os tiles só tornaram visível. Merece PR próprio por mexer em interceptor e SSR — e é o mesmo trabalho que destravaria contagem real no `/dias`.
- `/cidades` segue sem JSON-LD, enquanto `/estados` e `/dias` têm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)