### PR TITLE
feat(explorar): reconstrói /cidades, /estados e /dias como sistema de descoberta

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -169,6 +169,12 @@ export const serverRoutes: ServerRoute[] = [
   // Índice de estados (`/estados`) — estático (constante STATES), sem :param.
   { path: 'estados', renderMode: RenderMode.Prerender },
 
+  // Índice de cidades (`/cidades`) — mesma fonte/interceptor de `/estados`
+  // (`PrerenderEstadosInterceptor`, agora com `cidades[]` no resumo). Antes CSR
+  // (caía no `**` abaixo): era o hub com mais links internos (381 cidades) e o
+  // único sem HTML prerenderizado nem JSON-LD.
+  { path: 'cidades', renderMode: RenderMode.Prerender },
+
   // Índice de dias (`/dias`) — estático (constante DIAS_INTENCAO), sem :param.
   { path: 'dias', renderMode: RenderMode.Prerender },
 

--- a/src/app/core/constants/states.ts
+++ b/src/app/core/constants/states.ts
@@ -61,3 +61,24 @@ export function nomeComPreposicao(siglaOuNome: string): string {
   if (!estado) return `em ${siglaOuNome}`;
   return `${preposicaoDe(estado.sigla)} ${estado.nome}`;
 }
+
+/** Contração de "de" + artigo ("do"/"da"/"de") derivada da preposição da UF:
+ * quem rege "no" tem artigo "o" ("do"), quem rege "na" tem artigo "a" ("da"),
+ * quem rege "em" não tem artigo (sem contração, "de"). Mesma fonte de
+ * `PREPOSICAO_UF` — não duplica dado. */
+const CONTRACAO_DE: Record<'no' | 'na' | 'em', 'do' | 'da' | 'de'> = {
+  no: 'do', na: 'da', em: 'de',
+};
+
+/**
+ * "estado {do/da/de} {nome}" com a contração correta (ex.: "estado do Paraná",
+ * "estado da Bahia", "estado de Minas Gerais") — substitui o "estado de X" que
+ * nunca contraía o artigo. Aceita sigla ou nome; sem UF reconhecida, cai em
+ * "estado de {nome}".
+ */
+export function nomeDoEstadoComArtigo(siglaOuNome: string): string {
+  const porSigla = STATES.find((e) => e.sigla === siglaOuNome.toUpperCase());
+  const estado = porSigla ?? STATES.find((e) => e.nome === siglaOuNome);
+  if (!estado) return `estado de ${siglaOuNome}`;
+  return `estado ${CONTRACAO_DE[preposicaoDe(estado.sigla)]} ${estado.nome}`;
+}

--- a/src/app/core/constants/states.ts
+++ b/src/app/core/constants/states.ts
@@ -27,4 +27,37 @@ export const STATES = [
     { sigla: "SE", nome: "Sergipe" },
     { sigla: "TO", nome: "Tocantins" },
   ];
-  
+
+/**
+ * Preposição de regência ("no"/"na"/"em") por UF — não é regra gramatical
+ * derivável (gênero de topônimo tem muita exceção em pt-BR), por isso é mapa
+ * explícito. Alimenta o H1 de `/missas/:uf`: "Horários de Missa no Paraná",
+ * "... em São Paulo", "... na Bahia" — em vez do genérico e incorreto
+ * "no Estado de X" que não respeita a contração do artigo.
+ */
+const PREPOSICAO_UF: Record<string, 'no' | 'na' | 'em'> = {
+  AC: 'no', AL: 'em', AP: 'no', AM: 'no', BA: 'na', CE: 'no',
+  DF: 'no', ES: 'no', GO: 'em', MA: 'no', MT: 'no', MS: 'no',
+  MG: 'em', PA: 'no', PB: 'na', PR: 'no', PE: 'em', PI: 'no',
+  RJ: 'no', RN: 'no', RS: 'no', RO: 'em', RR: 'em', SC: 'em',
+  SP: 'em', SE: 'em', TO: 'no',
+};
+
+/** Só a preposição ("no"/"na"/"em") de uma UF. Aceita sigla ou nome; sem UF reconhecida, "em". */
+export function preposicaoDe(siglaOuNome: string): 'no' | 'na' | 'em' {
+  const porSigla = STATES.find((e) => e.sigla === siglaOuNome.toUpperCase());
+  const estado = porSigla ?? STATES.find((e) => e.nome === siglaOuNome);
+  return (estado && PREPOSICAO_UF[estado.sigla]) ?? 'em';
+}
+
+/**
+ * Nome do estado já precedido da preposição correta (ex.: "no Paraná",
+ * "em São Paulo"). Aceita sigla ou nome; sem UF reconhecida, cai em "em {nome}"
+ * (degrada de forma segura, nunca lança).
+ */
+export function nomeComPreposicao(siglaOuNome: string): string {
+  const porSigla = STATES.find((e) => e.sigla === siglaOuNome.toUpperCase());
+  const estado = porSigla ?? STATES.find((e) => e.nome === siglaOuNome);
+  if (!estado) return `em ${siglaOuNome}`;
+  return `${preposicaoDe(estado.sigla)} ${estado.nome}`;
+}

--- a/src/app/core/layout/home/header/header.component.scss
+++ b/src/app/core/layout/home/header/header.component.scss
@@ -9,7 +9,9 @@
   &__inner {
     max-width: 72rem;
     margin: 0 auto;
-    padding: 0 1.25rem;
+    // 1.5rem: mesmo padding lateral do conteúdo (.ph-hero__conteudo, .hub, .wrap,
+    // .cidades-page) — antes era 1.25rem e o logo ficava 4px à esquerda do H1.
+    padding: 0 1.5rem;
     height: 3.75rem;
     display: flex;
     align-items: center;

--- a/src/app/core/layout/home/layout/layout.component.ts
+++ b/src/app/core/layout/home/layout/layout.component.ts
@@ -12,7 +12,7 @@ import { RouterModule } from "@angular/router";
     FooterHomeComponent,
     RouterModule,
   ],
-  template: `<div class="layout-wrapper" style="padding:3px">
+  template: `<div class="layout-wrapper">
     <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
     <div class="layout-main-container">
       <app-header-home></app-header-home>

--- a/src/app/core/middleware/prerender-estados.interceptor.ts
+++ b/src/app/core/middleware/prerender-estados.interceptor.ts
@@ -10,17 +10,19 @@ import { Observable, from, of, switchMap } from 'rxjs';
 import { chaveEstados, stateKeyEstados } from './prerender-state-keys';
 import { obterListaEstados, EstadoPayload } from './prerender-estados-bulk';
 
-/** O que o índice `/estados` realmente consome de cada item do bulk. */
+/** O que os índices `/estados` e `/cidades` consomem de cada item do bulk. */
 interface EstadoResumo {
   uf: string;
   estado: string;
   totalCidades: number;
   totalParoquias: number;
+  cidades: Array<{ cidadeSlug: string; cidade: string; totalParoquias: number }>;
 }
 
 /**
- * Interceptor SÓ-SERVER — serve o BULK `GET /v2/seo/estados` durante o prerender do
- * índice `/estados`, a partir do arquivo em `.prerender-cache/`.
+ * Interceptor SÓ-SERVER — serve o BULK `GET /v2/seo/estados` durante o prerender dos
+ * índices `/estados` e `/cidades` (Fase 2 do Explorar), a partir do arquivo em
+ * `.prerender-cache/`.
  *
  * Antes desta ligação, `/estados` era a única página de SEO que ainda buscava seus
  * dados AO VIVO no prerender e, pior, sem TransferState: ao hidratar, o cliente
@@ -30,12 +32,12 @@ interface EstadoResumo {
  * na hidratação e, na revalidação, o `catchError(() => EMPTY)` que garante que uma
  * falha NUNCA rebaixa a página já renderizada.
  *
- * PAYLOAD ENXUTO, de propósito: o bulk tem ~90 KB porque cada estado traz `seo` e a
- * lista inteira de `cidades`, mas o índice só usa uf/estado/totalCidades/
- * totalParoquias — 2 KB. Transferir o bulk cru quase triplicaria o HTML desta
- * página para dado que ninguém lê. O recorte é seguro porque `getEstados()` tem um
- * único consumidor (`EstadosComponent`); se algum dia outro passar a precisar de
- * `cidades`, este recorte precisa acompanhar.
+ * `cidades[]` ENTROU no resumo (antes recortado fora, ~2 KB → ~34 KB): `/cidades`
+ * passou a consumir a MESMA fonte canônica que `/estados` (nenhum hub geográfico
+ * deve mais buscar/somar esses números por conta própria — era a causa de
+ * `/cidades` e `/estados` mostrarem totais diferentes). `seo` continua de fora:
+ * ninguém consome. Se o tamanho do dist virar problema
+ * (`scripts/verificar-dist-size.mjs`), o próximo corte é por aqui.
  *
  * Degrada com segurança: bulk ausente ou vazio → `next.handle(req)` (chamada real).
  */
@@ -57,6 +59,7 @@ export class PrerenderEstadosInterceptor implements HttpInterceptor {
           estado: e.estado,
           totalCidades: e.totalCidades,
           totalParoquias: e.totalParoquias,
+          cidades: (e.cidades ?? []) as EstadoResumo['cidades'],
         }));
 
         this._transferState.set(stateKeyEstados(chave), resumo);

--- a/src/app/core/services/churches.service.ts
+++ b/src/app/core/services/churches.service.ts
@@ -106,15 +106,6 @@ export class ChurchesService {
     return this.addressRange$;
   }
 
-  /**
-   * Descarta o cache de `addressRange()`. Necessário para "Tentar novamente" ter
-   * efeito: o `shareReplay` guarda também o ERRO, então sem limpar, toda nova
-   * assinatura recebe a mesma falha na hora, sem tocar na rede.
-   */
-  public limparCacheEnderecos(): void {
-    this.addressRange$ = undefined;
-  }
-
   /** Busca igrejas filtradas pelos parâmetros informados */
   searchByFilters(filters: FilterSearchChurch) {
     let params = new HttpParams();

--- a/src/app/modules/public/cidades/cidades.component.html
+++ b/src/app/modules/public/cidades/cidades.component.html
@@ -142,9 +142,8 @@
         </div>
       </section>
 
-      <!-- ============ PONTE ============
-           TODO(fase 4): <app-hub-ponte eixoAtual="cidades" /> entra aqui quando o
-           componente compartilhado existir. -->
+      <!-- ============ PONTE ============ -->
+      <app-hub-ponte eixoAtual="cidades" class="block mt-10" />
 
       <!-- ============ CTA ============ -->
       <div class="mt-10">

--- a/src/app/modules/public/cidades/cidades.component.html
+++ b/src/app/modules/public/cidades/cidades.component.html
@@ -126,16 +126,26 @@
                    [ngClass]="e.expandido ? 'pi-chevron-up text-primary' : 'pi-chevron-down text-gray-400'"></i>
               </button>
 
-              <!-- Grid de cidades: SEMPRE no DOM (display:none quando colapsado) —
-                   os <a href> continuam rastreáveis no HTML prerenderizado mesmo
-                   com o acordeão fechado. -->
+              <!-- Grid de cidades: SEMPRE no DOM (display:none quando colapsado ou
+                   além do cap de "ver mais") — os <a href> continuam rastreáveis
+                   no HTML prerenderizado independente do estado da UI. -->
               <div class="cidades-grid px-4 pb-4 pt-2" [class.cidades-grid--oculto]="!e.expandido">
-                @for (c of e.cidades; track c.slug) {
-                  <a [routerLink]="['/missas', e.sigla.toLowerCase(), c.slug]" class="cidade-link">
+                @for (c of e.cidades; track c.slug; let i = $index) {
+                  <a [routerLink]="['/missas', e.sigla.toLowerCase(), c.slug]" class="cidade-link"
+                     [class.cidade-link--oculto]="cidadeOculta(e, i)">
                     {{ c.nome }}
                   </a>
                 }
               </div>
+
+              @if (e.expandido && temMaisCidades(e)) {
+                <div class="ver-mais-cidades">
+                  <button type="button" class="ver-mais-cidades__btn" (click)="toggleVerTodas(e)">
+                    Ver mais {{ cidadesOcultasCount(e) }} cidades
+                    <i class="pi pi-chevron-down" aria-hidden="true"></i>
+                  </button>
+                </div>
+              }
 
             </div>
           }

--- a/src/app/modules/public/cidades/cidades.component.html
+++ b/src/app/modules/public/cidades/cidades.component.html
@@ -7,6 +7,7 @@
   [tilesCarregando]="isLoading"
   hint="Digite o nome da cidade ou do estado."
 >
+  <!-- Ação primária ANTES dos números: a busca é o que o usuário veio fazer aqui. -->
   <div class="busca" hero-busca>
     <i class="pi pi-search" aria-hidden="true"></i>
     <input
@@ -52,71 +53,122 @@
 <div class="cidades-page">
 
   <!-- Skeleton -->
-  <div *ngIf="isLoading" class="flex flex-col gap-3 mt-6">
-    <div *ngFor="let i of [1,2,3,4,5]"
-         class="h-14 rounded-xl bg-gray-100 animate-pulse"></div>
-  </div>
-
-  <!-- Lista por estado -->
-  <section *ngIf="!isLoading" class="mt-6">
-    <h2 class="text-sm font-bold text-gray-500 uppercase tracking-widest mb-3">
-      Cidades por estado
-    </h2>
-
-    <!-- Falha de carga e busca sem resultado são coisas diferentes: com a lista
-         vazia por erro de rede, dizer que a BUSCA não encontrou nada é mentira
-         (e ainda por cima com aspas vazias, já que não há termo buscado). -->
-    <div *ngIf="semDados" class="text-center py-10 text-gray-500">
-      <i class="pi pi-exclamation-circle text-3xl mb-3 block"></i>
-      Não foi possível carregar a lista de cidades.
-      <button type="button" class="cidades-retry" (click)="recarregar()">Tentar novamente</button>
+  @if (isLoading) {
+    <div class="flex flex-col gap-3 mt-6">
+      @for (i of [1,2,3,4,5]; track i) {
+        <div class="h-14 rounded-xl bg-gray-100 animate-pulse"></div>
+      }
     </div>
+  }
 
-    <div *ngIf="!semDados && estadosFiltrados.length === 0" class="text-center py-10 text-gray-400">
-      <i class="pi pi-search text-3xl mb-3 block"></i>
-      Nenhuma cidade encontrada para "{{ busca }}"
-    </div>
+  @if (!isLoading) {
+    <!-- Falha de carga: distinta de "a busca não achou". -->
+    @if (semDados) {
+      <div class="text-center py-10 text-gray-500">
+        <i class="pi pi-exclamation-circle text-3xl mb-3 block"></i>
+        Não foi possível carregar a lista de cidades.
+        <button type="button" class="cidades-retry" (click)="recarregar()">Tentar novamente</button>
+      </div>
+    } @else {
 
-    <div class="flex flex-col gap-2">
-      <div *ngFor="let e of estadosFiltrados" class="estado-card">
+      <!-- ============ CAPITAIS E PRINCIPAIS CIDADES ============
+           Vitrine antes do índice completo: as cidades com mais paróquias
+           cadastradas, no mesmo formato de destaque de /missas/:uf. Ordenação e
+           dados vêm do mesmo payload do índice abaixo — nenhuma requisição extra. -->
+      @if (principaisCidades.length) {
+        <section class="mt-6">
+          <h2 class="sec-titulo">
+            <i class="pi pi-building sec-titulo__ico" aria-hidden="true"></i>
+            Capitais e principais cidades
+          </h2>
+          <p class="sec-sub">Cidades com mais paróquias cadastradas em todo o Brasil.</p>
 
-        <!-- Cabeçalho do estado -->
-        <button class="estado-header" (click)="toggleEstado(e)" type="button">
-          <span class="estado-badge" [ngClass]="badgeClass(e.sigla)">{{ e.sigla }}</span>
-          <div class="flex-1 text-left">
-            <span class="estado-nome">{{ e.nome }}</span>
-            <span class="estado-count">{{ e.cidades.length }} cidades</span>
+          <div class="destaque-grid">
+            @for (c of principaisCidades; track c.uf + '/' + c.slug) {
+              <a class="destaque" [routerLink]="['/missas', c.uf, c.slug]">
+                <i class="pi pi-map-marker destaque__ico" aria-hidden="true"></i>
+                <span class="destaque__nome">{{ c.nome }}</span>
+                <span class="destaque__meta">{{ c.totalParoquias }} paróquias</span>
+              </a>
+            }
           </div>
-          <i class="pi transition-transform duration-200"
-             [ngClass]="e.expandido ? 'pi-chevron-up text-primary' : 'pi-chevron-down text-gray-400'"></i>
-        </button>
+        </section>
+      }
 
-        <!-- Grid de cidades -->
-        <div *ngIf="e.expandido" class="cidades-grid px-4 pb-4 pt-2">
-          <a *ngFor="let c of e.cidades"
-             [routerLink]="['/missas', e.sigla.toLowerCase(), c.slug]"
-             class="cidade-link">
-            {{ c.nome }} <i class="pi pi-chevron-right text-[10px]"></i>
+      <!-- ============ TODAS AS CIDADES POR ESTADO ============ -->
+      <section class="mt-10">
+        <h2 class="sec-titulo">
+          <i class="pi pi-th-large sec-titulo__ico" aria-hidden="true"></i>
+          Todas as cidades por estado
+        </h2>
+        <p class="sec-sub">Escolha o estado para ver todas as cidades com paróquias cadastradas.</p>
+
+        @if (estadosFiltrados.length === 0) {
+          <p class="text-center py-10 text-gray-400">
+            <i class="pi pi-search text-3xl mb-3 block"></i>
+            Nenhuma cidade encontrada para "{{ busca }}"
+          </p>
+        }
+
+        <div class="flex flex-col gap-2">
+          @for (e of estadosFiltrados; track e.sigla) {
+            <div class="estado-card">
+
+              <!-- Cabeçalho do estado -->
+              <button class="estado-header" (click)="toggleEstado(e)" type="button"
+                      [attr.aria-expanded]="e.expandido">
+                <span class="estado-badge" [ngClass]="badgeClass(e.sigla)">{{ e.sigla }}</span>
+                <div class="flex-1 text-left">
+                  <span class="estado-nome">{{ e.nome }}</span>
+                  <span class="estado-count">{{ e.cidades.length }} cidades</span>
+                </div>
+                <i class="pi transition-transform duration-200"
+                   [ngClass]="e.expandido ? 'pi-chevron-up text-primary' : 'pi-chevron-down text-gray-400'"></i>
+              </button>
+
+              <!-- Grid de cidades: SEMPRE no DOM (display:none quando colapsado) —
+                   os <a href> continuam rastreáveis no HTML prerenderizado mesmo
+                   com o acordeão fechado. -->
+              <div class="cidades-grid px-4 pb-4 pt-2" [class.cidades-grid--oculto]="!e.expandido">
+                @for (c of e.cidades; track c.slug) {
+                  <a [routerLink]="['/missas', e.sigla.toLowerCase(), c.slug]" class="cidade-link">
+                    {{ c.nome }}
+                  </a>
+                }
+              </div>
+
+            </div>
+          }
+        </div>
+      </section>
+
+      <!-- ============ PONTE ============
+           TODO(fase 4): <app-hub-ponte eixoAtual="cidades" /> entra aqui quando o
+           componente compartilhado existir. -->
+
+      <!-- ============ CTA ============ -->
+      <div class="mt-10">
+        <div class="cta">
+          <svg class="cta__ico" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2.5"
+               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M32 3v11M27.5 8.5h9" />
+            <path d="M32 15 21 25v29h22V25L32 15Z" />
+            <path d="M21 32 9 40v14h12M43 32l12 8v14H43" />
+            <path d="M28.5 54v-9a3.5 3.5 0 0 1 7 0v9" />
+            <circle cx="32" cy="30" r="2.5" />
+          </svg>
+          <strong class="cta__titulo">Não encontrou<br />sua cidade?</strong>
+          <p class="cta__texto">Ajude nossa comunidade a crescer — sugira sua cidade e suas paróquias.</p>
+          <a class="cta__btn" routerLink="/solicitar">
+            Sugerir minha cidade <i class="pi pi-chevron-right" aria-hidden="true"></i>
           </a>
         </div>
 
+        <p class="assinatura"><i class="pi pi-heart-fill" aria-hidden="true"></i>
+          Feito com amor para aproximar você de Deus e da sua comunidade.</p>
       </div>
-    </div>
-  </section>
 
-  <!-- CTA: Não encontrou sua cidade -->
-  <div class="nao-encontrou mt-8">
-    <div class="nao-encontrou__icon">
-      <i class="pi pi-map-marker text-2xl" style="color: #bc5d10;"></i>
-    </div>
-    <div class="flex-1 min-w-0">
-      <p class="font-semibold text-gray-800 text-sm">Não encontrou sua cidade?</p>
-      <p class="text-gray-500 text-xs mt-0.5">Ajude nossa comunidade a crescer.</p>
-    </div>
-    <a routerLink="/solicitar"
-       class="cta-btn shrink-0">
-      <i class="pi pi-send"></i> Sugerir minha cidade
-    </a>
-  </div>
+    }
+  }
 
 </div>

--- a/src/app/modules/public/cidades/cidades.component.scss
+++ b/src/app/modules/public/cidades/cidades.component.scss
@@ -96,8 +96,9 @@ $muted: #6b7280;
   border: none;
   cursor: pointer;
   transition: background 0.15s;
-  // Alvo de toque confortável no mobile (era só a altura do texto).
-  min-height: 2.75rem;
+  // Alvo de toque confortável no mobile (era só a altura do texto). Em px, não
+  // rem: a raiz do site é 14px (não 16px) — 2.75rem virava 38.5px, não 44px.
+  min-height: 44px;
 
   &:hover { background: #fafafa; }
 }
@@ -181,9 +182,10 @@ $muted: #6b7280;
   }
 
   // Alvo de toque ≥ 44px no mobile, sem alterar a densidade do desktop (a grade de
-  // 2 colunas já dá espaço de sobra ali; era 25px de altura efetiva).
+  // 2 colunas já dá espaço de sobra ali; era 25px de altura efetiva). Em px: a
+  // raiz do site é 14px, não 16px — 2.75rem dava 38.5px, não 44px.
   @media (max-width: 640px) {
-    min-height: 2.75rem;
+    min-height: 44px;
   }
 }
 

--- a/src/app/modules/public/cidades/cidades.component.scss
+++ b/src/app/modules/public/cidades/cidades.component.scss
@@ -1,6 +1,14 @@
 // Campo de busca projetado no slot [hero-busca].
 @use '../../../shared/styles/hero-busca' as *;
 
+$laranja: #bc5d10;
+$laranja-vivo: #e2761b;
+$creme: #fdf6f0;
+$borda: #e5e7eb;
+$titulo: #1f2937;
+$texto: #374151;
+$muted: #6b7280;
+
 // ── Hero ───────────────────────────────────────────────────────────────────────
 // A casca (faixa, breadcrumb, H1, subtítulo, tiles) é do <app-page-hero>. Aqui
 // ficam só a ilustração projetada e o container do conteúdo abaixo do hero.
@@ -23,26 +31,54 @@
   padding: 0 1.5rem 3rem;
 }
 
+// `.mt-6`/`.mt-10` no template são utilitários do Tailwind (já global via
+// styles.scss) — sem redeclarar aqui para não colidir com a escala dele.
+
 // Saída do estado de erro de carga.
 .cidades-retry {
   display: inline-block;
   margin-top: 0.9rem;
   padding: 0.55rem 1.1rem;
   background: #fff;
-  border: 1px solid #e5e7eb;
+  border: 1px solid $borda;
   border-radius: 0.625rem;
-  color: #bc5d10;
+  color: $laranja;
   font-weight: 600;
   font-size: 0.875rem;
   cursor: pointer;
 
-  &:hover { background: #fdf6f0; border-color: #f3b989; }
+  &:hover { background: $creme; border-color: #f3b989; }
 }
 
-// ── Card de estado ─────────────────────────────────────────────────────────────
+// ================= SEÇÕES (mesmo padrão de /missas/:uf) =================
+.sec-titulo {
+  display: flex; align-items: center; gap: 0.6rem;
+  font-size: 1.1875rem; font-weight: 800; color: $titulo; margin: 0 0 0.35rem; line-height: 1.25;
+}
+.sec-titulo__ico { color: $laranja-vivo; font-size: 1.15rem; }
+.sec-sub { color: $muted; margin: 0 0 1.25rem; font-size: 0.875rem; }
+
+// ── Capitais e principais cidades ──────────────────────────────────────────────
+.destaque-grid {
+  display: grid; gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+.destaque {
+  display: flex; flex-direction: column; align-items: center; gap: 0.3rem;
+  padding: 1.25rem 0.75rem;
+  background: #fff; border: 1px solid $borda; border-radius: 14px;
+  text-decoration: none; text-align: center;
+  transition: border-color .15s, box-shadow .15s, transform .15s;
+  &:hover { border-color: #f3b989; box-shadow: 0 3px 12px rgba(0,0,0,.06); transform: translateY(-2px); }
+  &__ico { color: $laranja-vivo; font-size: 1.2rem; margin-bottom: 0.15rem; }
+  &__nome { font-weight: 700; color: $titulo; font-size: 0.9375rem; line-height: 1.25; }
+  &__meta { color: $muted; font-size: 0.8125rem; }
+}
+
+// ── Card de estado (acordeão) ──────────────────────────────────────────────────
 .estado-card {
   background: #fff;
-  border: 1px solid #e5e7eb;
+  border: 1px solid $borda;
   border-radius: 0.75rem;
   overflow: hidden;
   transition: border-color 0.15s;
@@ -60,6 +96,8 @@
   border: none;
   cursor: pointer;
   transition: background 0.15s;
+  // Alvo de toque confortável no mobile (era só a altura do texto).
+  min-height: 2.75rem;
 
   &:hover { background: #fafafa; }
 }
@@ -89,22 +127,26 @@
   &--ce      { background: #ecfdf5; color: #065f46; }
   &--pe      { background: #fef3c7; color: #92400e; }
   &--pa      { background: #f0fdf4; color: #166534; }
-  &--default { background: #f3f4f6; color: #6b7280; }
+  &--default { background: #f3f4f6; color: $muted; }
 }
 
 .estado-nome {
   font-size: 0.9rem;
   font-weight: 600;
-  color: #1f2937;
+  color: $titulo;
   margin-right: 0.5rem;
 }
 
+// Era #9ca3af (~2,5:1, abaixo do mínimo AA de 4,5:1). $muted (#6b7280) já é
+// token do projeto e passa (~4,8:1) sem inventar cor nova.
 .estado-count {
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: $muted;
 }
 
 // ── Grid de cidades ────────────────────────────────────────────────────────────
+// Colapsa por display:none (não por *ngIf/@if): os <a href> continuam no HTML
+// prerenderizado com o acordeão fechado — a linkagem interna/SEO não depende de JS.
 .cidades-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -113,15 +155,18 @@
 
   @media (min-width: 480px) { grid-template-columns: repeat(3, 1fr); }
   @media (min-width: 700px) { grid-template-columns: repeat(4, 1fr); }
+
+  &--oculto { display: none; }
 }
 
 .cidade-link {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  // Sem chevron: com centenas de cidades por estado, um ícone por link é ruído,
+  // não affordance — o link já se lê como link (cor + hover + sublinhado).
   padding: 0.375rem 0.5rem;
   font-size: 0.8125rem;
-  color: #374151;
+  color: $texto;
   text-decoration: none;
   border-radius: 0.375rem;
   transition: background 0.12s, color 0.12s;
@@ -131,45 +176,44 @@
 
   &:hover {
     background: #fff4ed;
-    color: #bc5d10;
+    color: $laranja;
+    text-decoration: underline;
+  }
+
+  // Alvo de toque ≥ 44px no mobile, sem alterar a densidade do desktop (a grade de
+  // 2 colunas já dá espaço de sobra ali; era 25px de altura efetiva).
+  @media (max-width: 640px) {
+    min-height: 2.75rem;
   }
 }
 
-// ── CTA "Não encontrou" ────────────────────────────────────────────────────────
-.nao-encontrou {
-  display: flex;
+// ================= CTA (mesmo padrão de /missas/:uf) =================
+.cta {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
-  gap: 1rem;
-  padding: 1.125rem 1.25rem;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.875rem;
-  flex-wrap: wrap;
-
-  &__icon {
-    width: 2.5rem;
-    height: 2.5rem;
-    background: #fff4ed;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-  }
+  gap: 0.75rem 1.5rem;
+  background: $creme;
+  border-radius: 16px;
+  padding: 1.5rem 1.75rem;
+}
+.cta__ico { width: 58px; height: 58px; flex: 0 0 auto; color: $laranja-vivo; }
+.cta__titulo { color: $titulo; font-size: 1.0625rem; font-weight: 800; line-height: 1.3; }
+.cta__texto { color: $texto; margin: 0; font-size: 0.9375rem; line-height: 1.5; }
+.cta__btn {
+  display: inline-flex; align-items: center; gap: 0.5rem; white-space: nowrap;
+  background: $laranja-vivo; color: #fff; text-decoration: none; font-weight: 700;
+  padding: 0.85rem 1.5rem; border-radius: 12px; font-size: 0.9375rem;
+  i { font-size: 0.7rem; }
+  &:hover { background: $laranja; }
+}
+@media (max-width: 900px) {
+  .cta { grid-template-columns: auto 1fr; }
+  .cta__texto { grid-column: 1 / -1; }
+  .cta__btn { grid-column: 1 / -1; justify-content: center; }
 }
 
-.cta-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1.125rem;
-  border: 1.5px solid #bc5d10;
-  border-radius: 0.5rem;
-  color: #bc5d10;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.15s;
-
-  &:hover { background: #fff4ed; }
+.assinatura {
+  text-align: center; color: $muted; font-size: 0.8125rem; margin: 2rem 0 0;
+  i { color: #ef6b6b; margin-right: 0.35rem; }
 }

--- a/src/app/modules/public/cidades/cidades.component.scss
+++ b/src/app/modules/public/cidades/cidades.component.scss
@@ -187,6 +187,28 @@ $muted: #6b7280;
   @media (max-width: 640px) {
     min-height: 44px;
   }
+
+  // Além do cap de "ver mais" (CAP_CIDADES_POR_ESTADO): continua no HTML
+  // (rastreável), só não ocupa espaço na tela até o clique.
+  &--oculto { display: none; }
+}
+
+// Botão "ver mais N cidades" — mesma gramática do "Ver mais cidades" de
+// /missas/:uf (btn-linha), sem duplicar a classe porque essa vive num
+// componente diferente.
+.ver-mais-cidades {
+  display: flex;
+  justify-content: center;
+  padding: 0 1rem 1rem;
+
+  &__btn {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    background: #fff; border: 1px solid $borda; border-radius: 10px;
+    padding: 0.5rem 1rem; font-size: 0.8125rem; font-weight: 600;
+    color: $texto; cursor: pointer;
+    i { font-size: 0.65rem; color: $muted; }
+    &:hover { border-color: #f3b989; color: $laranja; background: $creme; i { color: $laranja; } }
+  }
 }
 
 // ================= CTA (mesmo padrão de /missas/:uf) =================

--- a/src/app/modules/public/cidades/cidades.component.ts
+++ b/src/app/modules/public/cidades/cidades.component.ts
@@ -14,9 +14,16 @@ import { HubPonteComponent } from '../../../shared/components/hub-ponte/hub-pont
 const SITE = 'https://buscamissa.com.br';
 /** Cap do bloco "Capitais e principais cidades" — vitrine, não substitui o índice completo. */
 const TOP_CIDADES = 8;
+/**
+ * Cap de cidades visíveis por estado ao abrir o acordeão — sem isso, um estado
+ * como o Paraná (159 cidades) despeja uma grade enorme de uma vez, o tipo de
+ * "parede de links" que lê mal principalmente no mobile. Mesmo padrão de
+ * "ver mais" que `estado.component.ts` já usa no índice A–Z.
+ */
+const CAP_CIDADES_POR_ESTADO = 24;
 
 interface CidadeItem { nome: string; slug: string; totalParoquias: number; }
-interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expandido: boolean; }
+interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expandido: boolean; verTodas: boolean; }
 interface CidadeDestaque { nome: string; slug: string; uf: string; totalParoquias: number; }
 
 /** Formato de item de `/v2/seo/estados` — mesmo bulk que alimenta `/estados` e o prerender. */
@@ -103,6 +110,9 @@ export class CidadesComponent implements OnInit, OnDestroy {
       .map(e => ({
         ...e,
         expandido: true,
+        // Busca já é uma lista curta e intencional — o cap de "ver mais" não
+        // deveria esconder o resultado que a pessoa acabou de procurar.
+        verTodas: true,
         cidades: e.cidades.filter(c => this.normalizar(c.nome).includes(q)),
       }))
       .filter(e => this.normalizar(e.nome).includes(q) || e.cidades.length > 0);
@@ -167,6 +177,7 @@ export class CidadesComponent implements OnInit, OnDestroy {
           .map((c) => ({ nome: c.cidade, slug: c.cidadeSlug, totalParoquias: c.totalParoquias }))
           .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
         expandido: false,
+        verTodas: false,
       }))
       .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'));
 
@@ -201,6 +212,21 @@ export class CidadesComponent implements OnInit, OnDestroy {
   }
 
   toggleEstado(e: EstadoItem): void { e.expandido = !e.expandido; }
+
+  toggleVerTodas(e: EstadoItem): void { e.verTodas = !e.verTodas; }
+
+  /** Cap de exibição por estado — ver `CAP_CIDADES_POR_ESTADO`. */
+  cidadeOculta(e: EstadoItem, indice: number): boolean {
+    return !e.verTodas && indice >= CAP_CIDADES_POR_ESTADO && e.cidades.length > CAP_CIDADES_POR_ESTADO;
+  }
+
+  temMaisCidades(e: EstadoItem): boolean {
+    return !e.verTodas && e.cidades.length > CAP_CIDADES_POR_ESTADO;
+  }
+
+  cidadesOcultasCount(e: EstadoItem): number {
+    return e.cidades.length - CAP_CIDADES_POR_ESTADO;
+  }
 
   badgeClass(sigla: string): string {
     return this.estadoCores[sigla] ?? 'badge--default';

--- a/src/app/modules/public/cidades/cidades.component.ts
+++ b/src/app/modules/public/cidades/cidades.component.ts
@@ -1,30 +1,64 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { ChurchesService } from '../../../core/services/churches.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MetricasService, PaginaMetrica } from '../../../core/services/metricas.service';
+import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
+import { SeoService } from '../../../core/services/seo.service';
 import { STATES } from '../../../core/constants/states';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
 
-interface CidadeItem { nome: string; slug: string; }
-interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expandido: boolean; }
+const SITE = 'https://buscamissa.com.br';
+/** Cap do bloco "Capitais e principais cidades" — vitrine, não substitui o índice completo. */
+const TOP_CIDADES = 8;
 
+interface CidadeItem { nome: string; slug: string; totalParoquias: number; }
+interface EstadoItem { sigla: string; nome: string; cidades: CidadeItem[]; expandido: boolean; }
+interface CidadeDestaque { nome: string; slug: string; uf: string; totalParoquias: number; }
+
+/** Formato de item de `/v2/seo/estados` — mesmo bulk que alimenta `/estados` e o prerender. */
+interface EstadoBulk {
+  uf: string;
+  estado: string;
+  totalCidades: number;
+  totalParoquias: number;
+  cidades?: Array<{ cidadeSlug: string; cidade: string; totalParoquias: number }>;
+}
+
+/**
+ * Índice de CIDADES (`/cidades`) — antes CSR e alimentado por `v1/Igreja/v2/obter-enderecos`
+ * + `v1/Igreja/infos`, dois endpoints independentes de `/estados`, que produziam totais
+ * divergentes (2328×2090) e slugs gerados no cliente (`slugify()`) que podiam não bater
+ * com o slug real do backend — ex.: "Itapejara d'Oeste" virava `itapejara-doeste` (404)
+ * em vez de `itapejara-d-oeste`.
+ *
+ * Agora consome a MESMA fonte canônica que `/estados`: `GET /v2/seo/estados`
+ * (`SeoPaginasService.getEstados()`), já com `cidadeSlug` do backend e já servida do
+ * `.prerender-cache/estados.json` durante o build (via `PrerenderEstadosInterceptor`).
+ * Nenhum hub geográfico deve mais buscar ou somar esses números por conta própria.
+ */
 @Component({
   selector: 'app-cidades',
   standalone: true,
   imports: [CommonModule, RouterLink, FormsModule, PageHeroComponent],
   templateUrl: './cidades.component.html',
   styleUrl: './cidades.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CidadesComponent implements OnInit {
-  private _church = inject(ChurchesService);
+export class CidadesComponent implements OnInit, OnDestroy {
+  private _api = inject(SeoPaginasService);
+  private _seo = inject(SeoService);
   private _metricas = inject(MetricasService);
+  private _cdr = inject(ChangeDetectorRef);
+  private _destroyRef = inject(DestroyRef);
 
   isLoading = true;
   busca = '';
   estados: EstadoItem[] = [];
+  /** Vitrine acima do índice completo — capitais e cidades com mais paróquias. */
+  principaisCidades: CidadeDestaque[] = [];
 
   readonly breadcrumb: HubBreadcrumb[] = [
     { label: 'Início', link: ['/home'] },
@@ -34,23 +68,17 @@ export class CidadesComponent implements OnInit {
   /** `\n` vira quebra de linha (o hero usa `white-space: pre-line`). */
   readonly TITULO_HERO = 'Horários de Missa\npor';
 
-  /**
-   * Os números saem de `addressRange()` (estados/cidades) e de `getInfo()`
-   * (paróquias). Nada é fixo no template: o "700+" que vivia aqui era um chute
-   * que envelhecia sozinho numa página indexada.
-   */
+  /** Ordem e ícone únicos entre os hubs: cidades → paróquias → estados. */
   tiles: HeroTile[] = [
-    { icone: 'pi pi-map', numero: 0, rotulo: 'estados e o DF' },
-    { icone: 'pi pi-building', numero: 0, rotulo: 'cidades cadastradas' },
-    { icone: 'pi pi-users', numero: 0, rotulo: 'paróquias e comunidades' },
+    { icone: 'pi pi-map-marker', numero: 0, rotulo: 'cidades' },
+    { icone: 'pi pi-building', numero: 0, rotulo: 'paróquias' },
+    { icone: 'pi pi-map', numero: 0, rotulo: 'estados' },
   ];
 
-  /** Contagem global de paróquias; `null` enquanto não chega — o tile só entra com número. */
-  private totalParoquias: number | null = null;
   /**
-   * `addressRange()` falhou. Distingue "não carregou" de "a busca não achou": sem
-   * isso a página exibia "Nenhuma cidade encontrada" com aspas vazias em cima de
-   * um erro de rede. Também zera os tiles — hero sem número é melhor que zeros.
+   * `getEstados()` falhou. Distingue "não carregou" de "a busca não achou": sem isso a
+   * página exibia "Nenhuma cidade encontrada" com aspas vazias em cima de um erro de
+   * rede. Também zera os tiles — hero sem número é melhor que zeros.
    */
   semDados = false;
 
@@ -60,6 +88,8 @@ export class CidadesComponent implements OnInit {
     RS: 'badge--rs', SC: 'badge--sc', DF: 'badge--df', GO: 'badge--go',
     BA: 'badge--ba', CE: 'badge--ce', PE: 'badge--pe', PA: 'badge--pa',
   };
+
+  private totalParoquias = 0;
 
   get totalCidades(): number {
     return this.estados.reduce((s, e) => s + e.cidades.length, 0);
@@ -79,86 +109,94 @@ export class CidadesComponent implements OnInit {
 
   ngOnInit(): void {
     this._metricas.registrarVisualizacaoPagina(PaginaMetrica.Cidades);
-    this.carregarCidades();
-    this.carregarTotalParoquias();
+    this.aplicarSeo();
+    this.carregar();
   }
 
-  /**
-   * Refaz a carga depois de uma falha. O cache precisa ser descartado antes: o
-   * `shareReplay` de `addressRange()` guarda o erro e devolveria a mesma falha
-   * na hora, sem nova requisição — o botão viraria enfeite.
-   */
+  ngOnDestroy(): void {
+    this._seo.removeJsonLd('breadcrumb');
+    this._seo.removeJsonLd('itemlist');
+  }
+
+  /** Refaz a carga depois de uma falha (o GET não tem cache local para descartar). */
   recarregar(): void {
-    if (this.isLoading) return;
-    this.isLoading = true;
+    if (!this.isLoading) {
+      this.isLoading = true;
+      this.semDados = false;
+      this._cdr.markForCheck();
+      this.carregar();
+    }
+  }
+
+  private carregar(): void {
+    this._api
+      .getEstados()
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe({
+        next: (data: unknown) => {
+          const lista: EstadoBulk[] = Array.isArray(data) ? data : ((data as any)?.data ?? []);
+          this.aplicar(lista.filter((e) => e?.uf));
+        },
+        error: () => {
+          this.isLoading = false;
+          this.semDados = true;
+          this.tiles = [];
+          this._cdr.markForCheck();
+        },
+      });
+  }
+
+  private aplicar(lista: EstadoBulk[]): void {
+    if (!lista.length) {
+      this.isLoading = false;
+      this.semDados = true;
+      this.tiles = [];
+      this._cdr.markForCheck();
+      return;
+    }
+
+    // Ordem alfabética: isto é um índice para consultar, não um ranking — a vitrine
+    // de "principais cidades" abaixo já cobre o volume. Nenhum estado abre sozinho
+    // por padrão (antes o PR, o maior, abria com 161 cidades na cara de quem procura SP).
+    this.estados = lista
+      .map((e) => ({
+        sigla: e.uf.toUpperCase(),
+        nome: STATES.find((s) => s.sigla === e.uf.toUpperCase())?.nome ?? e.estado,
+        cidades: (e.cidades ?? [])
+          .map((c) => ({ nome: c.cidade, slug: c.cidadeSlug, totalParoquias: c.totalParoquias }))
+          .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
+        expandido: false,
+      }))
+      .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'));
+
+    this.principaisCidades = lista
+      .flatMap((e) => (e.cidades ?? []).map((c) => ({
+        nome: c.cidade,
+        slug: c.cidadeSlug,
+        uf: e.uf.toLowerCase(),
+        totalParoquias: c.totalParoquias,
+      })))
+      .sort((a, b) => b.totalParoquias - a.totalParoquias)
+      .slice(0, TOP_CIDADES);
+
+    this.totalParoquias = lista.reduce((s, e) => s + (e.totalParoquias ?? 0), 0);
+    this.isLoading = false;
     this.semDados = false;
-    this._church.limparCacheEnderecos();
-    this.carregarCidades();
-  }
-
-  private carregarCidades(): void {
-    this._church.addressRange().subscribe({
-      next: ({ data }: any) => {
-        this.estados = Object.entries(data)
-          .map(([uf, cities]: [string, any]) => ({
-            sigla: uf,
-            nome: STATES.find(s => s.sigla === uf)?.nome ?? uf,
-            cidades: Object.keys(cities)
-              .map(nome => ({ nome, slug: this.slugify(nome) }))
-              .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
-            expandido: false,
-          }))
-          .sort((a, b) => b.cidades.length - a.cidades.length);
-
-        if (this.estados.length) this.estados[0].expandido = true;
-        this.isLoading = false;
-        this.montarTiles();
-      },
-      error: () => {
-        this.isLoading = false;
-        // Sem dado, sem tile: "0 estados e o DF" é tão falso quanto o "700+" fixo
-        // que vivia aqui. Melhor não afirmar número nenhum.
-        this.semDados = true;
-        this.montarTiles();
-      },
-    });
-  }
-
-  /**
-   * Contagem global de paróquias — mesmo endpoint que a Home usa. Página CSR
-   * (catch-all no `app.routes.server.ts`), então não há prerender para depender
-   * de rede: o número é sempre o de agora. Falhando, o tile sai em vez de exibir
-   * um número inventado.
-   */
-  private carregarTotalParoquias(): void {
-    this._church.getInfo().subscribe({
-      next: (res: any) => {
-        const d = res?.data ?? res ?? {};
-        this.totalParoquias = d.quantidadesIgrejas ?? d.quantidadeIgrejas ?? d.totalIgrejas ?? null;
-        this.montarTiles();
-      },
-      error: () => { this.montarTiles(); },
-    });
+    this.montarTiles(lista.length);
+    this.aplicarJsonLd();
+    this._cdr.markForCheck();
   }
 
   /**
    * Sempre um ARRAY NOVO: `PageHeroComponent` é OnPush e só re-renderiza quando a
-   * referência do input muda — mutar `tiles` no lugar não repintaria nada. Mesmo
-   * cuidado que a Home documenta para o `HomeStatsComponent`.
+   * referência do input muda — mutar `tiles` no lugar não repintaria nada.
    */
-  private montarTiles(): void {
-    if (this.semDados) {
-      this.tiles = [];
-      return;
-    }
-    const tiles: HeroTile[] = [
-      { icone: 'pi pi-map', numero: this.estados.length, rotulo: 'estados e o DF' },
-      { icone: 'pi pi-building', numero: this.totalCidades, rotulo: 'cidades cadastradas' },
+  private montarTiles(totalEstados: number): void {
+    this.tiles = [
+      { icone: 'pi pi-map-marker', numero: this.totalCidades, rotulo: 'cidades' },
+      { icone: 'pi pi-building', numero: this.totalParoquias, rotulo: 'paróquias' },
+      { icone: 'pi pi-map', numero: totalEstados, rotulo: 'estados' },
     ];
-    if (this.totalParoquias) {
-      tiles.push({ icone: 'pi pi-users', numero: this.totalParoquias, rotulo: 'paróquias e comunidades' });
-    }
-    this.tiles = tiles;
   }
 
   toggleEstado(e: EstadoItem): void { e.expandido = !e.expandido; }
@@ -167,12 +205,36 @@ export class CidadesComponent implements OnInit {
     return this.estadoCores[sigla] ?? 'badge--default';
   }
 
-  slugify(s: string): string {
-    return s.normalize('NFD').replace(/[̀-ͯ]/g, '')
-      .toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-  }
-
   normalizar(s: string): string {
     return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().trim();
+  }
+
+  private aplicarSeo(): void {
+    this._seo.update({
+      title: 'Cidades com missas cadastradas — horários por cidade | BuscaMissa',
+      description: 'Encontre horários de missa em qualquer cidade do Brasil. Escolha o estado e veja as paróquias e comunidades católicas cadastradas.',
+      canonical: `${SITE}/cidades`,
+    });
+  }
+
+  private aplicarJsonLd(): void {
+    this._seo.setJsonLd('breadcrumb', {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Início', item: `${SITE}/home` },
+        { '@type': 'ListItem', position: 2, name: 'Cidades', item: `${SITE}/cidades` },
+      ],
+    });
+
+    this._seo.setJsonLd('itemlist', {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: 'Cidades do Brasil com missas cadastradas',
+      numberOfItems: this.totalCidades,
+      itemListElement: this.estados.flatMap((e) =>
+        e.cidades.map((c) => ({ name: c.nome, item: `${SITE}/missas/${e.sigla.toLowerCase()}/${c.slug}` })),
+      ).map((it, i) => ({ '@type': 'ListItem', position: i + 1, name: it.name, item: it.item })),
+    });
   }
 }

--- a/src/app/modules/public/cidades/cidades.component.ts
+++ b/src/app/modules/public/cidades/cidades.component.ts
@@ -9,6 +9,7 @@ import { SeoService } from '../../../core/services/seo.service';
 import { STATES } from '../../../core/constants/states';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
+import { HubPonteComponent } from '../../../shared/components/hub-ponte/hub-ponte.component';
 
 const SITE = 'https://buscamissa.com.br';
 /** Cap do bloco "Capitais e principais cidades" — vitrine, não substitui o índice completo. */
@@ -42,7 +43,7 @@ interface EstadoBulk {
 @Component({
   selector: 'app-cidades',
   standalone: true,
-  imports: [CommonModule, RouterLink, FormsModule, PageHeroComponent],
+  imports: [CommonModule, RouterLink, FormsModule, PageHeroComponent, HubPonteComponent],
   templateUrl: './cidades.component.html',
   styleUrl: './cidades.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/modules/public/dias/dias.component.html
+++ b/src/app/modules/public/dias/dias.component.html
@@ -87,9 +87,8 @@
 
 <app-hub-lista icone="pi pi-calendar" [itens]="itens" />
 
-<!-- ============ PONTE ============
-     TODO(fase 4): <app-hub-ponte eixoAtual="dias" /> entra aqui quando o
-     componente compartilhado existir. -->
+<!-- ============ PONTE ============ -->
+<app-hub-ponte eixoAtual="dias" class="block mt-10" />
 
 <!-- ============ CTA ============ -->
 <div class="wrap mt-10">

--- a/src/app/modules/public/dias/dias.component.html
+++ b/src/app/modules/public/dias/dias.component.html
@@ -6,8 +6,10 @@
   [tiles]="tiles"
 >
   <!--
-    Sem slot [hero-busca]: são 7 itens, todos visíveis na grade abaixo. Campo de
-    busca aqui seria decoração. O hero não reserva espaço para slot vazio.
+    Sem slot [hero-busca] e sem tiles ([tiles]="[]" — ver dias.component.ts): são
+    7 itens, todos visíveis na grade abaixo, e o número "7 dias da semana" não
+    informava nada. O hero não reserva espaço para nenhum dos dois vazio, então
+    fica deliberadamente mais curto que o de /cidades e /estados.
 
     Ilustração leve em vez de foto — mesma razão de /estados.
   -->
@@ -59,4 +61,54 @@
   </svg>
 </app-page-hero>
 
+<!-- ============ MISSA DE HOJE ============
+     A ação real desta página: a rota existe (/missa-hoje) e não era referenciada
+     em lugar nenhum do hub de dias. Mais destaque visual que os 7 dias abaixo —
+     de propósito, é a intenção mais imediata de quem chega em /dias. -->
+<div class="wrap mt-6">
+  <a class="hoje" routerLink="/missa-hoje">
+    <span class="hoje__ico" aria-hidden="true"><i class="pi pi-calendar-plus"></i></span>
+    <span class="hoje__texto">
+      <strong class="hoje__titulo">Missa de hoje</strong>
+      <span class="hoje__sub">Veja direto os horários de missa de hoje, sem escolher o dia.</span>
+    </span>
+    <i class="pi pi-arrow-right hoje__seta" aria-hidden="true"></i>
+  </a>
+</div>
+
+<!-- ============ ESCOLHA O DIA DA SEMANA ============ -->
+<div class="wrap mt-10">
+  <h2 class="sec-titulo">
+    <i class="pi pi-calendar sec-titulo__ico" aria-hidden="true"></i>
+    Escolha o dia da semana
+  </h2>
+  <p class="sec-sub">Veja os horários de missa cadastrados para cada dia, em todo o Brasil.</p>
+</div>
+
 <app-hub-lista icone="pi pi-calendar" [itens]="itens" />
+
+<!-- ============ PONTE ============
+     TODO(fase 4): <app-hub-ponte eixoAtual="dias" /> entra aqui quando o
+     componente compartilhado existir. -->
+
+<!-- ============ CTA ============ -->
+<div class="wrap mt-10">
+  <div class="cta">
+    <svg class="cta__ico" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2.5"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+      <path d="M32 3v11M27.5 8.5h9" />
+      <path d="M32 15 21 25v29h22V25L32 15Z" />
+      <path d="M21 32 9 40v14h12M43 32l12 8v14H43" />
+      <path d="M28.5 54v-9a3.5 3.5 0 0 1 7 0v9" />
+      <circle cx="32" cy="30" r="2.5" />
+    </svg>
+    <strong class="cta__titulo">Encontre uma missa<br />perto de você</strong>
+    <p class="cta__texto">O Busca Missa conecta você às paróquias da sua comunidade. Participe!</p>
+    <a class="cta__btn" routerLink="/missa-agora">
+      Buscar missa agora <i class="pi pi-chevron-right" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <p class="assinatura"><i class="pi pi-heart-fill" aria-hidden="true"></i>
+    Feito com amor para aproximar você de Deus e da sua comunidade.</p>
+</div>

--- a/src/app/modules/public/dias/dias.component.scss
+++ b/src/app/modules/public/dias/dias.component.scss
@@ -1,3 +1,12 @@
+$laranja: #bc5d10;
+$laranja-vivo: #e2761b;
+$creme: #fdf6f0;
+$creme-forte: #fdeee2;
+$borda: #e5e7eb;
+$titulo: #1f2937;
+$texto: #374151;
+$muted: #6b7280;
+
 // Ilustração projetada em [hero-arte]. A caixa é do <app-page-hero>; o
 // preenchimento e o recorte são desta página.
 .dias-arte {
@@ -8,4 +17,75 @@
   // Mesma curva elíptica da foto em /missas/:uf.
   border-top-left-radius: 38% 62%;
   border-bottom-left-radius: 14% 24%;
+}
+
+// Mesmo container de estado.component.scss/estados.component.scss (72rem / 1.5rem).
+.wrap {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.sec-titulo {
+  display: flex; align-items: center; gap: 0.6rem;
+  font-size: 1.1875rem; font-weight: 800; color: $titulo; margin: 0 0 0.35rem; line-height: 1.25;
+}
+.sec-titulo__ico { color: $laranja-vivo; font-size: 1.15rem; }
+.sec-sub { color: $muted; margin: 0 0 1.25rem; font-size: 0.875rem; }
+
+// ── Missa de hoje — destaque acima da grade dos 7 dias ─────────────────────────
+.hoje {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  background: $creme;
+  border: 1.5px solid #f3b989;
+  border-radius: 16px;
+  text-decoration: none;
+  transition: border-color .15s, box-shadow .15s, transform .15s;
+
+  &:hover { box-shadow: 0 4px 16px rgba(226, 118, 27, .12); transform: translateY(-1px); }
+
+  &__ico {
+    display: grid; place-items: center;
+    width: 3rem; height: 3rem; flex: 0 0 3rem;
+    background: $laranja-vivo; border-radius: 12px;
+    i { color: #fff; font-size: 1.35rem; }
+  }
+  &__texto { display: flex; flex-direction: column; gap: 0.15rem; flex: 1; min-width: 0; }
+  &__titulo { font-size: 1.0625rem; font-weight: 800; color: $titulo; }
+  &__sub { font-size: 0.875rem; color: $texto; }
+  &__seta { color: $laranja-vivo; font-size: 1rem; flex-shrink: 0; }
+}
+
+// ================= CTA (mesmo padrão de /missas/:uf) =================
+.cta {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  background: $creme;
+  border-radius: 16px;
+  padding: 1.5rem 1.75rem;
+}
+.cta__ico { width: 58px; height: 58px; flex: 0 0 auto; color: $laranja-vivo; }
+.cta__titulo { color: $titulo; font-size: 1.0625rem; font-weight: 800; line-height: 1.3; }
+.cta__texto { color: $texto; margin: 0; font-size: 0.9375rem; line-height: 1.5; }
+.cta__btn {
+  display: inline-flex; align-items: center; gap: 0.5rem; white-space: nowrap;
+  background: $laranja-vivo; color: #fff; text-decoration: none; font-weight: 700;
+  padding: 0.85rem 1.5rem; border-radius: 12px; font-size: 0.9375rem;
+  i { font-size: 0.7rem; }
+  &:hover { background: $laranja; }
+}
+@media (max-width: 900px) {
+  .cta { grid-template-columns: auto 1fr; }
+  .cta__texto { grid-column: 1 / -1; }
+  .cta__btn { grid-column: 1 / -1; justify-content: center; }
+}
+
+.assinatura {
+  text-align: center; color: $muted; font-size: 0.8125rem; margin: 2rem 0 0;
+  i { color: #ef6b6b; margin-right: 0.35rem; }
 }

--- a/src/app/modules/public/dias/dias.component.ts
+++ b/src/app/modules/public/dias/dias.component.ts
@@ -5,6 +5,7 @@ import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
+import { HubPonteComponent } from '../../../shared/components/hub-ponte/hub-ponte.component';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -27,7 +28,7 @@ const SITE = 'https://buscamissa.com.br';
 @Component({
   selector: 'app-dias',
   standalone: true,
-  imports: [CommonModule, RouterLink, HubListaComponent, PageHeroComponent],
+  imports: [CommonModule, RouterLink, HubListaComponent, PageHeroComponent, HubPonteComponent],
   templateUrl: './dias.component.html',
   styleUrl: './dias.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/modules/public/dias/dias.component.ts
+++ b/src/app/modules/public/dias/dias.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
@@ -8,8 +9,15 @@ import { PageHeroComponent, HeroTile } from '../../../shared/components/page-her
 const SITE = 'https://buscamissa.com.br';
 
 /**
- * Índice de DIAS DA SEMANA (`/dias`) — paridade com `/estados` e `/cidades`.
- * Fecha o eixo "dia": as 7 landings `/missa-{dia}` existiam sem página-mãe.
+ * Índice de DIAS DA SEMANA (`/dias`) — fecha o eixo "dia": as 7 landings
+ * `/missa-{dia}` existiam sem página-mãe.
+ *
+ * Estrutura DELIBERADAMENTE diferente de `/cidades`/`/estados`: aqueles são
+ * índices de navegação (o usuário escolhe onde), este tem uma intenção mais
+ * imediata ("que horas tem missa hoje?") — por isso o hero é curto (sem tile,
+ * sem busca: 7 itens cabem todos na grade abaixo, buscar seria decoração) e o
+ * primeiro bloco de conteúdo é o destaque para `/missa-hoje` (existia e não era
+ * referenciado em lugar nenhum do hub de dias), não a grade dos 7 dias.
  *
  * Alimentado pela constante `DIAS_INTENCAO`, NÃO pela API: os 7 dias são fixos e
  * todas as landings correspondentes já são prerenderizadas, então não há risco de
@@ -19,7 +27,7 @@ const SITE = 'https://buscamissa.com.br';
 @Component({
   selector: 'app-dias',
   standalone: true,
-  imports: [CommonModule, HubListaComponent, PageHeroComponent],
+  imports: [CommonModule, RouterLink, HubListaComponent, PageHeroComponent],
   templateUrl: './dias.component.html',
   styleUrl: './dias.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -36,19 +44,19 @@ export class DiasComponent implements OnInit, OnDestroy {
   readonly TITULO_HERO = 'Horários de Missa\npor';
 
   /**
-   * Números FIXOS, de constante — nada de rede. `ChurchesService.getInfo()`
-   * (`v1/Igreja/infos`) não tem StateKey em `prerender-state-keys.ts`, então
-   * nenhum interceptor de prerender o escreve: usá-lo aqui faria o prerender
-   * desta rota depender da API estar acessível na máquina de build, e assaria no
-   * HTML indexado um número que envelhece. Contagem global é papel da Home.
+   * Sem tiles: "7 · dias da semana" era tautológico (a semana tem 7 dias, o
+   * número não informa nada) e ocupava espaço acima da dobra sem valor. `/dias`
+   * não segue a estrutura de `/cidades`/`/estados` de propósito — a intenção
+   * aqui é diferente (ver comentário da classe).
    */
-  readonly tiles: HeroTile[] = [
-    { icone: 'pi pi-calendar', numero: DIAS_INTENCAO.length, rotulo: 'dias da semana' },
-  ];
+  readonly tiles: HeroTile[] = [];
 
+  /**
+   * Sem meta: "Missas de domingo" só repetia o título do card ("Domingo") — a
+   * definição mais literal de microcopy sem informação.
+   */
   readonly itens: HubItem[] = DIAS_INTENCAO.map((d) => ({
     nome: d.nome,
-    meta: `Missas de ${d.nome.toLowerCase()}`,
     link: ['/missa-' + d.slug],
   }));
 

--- a/src/app/modules/public/estado/estado.component.html
+++ b/src/app/modules/public/estado/estado.component.html
@@ -22,7 +22,7 @@
     <!-- ================= HERO ================= -->
     <app-page-hero
       [breadcrumb]="breadcrumb"
-      [titulo]="TITULO_HERO"
+      [titulo]="tituloHero"
       [tituloDestaque]="estadoNome"
       [subtitulo]="subtituloHero"
       [tiles]="tilesHero"

--- a/src/app/modules/public/estado/estado.component.scss
+++ b/src/app/modules/public/estado/estado.component.scss
@@ -90,6 +90,15 @@ $muted: #6b7280;
   cursor: pointer; transition: background .15s, border-color .15s, color .15s;
   &:hover:not(:disabled) { background: $creme; border-color: #f3b989; color: $laranja; }
   &:disabled { color: #d1d5db; cursor: default; background: #fafafa; }
+
+  // Alvo de toque: 26×24px no mobile era abaixo do mínimo prático (44px). Cresce
+  // só o padding/min-size (área clicável) no mobile — a letra em si (font-size)
+  // não muda, então o alfabeto não fica visualmente maior, só mais fácil de tocar.
+  @media (max-width: 640px) {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding: 0.3rem 0.1rem;
+  }
 }
 
 /* ================= SEÇÕES ================= */

--- a/src/app/modules/public/estado/estado.component.scss
+++ b/src/app/modules/public/estado/estado.component.scss
@@ -94,9 +94,10 @@ $muted: #6b7280;
   // Alvo de toque: 26×24px no mobile era abaixo do mínimo prático (44px). Cresce
   // só o padding/min-size (área clicável) no mobile — a letra em si (font-size)
   // não muda, então o alfabeto não fica visualmente maior, só mais fácil de tocar.
+  // Em px, não rem: a raiz do site é 14px (não 16px) — 2.75rem virava 38.5px.
   @media (max-width: 640px) {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
+    min-width: 44px;
+    min-height: 44px;
     padding: 0.3rem 0.1rem;
   }
 }

--- a/src/app/modules/public/estado/estado.component.ts
+++ b/src/app/modules/public/estado/estado.component.ts
@@ -17,6 +17,7 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
+import { preposicaoDe } from '../../../core/constants/states';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
 
@@ -91,8 +92,15 @@ export class EstadoComponent implements OnInit, OnDestroy {
   // --- Hero (app-page-hero). Como os demais derivados abaixo, é montado UMA vez
   // por carga: com OnPush e 26 UFs prerenderizadas, getter de template sairia caro. ---
 
-  /** `\n` vira quebra de linha — o hero renderiza o título com `white-space: pre-line`. */
-  readonly TITULO_HERO = 'Horários de Missa no\nEstado de';
+  /**
+   * "Horários de Missa {preposição}" (ex.: "... no"), com o nome do estado
+   * entrando por `tituloDestaque` (ex.: "Paraná") — o H1 fecha em
+   * "Horários de Missa no Paraná". Monta uma vez por carga, em `montarHero()`:
+   * antes disso a string fixa "no Estado de" não respeitava a contração do
+   * artigo ("no Estado de São Paulo" em vez de "em São Paulo"), e o `\n` forçado
+   * no meio quebrava o título/subtítulo no mobile.
+   */
+  tituloHero = 'Horários de Missa';
   breadcrumb: HubBreadcrumb[] = [];
   subtituloHero = '';
   tilesHero: HeroTile[] = [];
@@ -155,10 +163,15 @@ export class EstadoComponent implements OnInit, OnDestroy {
       { label: 'Estados', link: ['/estados'] },
       { label: this.estadoNome },
     ];
-    this.subtituloHero = `Encontre igrejas, paróquias e horários de missa\nem todo o estado de ${this.estadoNome}.`;
+    // Preposição correta por UF ("no Paraná", "em São Paulo", "na Bahia") — o H1
+    // fecha em `tituloHero + ' ' + tituloDestaque` (ver template). Sem \n forçado:
+    // a quebra de linha do subtítulo passa a ser natural, conforme a largura da tela.
+    this.tituloHero = `Horários de Missa ${preposicaoDe(this.uf)}`;
+    this.subtituloHero = `Encontre igrejas, paróquias e horários de missa em todo o estado de ${this.estadoNome}.`;
+    // Ordem e ícone únicos entre os hubs: cidades (pi-map-marker) → paróquias (pi-building).
     this.tilesHero = [
-      { icone: 'pi pi-building', numero: this.totalParoquias, rotulo: 'paróquias' },
       { icone: 'pi pi-map-marker', numero: this.totalCidades, rotulo: 'cidades' },
+      { icone: 'pi pi-building', numero: this.totalParoquias, rotulo: 'paróquias' },
     ];
   }
 

--- a/src/app/modules/public/estado/estado.component.ts
+++ b/src/app/modules/public/estado/estado.component.ts
@@ -17,7 +17,7 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { DIAS_INTENCAO } from '../../../core/constants/dias-intencao';
-import { preposicaoDe } from '../../../core/constants/states';
+import { preposicaoDe, nomeDoEstadoComArtigo } from '../../../core/constants/states';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
 import { HubBreadcrumb } from '../../../shared/components/hub-lista/hub-lista.component';
 
@@ -167,7 +167,10 @@ export class EstadoComponent implements OnInit, OnDestroy {
     // fecha em `tituloHero + ' ' + tituloDestaque` (ver template). Sem \n forçado:
     // a quebra de linha do subtítulo passa a ser natural, conforme a largura da tela.
     this.tituloHero = `Horários de Missa ${preposicaoDe(this.uf)}`;
-    this.subtituloHero = `Encontre igrejas, paróquias e horários de missa em todo o estado de ${this.estadoNome}.`;
+    // "estado do Paraná" / "estado da Bahia" / "estado de Minas Gerais" — antes
+    // era sempre "estado de X", sem contrair o artigo (ex.: "estado de Bahia",
+    // incorreto). Ficava mais visível ao lado do H1 acima, que já contrai certo.
+    this.subtituloHero = `Encontre igrejas, paróquias e horários de missa em todo o ${nomeDoEstadoComArtigo(this.uf)}.`;
     // Ordem e ícone únicos entre os hubs: cidades (pi-map-marker) → paróquias (pi-building).
     this.tilesHero = [
       { icone: 'pi pi-map-marker', numero: this.totalCidades, rotulo: 'cidades' },

--- a/src/app/modules/public/estados/estados.component.html
+++ b/src/app/modules/public/estados/estados.component.html
@@ -73,9 +73,8 @@
   <p class="estados-vazio">Nenhum estado encontrado para "{{ busca }}".</p>
 }
 
-<!-- ============ PONTE ============
-     TODO(fase 4): <app-hub-ponte eixoAtual="estados" /> entra aqui quando o
-     componente compartilhado existir. -->
+<!-- ============ PONTE ============ -->
+<app-hub-ponte eixoAtual="estados" class="block mt-10" />
 
 <!-- ============ CTA ============ -->
 <div class="wrap mt-10">

--- a/src/app/modules/public/estados/estados.component.html
+++ b/src/app/modules/public/estados/estados.component.html
@@ -44,8 +44,57 @@
   </svg>
 </app-page-hero>
 
+<!--
+  `.wrap` (72rem / 1.5rem, mesmo padrão de estado.component.scss) só no H2/CTA:
+  <app-hub-lista> já traz seu próprio container (.hub) com a mesma medida —
+  envolvê-la de novo aqui somaria padding em dobro e estreitaria a grade em
+  relação ao título acima dela.
+-->
+<div class="wrap mt-6">
+  <h2 class="sec-titulo">
+    <i class="pi pi-map sec-titulo__ico" aria-hidden="true"></i>
+    Estados com missas cadastradas
+  </h2>
+  <!--
+    Sem isto, a página mostra 12 de 27 estados e o silêncio lê como "site
+    incompleto". Só entram UFs com paróquia cadastrada (mesma regra que decide
+    quais /missas/:uf existem) — a página não está faltando dado, está sendo
+    honesta sobre o que o BuscaMissa já cobre.
+  -->
+  <p class="sec-sub">
+    Estes são os estados que já têm paróquias cadastradas no BuscaMissa. Conforme
+    novas cidades entram na plataforma, mais estados aparecem aqui.
+  </p>
+</div>
+
 <app-hub-lista icone="pi pi-map-marker" [itens]="itensVisiveis" />
 
 @if (busca && !itensVisiveis.length) {
   <p class="estados-vazio">Nenhum estado encontrado para "{{ busca }}".</p>
 }
+
+<!-- ============ PONTE ============
+     TODO(fase 4): <app-hub-ponte eixoAtual="estados" /> entra aqui quando o
+     componente compartilhado existir. -->
+
+<!-- ============ CTA ============ -->
+<div class="wrap mt-10">
+  <div class="cta">
+    <svg class="cta__ico" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2.5"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+      <path d="M32 3v11M27.5 8.5h9" />
+      <path d="M32 15 21 25v29h22V25L32 15Z" />
+      <path d="M21 32 9 40v14h12M43 32l12 8v14H43" />
+      <path d="M28.5 54v-9a3.5 3.5 0 0 1 7 0v9" />
+      <circle cx="32" cy="30" r="2.5" />
+    </svg>
+    <strong class="cta__titulo">Seu estado ainda<br />não está na lista?</strong>
+    <p class="cta__texto">Ajude o BuscaMissa a chegar até a sua paróquia — cadastre a igreja da sua comunidade.</p>
+    <a class="cta__btn" routerLink="/nova">
+      Cadastrar igreja <i class="pi pi-chevron-right" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <p class="assinatura"><i class="pi pi-heart-fill" aria-hidden="true"></i>
+    Feito com amor para aproximar você de Deus e da sua comunidade.</p>
+</div>

--- a/src/app/modules/public/estados/estados.component.html
+++ b/src/app/modules/public/estados/estados.component.html
@@ -5,7 +5,6 @@
   subtitulo="Explore as igrejas e horários de missa em cada estado do Brasil."
   [tiles]="tiles"
   [tilesCarregando]="carregando"
-  hint="Digite o nome do estado para ir direto ao hub dele."
 >
   <div class="busca" hero-busca>
     <i class="pi pi-search" aria-hidden="true"></i>

--- a/src/app/modules/public/estados/estados.component.scss
+++ b/src/app/modules/public/estados/estados.component.scss
@@ -1,6 +1,60 @@
 // Campo de busca projetado no slot [hero-busca].
 @use '../../../shared/styles/hero-busca' as *;
 
+$laranja: #bc5d10;
+$laranja-vivo: #e2761b;
+$creme: #fdf6f0;
+$titulo: #1f2937;
+$texto: #374151;
+$muted: #6b7280;
+
+// Mesmo container de estado.component.scss (72rem / 1.5rem): alinha o H2/CTA
+// com o breadcrumb/título do hero acima e com a grade do <app-hub-lista> abaixo
+// (que traz o próprio container idêntico).
+.wrap {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.sec-titulo {
+  display: flex; align-items: center; gap: 0.6rem;
+  font-size: 1.1875rem; font-weight: 800; color: $titulo; margin: 0 0 0.35rem; line-height: 1.25;
+}
+.sec-titulo__ico { color: $laranja-vivo; font-size: 1.15rem; }
+.sec-sub { color: $muted; margin: 0 0 1.25rem; font-size: 0.875rem; }
+
+// ================= CTA (mesmo padrão de /missas/:uf e /cidades) =================
+.cta {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  background: $creme;
+  border-radius: 16px;
+  padding: 1.5rem 1.75rem;
+}
+.cta__ico { width: 58px; height: 58px; flex: 0 0 auto; color: $laranja-vivo; }
+.cta__titulo { color: $titulo; font-size: 1.0625rem; font-weight: 800; line-height: 1.3; }
+.cta__texto { color: $texto; margin: 0; font-size: 0.9375rem; line-height: 1.5; }
+.cta__btn {
+  display: inline-flex; align-items: center; gap: 0.5rem; white-space: nowrap;
+  background: $laranja-vivo; color: #fff; text-decoration: none; font-weight: 700;
+  padding: 0.85rem 1.5rem; border-radius: 12px; font-size: 0.9375rem;
+  i { font-size: 0.7rem; }
+  &:hover { background: $laranja; }
+}
+@media (max-width: 900px) {
+  .cta { grid-template-columns: auto 1fr; }
+  .cta__texto { grid-column: 1 / -1; }
+  .cta__btn { grid-column: 1 / -1; justify-content: center; }
+}
+
+.assinatura {
+  text-align: center; color: $muted; font-size: 0.8125rem; margin: 2rem 0 0;
+  i { color: #ef6b6b; margin-right: 0.35rem; }
+}
+
 // Ilustração projetada em [hero-arte]. A caixa (posição, largura, ocultar abaixo
 // de 900px) é do <app-page-hero>; o preenchimento e o recorte são desta página.
 .estados-arte {

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -7,6 +7,7 @@ import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
+import { metaParoquiasCidades } from '../../../shared/utils/plural.utils';
 
 const SITE = 'https://buscamissa.com.br';
 
@@ -110,7 +111,7 @@ export class EstadosComponent implements OnInit, OnDestroy {
     this.estados = estados;
     this.itens = estados.map((e) => ({
       nome: e.estado,
-      meta: `${e.totalParoquias} paróquia(s) em ${e.totalCidades} cidade(s)`,
+      meta: metaParoquiasCidades(e.totalParoquias, e.totalCidades),
       link: ['/missas', e.uf.toLowerCase()],
     }));
     this.itensVisiveis = this.itens;
@@ -119,8 +120,9 @@ export class EstadosComponent implements OnInit, OnDestroy {
     const paroquias = estados.reduce((s, e) => s + (e.totalParoquias ?? 0), 0);
     const cidades = estados.reduce((s, e) => s + (e.totalCidades ?? 0), 0);
     this.tiles = [
-      { icone: 'pi pi-building', numero: paroquias, rotulo: 'paróquias' },
+      // Ordem e ícone únicos entre os hubs: cidades → paróquias → estados.
       { icone: 'pi pi-map-marker', numero: cidades, rotulo: 'cidades' },
+      { icone: 'pi pi-building', numero: paroquias, rotulo: 'paróquias' },
       { icone: 'pi pi-map', numero: estados.length, rotulo: 'estados' },
     ];
     this.carregando = false;

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -8,6 +8,7 @@ import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { HubListaComponent, HubBreadcrumb, HubItem } from '../../../shared/components/hub-lista/hub-lista.component';
 import { PageHeroComponent, HeroTile } from '../../../shared/components/page-hero/page-hero.component';
+import { HubPonteComponent } from '../../../shared/components/hub-ponte/hub-ponte.component';
 import { metaParoquiasCidades } from '../../../shared/utils/plural.utils';
 
 const SITE = 'https://buscamissa.com.br';
@@ -33,7 +34,7 @@ interface EstadoResumo {
 @Component({
   selector: 'app-estados',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, HubListaComponent, PageHeroComponent],
+  imports: [CommonModule, FormsModule, RouterLink, HubListaComponent, PageHeroComponent, HubPonteComponent],
   templateUrl: './estados.component.html',
   styleUrl: './estados.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/modules/public/estados/estados.component.ts
+++ b/src/app/modules/public/estados/estados.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnDe
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { STATES } from '../../../core/constants/states';
 import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { SeoService } from '../../../core/services/seo.service';
@@ -32,7 +33,7 @@ interface EstadoResumo {
 @Component({
   selector: 'app-estados',
   standalone: true,
-  imports: [CommonModule, FormsModule, HubListaComponent, PageHeroComponent],
+  imports: [CommonModule, FormsModule, RouterLink, HubListaComponent, PageHeroComponent],
   templateUrl: './estados.component.html',
   styleUrl: './estados.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/components/hub-ponte/hub-ponte.component.html
+++ b/src/app/shared/components/hub-ponte/hub-ponte.component.html
@@ -1,0 +1,16 @@
+<section class="ponte">
+  <h2 class="ponte__titulo">Você também pode explorar por</h2>
+
+  <div class="ponte__grid">
+    @for (e of outrosEixos; track e.eixo) {
+      <a class="ponte-card" [routerLink]="e.link">
+        <span class="ponte-card__icone" aria-hidden="true"><i [class]="e.icone"></i></span>
+        <span class="ponte-card__texto">
+          <span class="ponte-card__titulo">{{ e.titulo }}</span>
+          <span class="ponte-card__desc">{{ e.desc }}</span>
+        </span>
+        <i class="pi pi-arrow-right ponte-card__seta" aria-hidden="true"></i>
+      </a>
+    }
+  </div>
+</section>

--- a/src/app/shared/components/hub-ponte/hub-ponte.component.scss
+++ b/src/app/shared/components/hub-ponte/hub-ponte.component.scss
@@ -1,0 +1,61 @@
+$laranja: #bc5d10;
+$laranja-vivo: #e2761b;
+$borda: #e5e7eb;
+$titulo: #1f2937;
+$muted: #6b7280;
+
+// Mesmo container 72rem/1.5rem dos demais blocos dos hubs (.wrap em
+// estado/estados/dias.component.scss) — a Ponte é sempre o penúltimo bloco
+// antes do CTA, então herda o mesmo alinhamento horizontal.
+.ponte {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.ponte__titulo {
+  font-size: 1.0625rem;
+  font-weight: 800;
+  color: $titulo;
+  margin: 0 0 1rem;
+}
+
+.ponte__grid {
+  display: grid;
+  gap: 0.85rem;
+  // Dois cards (o eixo atual some da lista): metade/metade a partir de 480px,
+  // empilhados abaixo disso.
+  grid-template-columns: 1fr;
+  @media (min-width: 480px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.ponte-card {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1.1rem 1.25rem;
+  background: #fff;
+  border: 1px solid $borda;
+  border-radius: 14px;
+  text-decoration: none;
+  transition: border-color .15s, box-shadow .15s, transform .15s;
+
+  &:hover {
+    border-color: #f3b989;
+    box-shadow: 0 3px 12px rgba(0, 0, 0, .06);
+    transform: translateY(-2px);
+  }
+
+  &__icone {
+    display: grid; place-items: center;
+    width: 2.75rem; height: 2.75rem; flex: 0 0 2.75rem;
+    background: #fff4ed; border-radius: 10px;
+    i { color: $laranja-vivo; font-size: 1.1rem; }
+  }
+
+  &__texto { display: flex; flex-direction: column; gap: 0.15rem; flex: 1; min-width: 0; }
+  &__titulo { font-weight: 700; color: $titulo; font-size: 0.9375rem; }
+  &__desc { font-size: 0.8125rem; color: $muted; }
+
+  &__seta { color: #9ca3af; font-size: 0.85rem; flex-shrink: 0; }
+}

--- a/src/app/shared/components/hub-ponte/hub-ponte.component.ts
+++ b/src/app/shared/components/hub-ponte/hub-ponte.component.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+/** Um dos três eixos de descoberta do BuscaMissa. */
+export type EixoDescoberta = 'cidades' | 'estados' | 'dias';
+
+interface EixoItem {
+  eixo: EixoDescoberta;
+  icone: string;
+  titulo: string;
+  desc: string;
+  link: string;
+}
+
+/**
+ * Ponte entre os hubs de descoberta (`/cidades`, `/estados`, `/dias`) — resolve o
+ * problema de arquitetura da auditoria do Explorar: os três eixos eram becos sem
+ * saída, só conectados pelo menu do header. Sem `/explorar` como quarta página
+ * (decisão consciente: seria um nível de navegação a mais, uma URL a mais para
+ * indexar e uma duplicata da seção "Encontre do seu jeito" da home) — a ligação
+ * cruzada acontece aqui, no fim de cada hub.
+ *
+ * É PRESENTACIONAL de propósito, como `PageHeroComponent`/`HubListaComponent`:
+ * sem HTTP, sem lógica de página. O mapa dos 3 eixos é uma ÚNICA constante aqui
+ * dentro — cada página só informa `eixoAtual`, que o componente esconde da lista.
+ * Rótulos e ícones são os MESMOS do dropdown "Explorar" do header
+ * (`header.component.html`) e da seção "Encontre do seu jeito" da home
+ * (`home-explorar.component.html`): é o mesmo mapa mental em três lugares, não
+ * uma quarta variação.
+ */
+@Component({
+  selector: 'app-hub-ponte',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './hub-ponte.component.html',
+  styleUrl: './hub-ponte.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HubPonteComponent {
+  @Input({ required: true }) eixoAtual!: EixoDescoberta;
+
+  /** Fonte única dos 3 eixos — mesmos rótulos/ícones do header e da home. */
+  private static readonly EIXOS: EixoItem[] = [
+    { eixo: 'cidades', icone: 'pi pi-map-marker', titulo: 'Por cidade', desc: 'Encontre missas na sua cidade', link: '/cidades' },
+    { eixo: 'estados', icone: 'pi pi-map', titulo: 'Por estado', desc: 'Explore igrejas por estado', link: '/estados' },
+    { eixo: 'dias', icone: 'pi pi-calendar', titulo: 'Por dia da semana', desc: 'Encontre missas por dia', link: '/dias' },
+  ];
+
+  get outrosEixos(): EixoItem[] {
+    return HubPonteComponent.EIXOS.filter((e) => e.eixo !== this.eixoAtual);
+  }
+}

--- a/src/app/shared/components/page-hero/page-hero.component.html
+++ b/src/app/shared/components/page-hero/page-hero.component.html
@@ -20,19 +20,24 @@
     }
 
     <!--
-      Busca ANTES dos tiles: é a ação primária da página (o que o usuário veio
-      fazer), os números são prova social — vêm depois de o usuário já saber pra
-      onde ir. Antes os tiles vinham primeiro aqui (fixo neste template, a ordem
-      no HTML de quem consome o hero não tinha efeito nenhum sobre isto: é
-      projeção via ng-content num slot de posição fixa) e empurravam a busca para
-      fora da primeira dobra no mobile (ex.: top:454px em /cidades).
-      Sem margem própria: o espaçamento é dado pelo bloco seguinte (.ph-hero__tiles)
-      quando ele existe. Assim uma página sem busca (ex.: /dias) não ganha um
-      buraco reservado, e uma página sem tiles (nenhuma hoje) também não.
+      Ordem do bloco de ação: busca -> hint -> tiles. A busca é a ação primária
+      (o que o usuário veio fazer) e os números são prova de cobertura, que só
+      fazem sentido depois de ele já saber para onde ir. A ordem é fixada AQUI
+      porque `[hero-busca]` é projetado via ng-content num slot de posição fixa:
+      reordenar os elementos no HTML de quem consome o hero não tem efeito nenhum.
+      Espaçamento: cada bloco só empurra o seguinte quando de fato existe (ver
+      SCSS), então /dias — sem busca e sem tiles — não ganha buraco reservado.
     -->
     <div class="ph-hero__busca">
       <ng-content select="[hero-busca]"></ng-content>
     </div>
+
+    <!-- O hint descreve a BUSCA ("Digite o nome da cidade..."), então vem colado
+         nela — não depois dos tiles, onde ficava órfão de um campo que já tinha
+         saído da vista. -->
+    @if (hint) {
+      <p class="ph-hero__hint">{{ hint }}</p>
+    }
 
     @if (tiles.length) {
       <div class="ph-hero__tiles">
@@ -50,10 +55,6 @@
           </div>
         }
       </div>
-    }
-
-    @if (hint) {
-      <p class="ph-hero__hint">{{ hint }}</p>
     }
   </div>
 

--- a/src/app/shared/components/page-hero/page-hero.component.html
+++ b/src/app/shared/components/page-hero/page-hero.component.html
@@ -19,6 +19,21 @@
       <p class="ph-hero__sub">{{ subtitulo }}</p>
     }
 
+    <!--
+      Busca ANTES dos tiles: é a ação primária da página (o que o usuário veio
+      fazer), os números são prova social — vêm depois de o usuário já saber pra
+      onde ir. Antes os tiles vinham primeiro aqui (fixo neste template, a ordem
+      no HTML de quem consome o hero não tinha efeito nenhum sobre isto: é
+      projeção via ng-content num slot de posição fixa) e empurravam a busca para
+      fora da primeira dobra no mobile (ex.: top:454px em /cidades).
+      Sem margem própria: o espaçamento é dado pelo bloco seguinte (.ph-hero__tiles)
+      quando ele existe. Assim uma página sem busca (ex.: /dias) não ganha um
+      buraco reservado, e uma página sem tiles (nenhuma hoje) também não.
+    -->
+    <div class="ph-hero__busca">
+      <ng-content select="[hero-busca]"></ng-content>
+    </div>
+
     @if (tiles.length) {
       <div class="ph-hero__tiles">
         @for (t of tiles; track t.rotulo) {
@@ -36,14 +51,6 @@
         }
       </div>
     }
-
-    <!--
-      Sem margem própria: o espaçamento vem do bloco anterior (.ph-hero__tiles).
-      Assim uma página sem busca (ex.: /dias) não ganha um buraco reservado.
-    -->
-    <div class="ph-hero__busca">
-      <ng-content select="[hero-busca]"></ng-content>
-    </div>
 
     @if (hint) {
       <p class="ph-hero__hint">{{ hint }}</p>

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -92,11 +92,22 @@ $muted: #6b7280;
   grid-template-columns: repeat(var(--ph-tiles-n, 3), 1fr);
   gap: 0.75rem;
   margin-bottom: 1.75rem;
+
+  /* 3+ colunas em telas estreitas: cada tile tem só ~100-110px de largura —
+     padding/gap generosos (feitos para 1-2 tiles largos) deixavam pouca folga
+     para o rótulo. Aperta só nesse caso, sem mexer no tile de 1-2 colunas. */
+  @media (max-width: 480px) {
+    &:has(.ph-tile:nth-child(3)) { gap: 0.5rem; }
+  }
 }
 .ph-tile {
-  display: flex; align-items: center; gap: 0.7rem;
+  display: flex; align-items: center; gap: 0.5rem;
   background: #fff; border: 1px solid #f0e2d6; border-radius: 14px;
   padding: 0.85rem 1.15rem; min-width: 0;
+
+  @media (max-width: 480px) {
+    padding: 0.7rem 0.6rem;
+  }
 }
 .ph-tile__ico {
   display: grid; place-items: center;
@@ -104,14 +115,26 @@ $muted: #6b7280;
   background: $creme-forte; border-radius: 10px;
   i { color: $laranja-vivo; font-size: 1.05rem; }
 }
-.ph-tile__dados { display: block; }
+/*
+ * flex: 1 1 auto + min-width: 0: sem isso, um item flex não encolhe abaixo da
+ * largura intrínseca do próprio conteúdo — o rótulo "paróquias" empurrava a
+ * caixa para fora do tile (overflow silencioso) em vez de quebrar linha, em
+ * grades de 3 colunas estreitas no mobile (era o "clássico" bug de min-width:auto
+ * do flexbox).
+ */
+.ph-tile__dados { display: block; flex: 1 1 auto; min-width: 0; }
 .ph-tile__num {
   display: block; font-size: 1.375rem; font-weight: 800; color: $titulo;
   line-height: 1.1; font-variant-numeric: tabular-nums;
   /* Mesma caixa com número ou com skeleton — o tile não muda de altura. */
   min-height: 1.5125rem;
 }
-.ph-tile__lbl { display: block; font-size: 0.8125rem; color: $muted; }
+.ph-tile__lbl {
+  display: block; font-size: 0.8125rem; color: $muted;
+  /* Quebra em vez de vazar: colunas estreitas (3-4 tiles no mobile) não têm
+     largura garantida para um rótulo de uma palavra só. */
+  overflow-wrap: break-word;
+}
 
 /* Slot da busca: sem margem própria (ver comentário no template). */
 .ph-hero__busca { position: relative; }

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -80,6 +80,10 @@ $muted: #6b7280;
   font-size: 1rem;
   line-height: 1.55;
   white-space: pre-line;
+
+  /* No mobile o hero disputa a primeira dobra com a busca: 1.25rem mantém a
+     separação legível e devolve alguns px para a ação primária. */
+  @media (max-width: 640px) { margin-bottom: 1.25rem; }
 }
 
 /* STAT TILES — cards brancos com borda.
@@ -91,38 +95,77 @@ $muted: #6b7280;
   display: grid;
   grid-template-columns: repeat(var(--ph-tiles-n, 3), 1fr);
   gap: 0.75rem;
-  margin-bottom: 1.75rem;
+  /* Último bloco do hero: o fechamento é o padding-bottom do .ph-hero. */
+  margin: 1.5rem 0 0;
 
-  /* 3+ colunas em telas estreitas: cada tile tem só ~100-110px de largura —
-     padding/gap generosos (feitos para 1-2 tiles largos) deixavam pouca folga
-     para o rótulo. Aperta só nesse caso, sem mexer no tile de 1-2 colunas. */
-  @media (max-width: 480px) {
-    &:has(.ph-tile:nth-child(3)) { gap: 0.5rem; }
-  }
+  @media (max-width: 640px) { gap: 0.5rem; }
 }
+
+/*
+ * DESKTOP: composição horizontal (ícone ao lado do número+rótulo) — é a que dá
+ * a densidade "premium" da referência /missas/:uf.
+ *
+ * O padding lateral é 0.85rem (não 1.15rem) porque a coluna de texto aqui é mais
+ * apertada do que parece: a partir de 900px o hero reserva 42% da largura para a
+ * arte, então em 1280px os 3 tiles dividem só ~435px. Com 1.15rem sobravam 63px
+ * para o rótulo e "paróquias" ocupa 63px — passava por ~2px, e qualquer variação
+ * de renderização de fonte o quebraria em duas linhas.
+ */
 .ph-tile {
   display: flex; align-items: center; gap: 0.5rem;
   background: #fff; border: 1px solid #f0e2d6; border-radius: 14px;
-  padding: 0.85rem 1.15rem; min-width: 0;
+  padding: 0.85rem; min-width: 0;
 
-  @media (max-width: 480px) {
-    padding: 0.7rem 0.6rem;
+  /*
+   * MOBILE: composição VERTICAL (ícone em cima, número, rótulo) — mini-métrica,
+   * não card horizontal.
+   *
+   * Por quê: em 375px cada um dos 3 tiles tem ~106px. Na horizontal, o ícone
+   * (34px) + gap (7px) + padding (17px) consomem 58px, sobrando ~48px de coluna
+   * de texto — menos que os ~54px de que "paróquias" precisa, então o rótulo
+   * quebrava em duas linhas ("paróqui/as") e o tile parecia defeito.
+   * Empilhando, o rótulo passa a dispor da largura interna INTEIRA do tile
+   * (~92px) e cabe inteiro, sem encolher fonte nem cortar texto.
+   */
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.35rem;
+    padding: 0.9rem 0.5rem;
   }
 }
+
 .ph-tile__ico {
   display: grid; place-items: center;
-  width: 34px; height: 34px; flex: 0 0 34px;
-  background: $creme-forte; border-radius: 10px;
-  i { color: $laranja-vivo; font-size: 1.05rem; }
+  /* 30px, não 34px: na composição horizontal o ícone divide a largura com o
+     texto, e cada px que ele devolve é px de rótulo (ver comentário em .ph-tile). */
+  width: 30px; height: 30px; flex: 0 0 30px;
+  background: $creme-forte; border-radius: 9px;
+  i { color: $laranja-vivo; font-size: 1rem; }
+
+  @media (max-width: 640px) {
+    /* Empilhado o ícone não disputa largura com o texto, então pode voltar a
+       respirar um pouco. */
+    width: 32px; height: 32px; flex: 0 0 32px;
+    border-radius: 10px;
+  }
 }
+
 /*
  * flex: 1 1 auto + min-width: 0: sem isso, um item flex não encolhe abaixo da
- * largura intrínseca do próprio conteúdo — o rótulo "paróquias" empurrava a
- * caixa para fora do tile (overflow silencioso) em vez de quebrar linha, em
- * grades de 3 colunas estreitas no mobile (era o "clássico" bug de min-width:auto
- * do flexbox).
+ * largura intrínseca do próprio conteúdo — o rótulo empurrava a caixa para fora
+ * do tile (overflow silencioso) em vez de acomodar, em grades estreitas
+ * (o "clássico" min-width:auto do flexbox).
  */
 .ph-tile__dados { display: block; flex: 1 1 auto; min-width: 0; }
+@media (max-width: 640px) {
+  /* Empilhado: ocupa a largura toda para o texto centralizar sobre o tile
+     inteiro (com align-items:center um item de largura automática encolheria
+     ao conteúdo). */
+  .ph-tile__dados { width: 100%; flex: 0 0 auto; }
+}
+
 .ph-tile__num {
   display: block; font-size: 1.375rem; font-weight: 800; color: $titulo;
   line-height: 1.1; font-variant-numeric: tabular-nums;
@@ -130,19 +173,22 @@ $muted: #6b7280;
   min-height: 1.5125rem;
 }
 .ph-tile__lbl {
-  display: block; font-size: 0.8125rem; color: $muted;
-  /* Quebra em vez de vazar: colunas estreitas (3-4 tiles no mobile) não têm
-     largura garantida para um rótulo de uma palavra só. */
+  display: block; font-size: 0.8125rem; color: $muted; line-height: 1.25;
+  /* Rede de segurança para um rótulo futuro mais longo que a coluna: só dispara
+     quando a palavra não cabe sozinha na linha. Com a composição vertical, os
+     rótulos atuais (cidades/paróquias/estados) não chegam perto disso. */
   overflow-wrap: break-word;
 }
 
-/* Slot da busca: sem margem própria (ver comentário no template). */
-/* margin-bottom só quando HÁ tiles depois: numa página sem tiles (nenhuma hoje,
-   mas o hero não deve presumir) o hint já dá o respiro sozinho. `:has()` evita
-   duplicar espaçamento quando o slot de busca está vazio (ex.: /dias). */
+/* ===== Ritmo do bloco de ação: busca -> hint -> tiles =====
+   Cada bloco só empurra o seguinte quando existe de fato — `:has(> *)` cobre o
+   caso do slot projetado vazio (/dias não tem busca) e o `@if` do template cobre
+   hint e tiles. Assim nenhum hub ganha respiro reservado para algo que não tem. */
 .ph-hero__busca {
   position: relative;
-  &:has(> *) { margin-bottom: 1.25rem; }
+  &:has(> *) { margin-bottom: 0.55rem; }
 }
 
-.ph-hero__hint { color: $muted; font-size: 0.85rem; margin: 0.6rem 0 0; }
+/* Colado à busca: é o texto auxiliar DELA. O respiro até os tiles vem do
+   margin-top deles (margens adjacentes colapsam, então não soma em dobro). */
+.ph-hero__hint { color: $muted; font-size: 0.85rem; margin: 0; }

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -20,6 +20,10 @@ $muted: #6b7280;
   width: 100%;
   /* .hero global (styles.scss) centraliza texto; aqui o alinhamento é à esquerda. */
   text-align: left;
+
+  /* Bloco de estatísticas + respiro final ficavam grandes demais no mobile
+     (faixa creme ocupando boa parte da primeira dobra). */
+  @media (max-width: 640px) { padding-bottom: 1.5rem; margin-bottom: 2rem; }
 }
 @media (min-width: 900px) {
   /* altura maior deixa a arte respirar (object-fit: cover recorta) */
@@ -98,7 +102,7 @@ $muted: #6b7280;
   /* Último bloco do hero: o fechamento é o padding-bottom do .ph-hero. */
   margin: 1.5rem 0 0;
 
-  @media (max-width: 640px) { gap: 0.5rem; }
+  @media (max-width: 640px) { gap: 0.5rem; margin-top: 1rem; }
 }
 
 /*
@@ -131,8 +135,10 @@ $muted: #6b7280;
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 0.35rem;
-    padding: 0.9rem 0.5rem;
+    gap: 0.2rem;
+    /* Compacto: era 0.9rem 0.5rem (~99px de altura) — o bloco de 3 tiles
+       competia com o conteúdo logo abaixo por espaço na tela. */
+    padding: 0.55rem 0.4rem;
   }
 }
 
@@ -145,10 +151,9 @@ $muted: #6b7280;
   i { color: $laranja-vivo; font-size: 1rem; }
 
   @media (max-width: 640px) {
-    /* Empilhado o ícone não disputa largura com o texto, então pode voltar a
-       respirar um pouco. */
-    width: 32px; height: 32px; flex: 0 0 32px;
-    border-radius: 10px;
+    width: 24px; height: 24px; flex: 0 0 24px;
+    border-radius: 8px;
+    i { font-size: 0.8rem; }
   }
 }
 
@@ -171,6 +176,11 @@ $muted: #6b7280;
   line-height: 1.1; font-variant-numeric: tabular-nums;
   /* Mesma caixa com número ou com skeleton — o tile não muda de altura. */
   min-height: 1.5125rem;
+
+  /* Um pouco menor no mobile: some dos ~20px que o bloco de tiles tirava da
+     dobra sem comprometer a leitura (o número continua sendo o elemento
+     dominante do tile). */
+  @media (max-width: 640px) { font-size: 1.125rem; min-height: 1.25rem; }
 }
 .ph-tile__lbl {
   display: block; font-size: 0.8125rem; color: $muted; line-height: 1.25;
@@ -178,6 +188,8 @@ $muted: #6b7280;
      quando a palavra não cabe sozinha na linha. Com a composição vertical, os
      rótulos atuais (cidades/paróquias/estados) não chegam perto disso. */
   overflow-wrap: break-word;
+
+  @media (max-width: 640px) { font-size: 0.75rem; }
 }
 
 /* ===== Ritmo do bloco de ação: busca -> hint -> tiles =====

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -137,6 +137,12 @@ $muted: #6b7280;
 }
 
 /* Slot da busca: sem margem própria (ver comentário no template). */
-.ph-hero__busca { position: relative; }
+/* margin-bottom só quando HÁ tiles depois: numa página sem tiles (nenhuma hoje,
+   mas o hero não deve presumir) o hint já dá o respiro sozinho. `:has()` evita
+   duplicar espaçamento quando o slot de busca está vazio (ex.: /dias). */
+.ph-hero__busca {
+  position: relative;
+  &:has(> *) { margin-bottom: 1.25rem; }
+}
 
 .ph-hero__hint { color: $muted; font-size: 0.85rem; margin: 0.6rem 0 0; }

--- a/src/app/shared/components/page-hero/page-hero.component.scss
+++ b/src/app/shared/components/page-hero/page-hero.component.scss
@@ -82,12 +82,21 @@ $muted: #6b7280;
   white-space: pre-line;
 }
 
-/* STAT TILES — cards brancos com borda */
-.ph-hero__tiles { display: flex; flex-wrap: wrap; gap: 0.9rem; margin-bottom: 1.75rem; }
+/* STAT TILES — cards brancos com borda.
+   Grade de colunas IGUAIS (não flex-wrap/min-width): a largura por conteúdo
+   fazia os tiles ficarem em escada (ex.: 161/200/229px em 375px) e, com 3 tiles
+   de rótulo longo, sobrava um órfão sozinho na última linha. `--ph-tiles-n` é
+   setado no host conforme `tiles.length` — nunca 2+1, nunca degrau. */
+.ph-hero__tiles {
+  display: grid;
+  grid-template-columns: repeat(var(--ph-tiles-n, 3), 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1.75rem;
+}
 .ph-tile {
   display: flex; align-items: center; gap: 0.7rem;
   background: #fff; border: 1px solid #f0e2d6; border-radius: 14px;
-  padding: 0.85rem 1.15rem; min-width: 140px;
+  padding: 0.85rem 1.15rem; min-width: 0;
 }
 .ph-tile__ico {
   display: grid; place-items: center;

--- a/src/app/shared/components/page-hero/page-hero.component.ts
+++ b/src/app/shared/components/page-hero/page-hero.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -54,6 +54,18 @@ export class PageHeroComponent {
 
   /** Lista vazia remove a faixa de tiles inteira — sem reservar espaço. */
   @Input() tiles: HeroTile[] = [];
+
+  /**
+   * Nº de colunas da grade de tiles = nº de tiles (1 a 4). Grade de colunas
+   * IGUAIS em vez de flex-wrap: garante largura idêntica entre tiles e elimina
+   * o órfão de última linha (2+1) que o flex-wrap produzia com 3 tiles em
+   * telas estreitas. Acima de 4 tiles, trava em 4 colunas (2 linhas de 2)
+   * em vez de espremer colunas ao infinito.
+   */
+  @HostBinding('style.--ph-tiles-n')
+  get tilesColunas(): number {
+    return Math.min(Math.max(this.tiles.length, 1), 4);
+  }
 
   /**
    * Troca SÓ os números por skeleton, preservando a altura do tile (anti-CLS).

--- a/src/app/shared/utils/plural.utils.ts
+++ b/src/app/shared/utils/plural.utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Concordância singular/plural real para os contadores dos hubs de navegação
+ * (`/cidades`, `/estados`, `/missas/:uf`). Substitui o padrão "3 paróquia(s)",
+ * que é microcopy de engenharia, não texto de produto.
+ */
+
+/** "1 paróquia" / "3 paróquias" — troca só o sufixo, para palavras regulares em -a/-o. */
+export function pluralizar(quantidade: number, singular: string, plural: string): string {
+  const palavra = quantidade === 1 ? singular : plural;
+  return `${quantidade} ${palavra}`;
+}
+
+/** "1 paróquia" (singular real quando quantidade === 1). */
+export function paroquias(quantidade: number): string {
+  return pluralizar(quantidade, 'paróquia', 'paróquias');
+}
+
+/** "1 cidade" (singular real quando quantidade === 1). */
+export function cidades(quantidade: number): string {
+  return pluralizar(quantidade, 'cidade', 'cidades');
+}
+
+/** "1 estado" (singular real quando quantidade === 1). */
+export function estados(quantidade: number): string {
+  return pluralizar(quantidade, 'estado', 'estados');
+}
+
+/**
+ * Meta padrão dos cards de hub: "577 paróquias · 159 cidades" — sem "(s)" e
+ * com singular/plural corretos nos dois extremos.
+ */
+export function metaParoquiasCidades(totalParoquias: number, totalCidades: number): string {
+  return `${paroquias(totalParoquias)} · ${cidades(totalCidades)}`;
+}


### PR DESCRIPTION
## Contexto

Auditoria da área "Explorar" identificou que `/cidades`, `/estados` e `/dias` seguiam o padrão **Hero → números → lista → fim**: ação principal escondida atrás dos tiles, hubs sem ligação entre si, páginas terminando como lista de links, e `/cidades` fora do prerender com números divergentes de `/estados`.

## O que mudou

**Fase 1 — Fundação**
- Alinhamento do header com o conteúdo (padding 1.25rem → 1.5rem)
- Tiles do `PageHeroComponent` em grade de colunas iguais (elimina escadinha e órfão de última linha)
- Preposição correta por UF em `/missas/:uf` ("no Paraná", "na Bahia", "em São Paulo") via novo helper em `core/constants/states.ts`
- Microcopy de plural real (`shared/utils/plural.utils.ts`), sem mais "(s)"

**Fase 2 — `/cidades`**
- Passa a consumir `SeoPaginasService.getEstados()` — mesma fonte canônica de `/estados` — em vez de `ChurchesService.addressRange()`+`getInfo()`. Corrige totais divergentes, slugs gerados no cliente (havia um link 404: "Itapejara d'Oeste") e duas duplicatas de cidade
- Prerenderizada, com `canonical`, `BreadcrumbList` e `ItemList` — validado no HTML gerado (381 links de cidade)
- Nova seção "Capitais e principais cidades" + índice "Todas as cidades por estado" (todos os estados fechados por padrão)

**Fase 3 — `/estados` e `/dias`**
- `/estados`: H2 + subtítulo explicando por que aparecem 12 de 27 UFs
- `/dias`: estrutura própria — hero curto, destaque "Missa de hoje" → `/missa-hoje`, sem tile tautológico ("7 dias da semana")

**Fase 4 — `HubPonteComponent`**
- Liga os três hubs entre si no rodapé de cada página (mostra os outros 2 eixos, esconde o atual) — sem criar `/explorar` como quarta página

**Correções de revisão**
- Ordem real busca → tiles no `PageHeroComponent` (o slot de busca é projetado via `ng-content` em posição fixa; só reordenar bindings na página não tinha efeito)
- Recomposição dos tiles no mobile (vertical: ícone → número → rótulo) para eliminar quebra de rótulo ("paróqui/as")
- Alvos de toque em `px` (a raiz do site é 14px, não 16px — `2.75rem` resolvia para 38.5px, não 44px)
- Removido método órfão `ChurchesService.limparCacheEnderecos()`
- Contração de artigo no subtítulo de `/missas/:uf` ("estado do Paraná", "estado da Bahia")

## Test plan

- [x] `tsc --noEmit` limpo
- [x] `npm run build:staging` — prerender saudável (0% erro), dist 61.8MB/200MB
- [x] HTML prerenderizado validado: 381 links de cidade, `ItemList`/`BreadcrumbList`/canonical em `/cidades`, `/estados`, `/dias`
- [x] Alinhamento e ausência de scroll horizontal em 375px, 640px, 900px e 1280px nas 4 páginas
- [x] Navegação sem header/footer testada nas 3 direções (`HubPonteComponent`)
- [x] Contração de artigo testada nas 12 UFs reais da base