### PR TITLE
fix: esconder botão "Realizar alteração" quando a igreja já tem responsável

### DIFF
--- a/src/app/modules/public/home/details/details.component.html
+++ b/src/app/modules/public/home/details/details.component.html
@@ -171,7 +171,7 @@
         </div>
       </div>
       <div class="flex gap-2 shrink-0">
-        <button pButton type="button" icon="pi pi-pencil" label="Realizar alteração"
+        <button *ngIf="!igrejaVerificada" pButton type="button" icon="pi pi-pencil" label="Realizar alteração"
           class="p-button-outlined p-button-secondary p-button-sm"
           (click)="reportarErro()">
         </button>


### PR DESCRIPTION
## Summary
- Esconde o botão "Realizar alteração" (sugestão anônima de edição, `/editar/{id}`) na página de detalhes da igreja quando ela já tem um responsável verificado — reaproveita a flag `igrejaVerificada` já buscada pelo componente e já usada pra esconder o card "Solicitar Responsabilidade" no mesmo cenário.
- "Reportar problema" continua visível pra qualquer visitante, independente de ter responsável.

## Test plan
- [x] `tsc --noEmit` sem erros
- [ ] Abrir a página de uma igreja SEM responsável verificado e confirmar que o botão aparece
- [ ] Abrir a página de uma igreja COM responsável verificado e confirmar que o botão some