### PR TITLE
fix(estados): liga /v2/seo/estados ao TransferState no prerender

### DIFF
--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -7,6 +7,7 @@ import { serverRoutes } from './app.routes.server';
 import { PrerenderCidadeInterceptor } from './core/middleware/prerender-cidade.interceptor';
 import { PrerenderParoquiaInterceptor } from './core/middleware/prerender-paroquia.interceptor';
 import { PrerenderEstadoInterceptor } from './core/middleware/prerender-estado.interceptor';
+import { PrerenderEstadosInterceptor } from './core/middleware/prerender-estados.interceptor';
 import { PrerenderIntencaoInterceptor } from './core/middleware/prerender-intencao.interceptor';
 
 const serverConfig: ApplicationConfig = {
@@ -23,6 +24,9 @@ const serverConfig: ApplicationConfig = {
     // (/v2/seo/missa-dia/{dia}/{uf}/{cidade}), servidos dos bulks em disco.
     { provide: HTTP_INTERCEPTORS, useClass: PrerenderEstadoInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: PrerenderIntencaoInterceptor, multi: true },
+    // Bulk /v2/seo/estados para o índice /estados — a última página de SEO que
+    // ainda buscava ao vivo no prerender e ficava sem TransferState.
+    { provide: HTTP_INTERCEPTORS, useClass: PrerenderEstadosInterceptor, multi: true },
   ],
 };
 

--- a/src/app/core/middleware/prerender-estado.interceptor.ts
+++ b/src/app/core/middleware/prerender-estado.interceptor.ts
@@ -7,16 +7,17 @@ import {
   HttpResponse,
 } from '@angular/common/http';
 import { Observable, from, of, switchMap } from 'rxjs';
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { environment } from '../../../environments/environment';
 import { chaveEstado, stateKeyEstado } from './prerender-state-keys';
+import { obterMapaEstados } from './prerender-estados-bulk';
 
 /**
  * Interceptor SÓ-SERVER (registrado apenas em app.config.server.ts) — serve o
  * endpoint por-item de Estado (`GET /v2/seo/estado/{uf}`) durante o prerender das
  * páginas `/missas/{uf}` (Fase 3 SEO), a partir do bulk `/v2/seo/estados` baixado
  * pro disco no prebuild. Evita ~26 fetches ao vivo durante o render.
+ *
+ * A leitura do bulk mora em `prerender-estados-bulk.ts`, compartilhada com o
+ * interceptor que serve o BULK para a página `/estados`.
  *
  * Diferente de cidade/paróquia: os endpoints `/v2/seo/*` devolvem o DTO CRU (sem o
  * wrapper `{ data }` do ApiResponse), então servimos o objeto direto — o MESMO
@@ -25,62 +26,6 @@ import { chaveEstado, stateKeyEstado } from './prerender-state-keys';
  * No browser este interceptor NÃO existe; a chamada segue pro endpoint real.
  * Degrada com segurança: se o bulk faltar/UF ausente, cai na chamada individual (next).
  */
-
-interface EstadoPayload {
-  uf: string;
-  estado: string;
-  totalCidades: number;
-  totalParoquias: number;
-  seo: unknown;
-  cidades: unknown[];
-}
-
-/** Cache da Promise do mapa (1 leitura por build). */
-let cacheMapa: Promise<Map<string, EstadoPayload>> | null = null;
-
-/** Base absoluta da API sem o sufixo /api — /v2/seo/estados é rota absoluta. */
-function baseUrl(): string {
-  return String(environment.config.apiURL ?? '')
-    .replace(/\/api\/?$/, '')
-    .replace(/\/$/, '');
-}
-
-function lerDoDisco(): EstadoPayload[] | null {
-  const arquivo = join(process.cwd(), '.prerender-cache', 'estados.json');
-  if (!existsSync(arquivo)) return null;
-  return JSON.parse(readFileSync(arquivo, 'utf-8')) as EstadoPayload[];
-}
-
-async function carregarMapa(): Promise<Map<string, EstadoPayload>> {
-  const inicio = Date.now();
-  let lista = lerDoDisco();
-  const origem = lista ? 'disco (.prerender-cache)' : 'bulk /v2/seo/estados';
-  if (!lista) {
-    const res = await fetch(`${baseUrl()}/v2/seo/estados`);
-    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    lista = (await res.json()) as EstadoPayload[];
-  }
-
-  const mapa = new Map<string, EstadoPayload>();
-  for (const e of Array.isArray(lista) ? lista : []) {
-    if (!e?.uf) continue;
-    mapa.set(e.uf.toLowerCase(), e);
-  }
-  console.log(`[prerender] ${mapa.size} estados carregados de ${origem} em ${Date.now() - inicio}ms.`);
-  return mapa;
-}
-
-function obterMapa(): Promise<Map<string, EstadoPayload>> {
-  if (!cacheMapa) {
-    cacheMapa = carregarMapa().catch((err) => {
-      cacheMapa = null;
-      console.warn(`[prerender] bulk /v2/seo/estados falhou (${err?.message ?? err}) — caindo para chamadas individuais.`);
-      return new Map<string, EstadoPayload>();
-    });
-  }
-  return cacheMapa;
-}
-
 @Injectable()
 export class PrerenderEstadoInterceptor implements HttpInterceptor {
   private _transferState = inject(TransferState);
@@ -90,7 +35,7 @@ export class PrerenderEstadoInterceptor implements HttpInterceptor {
     const chave = chaveEstado(req.url);
     if (!chave) return next.handle(req);
 
-    return from(obterMapa()).pipe(
+    return from(obterMapaEstados()).pipe(
       switchMap((mapa) => {
         const e = mapa.get(chave);
         if (!e) return next.handle(req); // bulk fora ou UF ausente → chamada normal

--- a/src/app/core/middleware/prerender-estados-bulk.ts
+++ b/src/app/core/middleware/prerender-estados-bulk.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Carga SÓ-SERVER do bulk `/v2/seo/estados`, compartilhada pelos dois interceptors
+ * de prerender que dependem dele:
+ *
+ * - `PrerenderEstadoInterceptor` → serve o endpoint POR-ITEM (`/v2/seo/estado/{uf}`)
+ *   das 26 páginas `/missas/{uf}`, e precisa do mapa uf → payload;
+ * - `PrerenderEstadosInterceptor` → serve o BULK para a página `/estados`, e
+ *   precisa da lista.
+ *
+ * Uma leitura por build para os dois (a Promise é memoizada), a partir do arquivo
+ * que `scripts/baixar-bulk-prerender.mjs` deixa em `.prerender-cache/`.
+ */
+
+export interface EstadoPayload {
+  uf: string;
+  estado: string;
+  totalCidades: number;
+  totalParoquias: number;
+  seo: unknown;
+  cidades: unknown[];
+}
+
+/** Cache da Promise da lista (1 leitura por build). */
+let cacheLista: Promise<EstadoPayload[]> | null = null;
+let cacheMapa: Promise<Map<string, EstadoPayload>> | null = null;
+
+/** Base absoluta da API sem o sufixo /api — /v2/seo/estados é rota absoluta. */
+function baseUrl(): string {
+  return String(environment.config.apiURL ?? '')
+    .replace(/\/api\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+function lerDoDisco(): EstadoPayload[] | null {
+  const arquivo = join(process.cwd(), '.prerender-cache', 'estados.json');
+  if (!existsSync(arquivo)) return null;
+  return JSON.parse(readFileSync(arquivo, 'utf-8')) as EstadoPayload[];
+}
+
+async function carregarLista(): Promise<EstadoPayload[]> {
+  const inicio = Date.now();
+  let lista = lerDoDisco();
+  const origem = lista ? 'disco (.prerender-cache)' : 'bulk /v2/seo/estados';
+  if (!lista) {
+    const res = await fetch(`${baseUrl()}/v2/seo/estados`);
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    lista = (await res.json()) as EstadoPayload[];
+  }
+
+  const valida = (Array.isArray(lista) ? lista : []).filter((e) => e?.uf);
+  console.log(`[prerender] ${valida.length} estados carregados de ${origem} em ${Date.now() - inicio}ms.`);
+  return valida;
+}
+
+/** Lista de estados do bulk. Vazia se o bulk falhar — nunca rejeita. */
+export function obterListaEstados(): Promise<EstadoPayload[]> {
+  if (!cacheLista) {
+    cacheLista = carregarLista().catch((err) => {
+      cacheLista = null;
+      console.warn(`[prerender] bulk /v2/seo/estados falhou (${err?.message ?? err}) — caindo para chamadas individuais.`);
+      return [] as EstadoPayload[];
+    });
+  }
+  return cacheLista;
+}
+
+/** Mapa uf (lowercase) → payload. Vazio se o bulk falhar — nunca rejeita. */
+export function obterMapaEstados(): Promise<Map<string, EstadoPayload>> {
+  if (!cacheMapa) {
+    cacheMapa = obterListaEstados().then((lista) => {
+      const mapa = new Map<string, EstadoPayload>();
+      for (const e of lista) mapa.set(e.uf.toLowerCase(), e);
+      return mapa;
+    });
+  }
+  return cacheMapa;
+}

--- a/src/app/core/middleware/prerender-estados.interceptor.ts
+++ b/src/app/core/middleware/prerender-estados.interceptor.ts
@@ -1,0 +1,67 @@
+import { Injectable, TransferState, inject } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, from, of, switchMap } from 'rxjs';
+import { chaveEstados, stateKeyEstados } from './prerender-state-keys';
+import { obterListaEstados, EstadoPayload } from './prerender-estados-bulk';
+
+/** O que o índice `/estados` realmente consome de cada item do bulk. */
+interface EstadoResumo {
+  uf: string;
+  estado: string;
+  totalCidades: number;
+  totalParoquias: number;
+}
+
+/**
+ * Interceptor SÓ-SERVER — serve o BULK `GET /v2/seo/estados` durante o prerender do
+ * índice `/estados`, a partir do arquivo em `.prerender-cache/`.
+ *
+ * Antes desta ligação, `/estados` era a única página de SEO que ainda buscava seus
+ * dados AO VIVO no prerender e, pior, sem TransferState: ao hidratar, o cliente
+ * refazia a chamada do zero e um erro de rede derrubava a lista boa para a lista
+ * estática de STATES (perdendo as metas de cada UF). Com a chave registrada, o
+ * `PrerenderTransferStateInterceptor` passa a valer também aqui — emissão síncrona
+ * na hidratação e, na revalidação, o `catchError(() => EMPTY)` que garante que uma
+ * falha NUNCA rebaixa a página já renderizada.
+ *
+ * PAYLOAD ENXUTO, de propósito: o bulk tem ~90 KB porque cada estado traz `seo` e a
+ * lista inteira de `cidades`, mas o índice só usa uf/estado/totalCidades/
+ * totalParoquias — 2 KB. Transferir o bulk cru quase triplicaria o HTML desta
+ * página para dado que ninguém lê. O recorte é seguro porque `getEstados()` tem um
+ * único consumidor (`EstadosComponent`); se algum dia outro passar a precisar de
+ * `cidades`, este recorte precisa acompanhar.
+ *
+ * Degrada com segurança: bulk ausente ou vazio → `next.handle(req)` (chamada real).
+ */
+@Injectable()
+export class PrerenderEstadosInterceptor implements HttpInterceptor {
+  private _transferState = inject(TransferState);
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (req.method !== 'GET') return next.handle(req);
+    const chave = chaveEstados(req.url);
+    if (!chave) return next.handle(req);
+
+    return from(obterListaEstados()).pipe(
+      switchMap((lista) => {
+        if (!lista.length) return next.handle(req);
+
+        const resumo: EstadoResumo[] = lista.map((e: EstadoPayload) => ({
+          uf: e.uf,
+          estado: e.estado,
+          totalCidades: e.totalCidades,
+          totalParoquias: e.totalParoquias,
+        }));
+
+        this._transferState.set(stateKeyEstados(chave), resumo);
+        return of(new HttpResponse({ status: 200, url: req.url, body: resumo }));
+      }),
+    );
+  }
+}

--- a/src/app/core/middleware/prerender-state-keys.ts
+++ b/src/app/core/middleware/prerender-state-keys.ts
@@ -20,6 +20,10 @@ const RE_CIDADE = /v2\/Igreja\/cidade\/([^/]+)\/([^/?]+)/i;
 // Endpoints das páginas de SEO (Fase 3): Estado, Intenção-cidade (folha) e a
 // árvore do dia (hubs nacional/UF da intenção).
 const RE_ESTADO = /v2\/seo\/estado\/([^/?]+)/i;
+// BULK de estados (índice `/estados`). Não colide com RE_ESTADO, que exige a barra
+// depois de "estado" — foi justamente por isso que esta URL ficou de fora do
+// TransferState por tanto tempo.
+const RE_ESTADOS = /v2\/seo\/estados(?:\?|$)/i;
 const RE_INTENCAO = /v2\/seo\/missa-dia\/([^/]+)\/([^/]+)\/([^/?]+)/i;
 const RE_INTENCAO_ARVORE = /v2\/seo\/missa-dia\/([^/?]+)(?:\?|$)/i;
 
@@ -42,6 +46,14 @@ export function chaveEstado(url: string): string | null {
   const m = url.match(RE_ESTADO);
   if (!m) return null;
   return decodeURIComponent(m[1]).toLowerCase();
+}
+
+/**
+ * Chave fixa do bulk de estados (não tem parâmetro), ou null. Existe uma só, mas
+ * mantém o mesmo formato das demais para caber em `resolverStateKey`.
+ */
+export function chaveEstados(url: string): string | null {
+  return RE_ESTADOS.test(url) ? 'todos' : null;
 }
 
 /** Chave lógica dia/uf/cidade (lowercase) da Intenção-cidade, ou null. */
@@ -71,6 +83,11 @@ export function stateKeyCidade(chave: string): StateKey<unknown> {
 /** StateKey do TransferState para uma resposta de Estado. */
 export function stateKeyEstado(chave: string): StateKey<unknown> {
   return makeStateKey<unknown>(`pe:${chave}`);
+}
+
+/** StateKey do TransferState para o bulk de estados (índice `/estados`). */
+export function stateKeyEstados(chave: string): StateKey<unknown> {
+  return makeStateKey<unknown>(`pes:${chave}`);
 }
 
 /** StateKey do TransferState para uma resposta de Intenção-cidade. */

--- a/src/app/core/middleware/prerender-transfer-state.interceptor.ts
+++ b/src/app/core/middleware/prerender-transfer-state.interceptor.ts
@@ -14,11 +14,13 @@ import {
   chaveParoquia,
   chaveCidade,
   chaveEstado,
+  chaveEstados,
   chaveIntencao,
   chaveIntencaoArvore,
   stateKeyParoquia,
   stateKeyCidade,
   stateKeyEstado,
+  stateKeyEstados,
   stateKeyIntencao,
   stateKeyIntencaoArvore,
 } from './prerender-state-keys';
@@ -33,6 +35,8 @@ function resolverStateKey(url: string): StateKey<unknown> | null {
   if (ci) return stateKeyIntencao(ci);
   const cia = chaveIntencaoArvore(url); // dia (hub) — antes do estado
   if (cia) return stateKeyIntencaoArvore(cia);
+  const ces = chaveEstados(url); // bulk (índice) — antes do estado por-item
+  if (ces) return stateKeyEstados(ces);
   const ce = chaveEstado(url);
   if (ce) return stateKeyEstado(ce);
   return null;

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -66,7 +66,15 @@ export class EstadosComponent implements OnInit, OnDestroy {
         },
         // Degrada para a lista estática: um índice vazio é pior que um índice com
         // um link a mais. O risco de link para hub sem página volta só neste caso.
-        error: () => this.aplicarFallbackEstatico(),
+        //
+        // Só quando NUNCA houve dado. Com a página prerenderizada, o TransferState
+        // já emitiu a lista real de forma síncrona; deixar um erro de revalidação
+        // rebaixá-la para a lista estática trocaria dado bom (com as metas de cada
+        // UF) por dado pior. O interceptor de leitura já engole esse erro, isto é
+        // cinto de segurança para o caminho sem TransferState.
+        error: () => {
+          if (!this.itens.length) this.aplicarFallbackEstatico();
+        },
       });
   }
 


### PR DESCRIPTION
## O bug

`/estados` era a única página de SEO fora do mecanismo de TransferState. A causa é uma sutileza de regex em `prerender-state-keys.ts`:

```ts
const RE_ESTADO = /v2\/seo\/estado\/([^/?]+)/i;  // exige a barra depois de "estado"
```

A URL do bulk é `/v2/seo/estados` — sem barra. Ela não casava com nada, e `resolverStateKey()` devolvia `null`.

Duas consequências:

1. **O prerender de `/estados` buscava os dados ao vivo**, embora o prebuild já baixe esse mesmo bulk para `.prerender-cache/estados.json`. Uma dependência de rede desnecessária no build.
2. **Uma revalidação que falhava rebaixava a página.** Ao hidratar, o cliente refazia a chamada do zero; um erro de rede caía no handler de erro do componente e trocava a lista real pela lista estática de `STATES`, perdendo as metas de cada UF ("43 paróquia(s) em 19 cidade(s)"). É exatamente o que o `catchError(() => EMPTY)` do `PrerenderTransferStateInterceptor` evita nas outras páginas — cujo comentário já dizia que "uma revalidação que falha NUNCA vira erro da página já renderizada".

## A correção

- `chaveEstados` / `stateKeyEstados` em `prerender-state-keys.ts`, com o caso registrado em `resolverStateKey()`.
- `PrerenderEstadosInterceptor` (só-server) serve o bulk do disco e o escreve no TransferState.
- A carga do bulk, antes privada do `prerender-estado.interceptor.ts`, vira `prerender-estados-bulk.ts` — memoizada, uma leitura por build para os dois consumidores.
- Cinto de segurança no componente: a lista estática só entra quando **nunca** houve dado.

### Payload enxuto, de propósito

O bulk tem **~90 KB** porque cada estado carrega `seo` e a lista inteira de `cidades`. O índice só lê `uf`, `estado`, `totalCidades` e `totalParoquias` — **2 KB**. Transferir o bulk cru quase triplicaria o HTML desta página para dado que ninguém consome.

O recorte é seguro porque `getEstados()` tem um único consumidor (`EstadosComponent`), e isso está documentado no interceptor: se algum dia outro precisar de `cidades`, o recorte precisa acompanhar.

## Verificação

**O comportamento, medido no dist servido estaticamente com a API de produção bloqueada por CORS** — ou seja, o cenário exato do bug:

| | Antes | Depois |
|---|---|---|
| Cards | 27 (estáticos) | **26** (reais) |
| Com meta | 0 | **26** |
| Primeiro | "Acre" | **"Acre — 43 paróquia(s) em 19 cidade(s)"** |

Demais checagens:

- `npm run build:prod`: 4179 rotas, guard-rail em 0% de erro, dist **163,4 MB / 200 MB**.
- Log do prerender: `26 estados carregados de disco (.prerender-cache)` — sem fetch ao vivo.
- `ng-state` do `/estados` traz `pes:todos` com **2075 chars**; a página fica em 33,7 KB (com o bulk cru seriam ~120 KB).
- HTML prerenderizado mantém os 26 `<a href="/missas/{uf}">` e as 26 metas; `title` e `canonical` inalterados.
- `npm test`: 27/27.

## Nota de merge

Independente do PR #166 (hero unificado), mas os dois tocam `estados.component.ts` em pontos diferentes — o que merjar depois provavelmente pede rebase. O #166 adiciona os tiles do hero, que são justamente o que mais sofria com o rebaixamento descrito aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)