### PR TITLE
Promove dev → master: cabe no teto de distribuição do SWA

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-moss-0416a7b0f.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-0416a7b0f.yml
@@ -35,7 +35,19 @@ jobs:
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "dist/busca-missa/browser" # Built app content directory - optional
-          app_build_command: "npm run build:prod"
+          # skip_app_build: publica o dist que o step "Build Application" acima gerou e
+          # que os guards do postbuild JÁ validaram.
+          #
+          # Antes havia `app_build_command`, e com ele o Oryx rodava `npm run build:prod`
+          # DE NOVO dentro do Azure — ou seja, validávamos um artefato e publicávamos
+          # outro. Não era teórico: no deploy de 12/08 o step do Actions produziu 4.297
+          # arquivos (guards verdes) e o Oryx publicou 3.193 rotas, porque naquele build
+          # o fetch de `/v2/seo/routes` degradou e as 988 cidades sumiram. Foi assim que
+          # as cidades ficaram fora de produção com a esteira toda verde.
+          #
+          # De quebra, o build deixa de rodar duas vezes e a API de prod para de ser
+          # consultada em dobro a cada deploy.
+          skip_app_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-gentle-moss-0416a7b0f.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-0416a7b0f.yml
@@ -32,9 +32,13 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
+          # Com skip_app_build, o action IGNORA output_location e procura o artefato
+          # direto em app_location — por isso ele aponta para o dist já construído, e
+          # não para a raiz do repo. Deixar app_location: "/" faz o deploy falhar com
+          # "Failed to find a default file in the app artifacts folder (/)".
+          app_location: "dist/busca-missa/browser" # Conteúdo JÁ construído pelo step acima
           api_location: "" # Api source code path - optional
-          output_location: "dist/busca-missa/browser" # Built app content directory - optional
+          output_location: "" # Vazio: o conteúdo já é o app_location
           # skip_app_build: publica o dist que o step "Build Application" acima gerou e
           # que os guards do postbuild JÁ validaram.
           #

--- a/.github/workflows/azure-static-web-apps-proud-glacier-006788b0f.yml
+++ b/.github/workflows/azure-static-web-apps-proud-glacier-006788b0f.yml
@@ -34,7 +34,10 @@ jobs:
           app_location: "/" # App source code path
           api_location: "" # API source code path - Optional
           output_location: "dist/busca-missa/browser" # Built app content directory - Optional
-          app_build_command: "npm run build:staging"
+          # Ver o comentário equivalente no workflow de master: publica o dist que o
+          # step acima gerou e os guards validaram, em vez de deixar o Oryx reconstruir
+          # e publicar um artefato diferente do que foi verificado.
+          skip_app_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-proud-glacier-006788b0f.yml
+++ b/.github/workflows/azure-static-web-apps-proud-glacier-006788b0f.yml
@@ -31,9 +31,11 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          app_location: "/" # App source code path
+          # Com skip_app_build o action ignora output_location e lê de app_location —
+          # ver o comentário no workflow de master.
+          app_location: "dist/busca-missa/browser" # Conteúdo JÁ construído pelo step acima
           api_location: "" # API source code path - Optional
-          output_location: "dist/busca-missa/browser" # Built app content directory - Optional
+          output_location: "" # Vazio: o conteúdo já é o app_location
           # Ver o comentário equivalente no workflow de master: publica o dist que o
           # step acima gerou e os guards validaram, em vez de deixar o Oryx reconstruir
           # e publicar um artefato diferente do que foi verificado.

--- a/scripts/baixar-bulk-prerender.mjs
+++ b/scripts/baixar-bulk-prerender.mjs
@@ -140,9 +140,11 @@ async function main() {
   if (criticasFalharam.length > 0) {
     console.error(
       `\n   ${criticasFalharam.length} bulk(s) crítico(s) sem cache válido. Build ABORTADO.\n` +
-      `   Sem esse cache, /paroquia/* e /missas/* não são prerenderizadas — e como estão\n` +
-      `   fora do navigationFallback, cada página faltante vira 404 numa URL REAL.\n` +
-      `   Publicar assim tira milhares de páginas do índice. Corrija a API e rode de novo.\n`,
+      `   Sem esse cache o prerender sai vazio: /missas/* está FORA do navigationFallback,\n` +
+      `   então cada cidade faltante vira 404 numa URL REAL; e as páginas de paróquia\n` +
+      `   caem todas no shell CSR, sem HTML para o Google.\n` +
+      `   Causa mais comum: cold start da API (503 nos primeiros segundos). Confira\n` +
+      `   ${base}/health e rode de novo — se responder 200, era só a instância acordando.\n`,
     );
     process.exit(1);
   }

--- a/scripts/verificar-dist-size.mjs
+++ b/scripts/verificar-dist-size.mjs
@@ -44,10 +44,22 @@ const ROOT = join(__dirname, '..');
 // Juntos economizam ~5,2 KB/página ≈ 30 MB em prod, levando a projeção a ~181 MB.
 const LIMITE_MB = 220;
 const LIMITE_BYTES = LIMITE_MB * 1024 * 1024;
-// Teto de arquivos: se alguém reintroduzir prerender de milhares de páginas por engano,
-// a esteira quebra na hora — não depois do deploy. Base atual (~8 estáticas + ~380
-// cidades + ~3.4k paróquias com missa) fica muito abaixo; 15000 dá folga sem mascarar.
-const MAX_FILES = 15000;
+// Teto de ARQUIVOS — o guard que mais importa, e o que estava errado.
+//
+// 15.000 era a cota oficial do SWA. O limite REAL é operacional e muito menor: o Azure
+// faz polling por 300 s na distribuição de conteúdo e desiste, e o gatilho é a contagem
+// de arquivos (relatos da comunidade apontam ~3.000). Evidência própria, em master:
+//
+//   3.311 arquivos → deploy OK                                        (12/08)
+//   6.050 arquivos → "Failure during content distribution" @ 298,8 s  (14/08)
+//
+// O build de 6.050 passou neste guard com 15.000 e mesmo assim não publicou — o guard
+// dava confiança falsa. 3.400 fica logo acima da faixa provada boa, para barrar o
+// crescimento ANTES do deploy falhar em vez de depois.
+//
+// Se este guard estourar, o caminho NÃO é aumentá-lo: é reduzir o teto de páginas
+// (MAX_PAROQUIAS_PRERENDER em app.routes.server.ts) ou reavaliar a plataforma.
+const MAX_FILES = 3400;
 
 /** Acha dist/<app>/browser varrendo os apps sob dist/. */
 function acharBrowserDir(base) {

--- a/scripts/verificar-prerender.mjs
+++ b/scripts/verificar-prerender.mjs
@@ -133,6 +133,9 @@ if (browserDir) {
 // tem que barrar o deploy, não liberá-lo.
 const COBERTURA_MINIMA = 0.9;
 
+/** Espelha MAX_PAROQUIAS_PRERENDER de src/app/app.routes.server.ts. */
+const MAX_PAROQUIAS_PRERENDER = 1900;
+
 /** Espelha exatamente o universo de app.routes.server.ts (paroquiasDoDisco/cidadesDoDisco). */
 const esperadoPorSecao = {
   missas: () => {
@@ -146,15 +149,20 @@ const esperadoPorSecao = {
     return cidades.filter((c) => c?.uf && c?.cidadeSlug).length
       + estados.filter((e) => e?.uf).length;
   },
-  // TODAS as paróquias do disco — o filtro por missa/confiança saiu junto com o de
-  // app.routes.server.ts. O número não é fixo no código de propósito: sai do
-  // .prerender-cache, então acompanha o crescimento da base (dev ~2.090, prod ~4.727)
-  // sem virar constante desatualizada. Continua sendo uma exigência exata (≥90% do
-  // que o prebuild prometeu), não uma faixa larga que deixa regressão passar.
+  // Paróquias ELEGÍVEIS (com horário), limitadas pelo mesmo teto de
+  // app.routes.server.ts. Espelhamos só a CONTAGEM, não o algoritmo de seleção: o teto
+  // é determinístico, então basta `min(elegíveis, teto)` para saber quantas páginas
+  // deveriam existir — e assim não há um segundo lugar com o critério de ranking, que
+  // poderia divergir em silêncio do original.
+  //
+  // ⚠️ Se MAX_PAROQUIAS_PRERENDER mudar em app.routes.server.ts, mudar aqui também.
   paroquia: () => {
     const lista = lerCache('paroquias.json');
     if (!lista) return null;
-    return lista.filter((p) => p?.uf && p?.cidadeSlug && p?.slug).length;
+    const elegiveis = lista.filter(
+      (p) => p?.uf && p?.cidadeSlug && p?.slug && (p?.igreja?.missas?.length ?? 0) > 0,
+    ).length;
+    return Math.min(elegiveis, MAX_PAROQUIAS_PRERENDER);
   },
 };
 

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -18,42 +18,107 @@ import { buscarRotasSeo, normalizarBaseUrl } from '../../scripts/lib/seo-routes.
  *   sitemap).
  * - Fase 2.5 (aqui): prerender das páginas de PARÓQUIA (`/paroquia/:uf/:cidade/:slug`).
  *   O bulk `/v2/seo/paroquias` (interceptor só-server) evita as chamadas individuais.
- *   Prerenderiza TODAS as paróquias do disco (ver paroquiasDoDisco). Até 2026-08-13
- *   havia um filtro por `missas.length > 0` e confiança Média/Alta, motivado pelo
- *   tamanho do dist; ele deixava ~1.754 paróquias reais sem arquivo, e é justamente
- *   a ausência de arquivo que o Azure SWA lê como "não existe". Sem cobertura total
- *   não há como o servidor separar paróquia real de URL inventada — as duas caíam no
- *   `navigationFallback` e voltavam 200 com o HTML da HOME.
- *   Custo do dist coberto elevando o guard para 220 MB (ver verificar-dist-size.mjs).
+ *   Prerenderiza um SUBCONJUNTO das paróquias, sob teto (ver paroquiasDoDisco).
+ *
+ *   Em 2026-08-13 o filtro foi removido para prerenderizar todas as 4.727: no SWA
+ *   "sem arquivo = 404", então cobertura total era o que permitia 404 real em
+ *   `/paroquia/*`. Só que 4.717 paróquias = 6.050 arquivos, e o deploy em master
+ *   morreu no timeout de 300 s da distribuição de conteúdo do SWA (2026-08-14).
+ *
+ *   Decisão de 2026-08-23: cabe no teto da plataforma e abre mão do 404 de paróquia.
+ *   `/paroquia/*` volta ao `navigationFallback` (shell CSR em 200, SEM canonical), e
+ *   `/missas/*` continua fora dele — lá o universo é pequeno e 100% prerenderizado,
+ *   então o 404 real se sustenta. O ganho maior de SEO não depende disso: é o
+ *   fallback ter deixado de ser a HOME prerenderizada com `canonical=/home`.
  */
 
 /**
- * Lê o bulk baixado pelo prebuild (.prerender-cache/paroquias.json) e retorna a rota
- * de TODAS as paróquias. Retorna null se o arquivo não existe (ex.: build:dev sem
- * prebuild) → o caller cai no fallback (todas via routes).
+ * Teto de páginas de paróquia prerenderizadas.
  *
- * Antes chamava-se `paroquiasComMissaDoDisco` e filtrava por `missas.length > 0` e
- * `statusConfianca ∈ {Média, Alta}`, deixando ~1.754 paróquias sem arquivo no dist.
- * O filtro saiu porque o Azure SWA decide 200 vs 404 **só por existência de arquivo** —
- * ele não consulta a API. Enquanto uma paróquia real não tivesse arquivo, era
- * impossível distinguir "existe mas não prerenderizamos" de "não existe", e o
- * `navigationFallback` respondia 200 com o HTML da HOME para as duas.
+ * NÃO é uma escolha editorial — é orçamento de arquivos. O Azure SWA faz polling por
+ * 300 s na distribuição de conteúdo e desiste; o gatilho é a CONTAGEM DE ARQUIVOS, não
+ * o tamanho. Evidência de produção:
  *
- * Com todas no disco, a regra passa a ser exata:
- *   arquivo existe   → 200 (indexável; sem horário sai noindex pelo details.component)
- *   arquivo não existe → 404 de verdade
+ *   3.311 arquivos → deploy OK   (12/08)
+ *   6.050 arquivos → "Failure during content distribution" aos 298,8 s   (14/08)
  *
- * As sem horário continuam existindo de propósito: a página de cidade lista TODAS as
- * paróquias, então 404 nelas quebraria a navegação de quem clica na lista.
+ * A cota oficial do SWA (15.000 arquivos / 250 MB) não descreve esse limite — o build
+ * de 6.050 estava dentro dela e ainda assim não publicou.
+ *
+ * Orçamento: 118 não-HTML + 13 estáticas + 1 (404.html) + 26 estados + 987 cidades
+ * + 189 intenção = 1.334 fixos. Com 1.900 paróquias → 3.234 arquivos, DENTRO da faixa
+ * já provada. 2.000 daria 3.334, que cabe no guard mas sai do território conhecido —
+ * subir só depois de um deploy verde, de forma controlada.
+ */
+const MAX_PAROQUIAS_PRERENDER = 1900;
+
+/** Ranking de qualidade: confiança desc → nº de missas desc → alteração asc (estável). */
+function porQualidade(a: ParoquiaCache, b: ParoquiaCache): number {
+  return (
+    (b.igreja?.statusConfianca ?? 0) - (a.igreja?.statusConfianca ?? 0) ||
+    (b.igreja?.missas?.length ?? 0) - (a.igreja?.missas?.length ?? 0) ||
+    String(a.igreja?.alteracao ?? '').localeCompare(String(b.igreja?.alteracao ?? ''))
+  );
+}
+
+interface ParoquiaCache {
+  uf: string;
+  cidadeSlug: string;
+  slug: string;
+  igreja?: { missas?: unknown[]; statusConfianca?: number; alteracao?: string };
+}
+
+/**
+ * Escolhe QUAIS paróquias entram no prerender, dentro do teto acima.
+ *
+ * Duas fases, e a ordem importa:
+ *
+ *  1. PISO DE DESCOBERTA — a melhor paróquia de CADA cidade. Cobre 100% das 802
+ *     cidades, garantindo que toda página de cidade tenha profundidade real em HTML
+ *     abaixo dela. É por essa hierarquia (estado → cidade → paróquia) que o Google
+ *     desce, então uma cidade sem nenhuma paróquia assada é um galho morto.
+ *  2. RESTO POR QUALIDADE — preenche o que sobra pelo ranking acima.
+ *
+ * Por que não ordenar só por qualidade: medido contra os dados reais de produção, o
+ * ranking global puro dava fome geográfica. O RS ficava com 17 de 177 paróquias (9,6%)
+ * e AL com 1 de 8, só porque a base desses estados tem confiança mais baixa — enquanto
+ * SP levava 36% de todo o orçamento. Com o piso por cidade o RS sobe para 24%, a
+ * cobertura de cidades vai de 71% para 100%, e ainda assim 96,8% das selecionadas têm
+ * confiança Média/Alta. Round-robin por UF foi descartado por trocar isso por SP em
+ * 9,6%, que é pior negócio.
+ *
+ * Determinístico: as chaves de cidade são ordenadas antes do corte, então dois builds
+ * do mesmo cache selecionam exatamente o mesmo conjunto.
+ *
+ * Retorna null se o cache não existe (ex.: build:dev sem prebuild) → o caller cai no
+ * fallback. Em staging/prod o cache é obrigatório (ver baixar-bulk-prerender.mjs).
  */
 function paroquiasDoDisco(): Array<{ uf: string; cidade: string; slug: string }> | null {
   const arquivo = join(process.cwd(), '.prerender-cache', 'paroquias.json');
   if (!existsSync(arquivo)) return null;
-  const lista = JSON.parse(readFileSync(arquivo, 'utf-8')) as Array<{
-    uf: string; cidadeSlug: string; slug: string;
-  }>;
-  return lista
-    .filter((p) => p?.uf && p?.cidadeSlug && p?.slug)
+  const lista = JSON.parse(readFileSync(arquivo, 'utf-8')) as ParoquiaCache[];
+
+  // Paróquia sem NENHUM horário não entra: a página não tem o conteúdo que promete.
+  // Ela segue em CSR e o details.component aplica `noindex` após a hidratação.
+  const elegiveis = lista.filter(
+    (p) => p?.uf && p?.cidadeSlug && p?.slug && (p.igreja?.missas?.length ?? 0) > 0,
+  );
+
+  // Fase 1 — melhor de cada cidade.
+  const melhorPorCidade = new Map<string, ParoquiaCache>();
+  for (const p of elegiveis) {
+    const chave = `${p.uf}/${p.cidadeSlug}`;
+    const atual = melhorPorCidade.get(chave);
+    if (!atual || porQualidade(p, atual) < 0) melhorPorCidade.set(chave, p);
+  }
+  const piso = [...melhorPorCidade.keys()].sort().map((k) => melhorPorCidade.get(k)!);
+
+  // Fase 2 — resto por qualidade.
+  const jaEscolhidas = new Set(piso);
+  const resto = elegiveis.filter((p) => !jaEscolhidas.has(p)).sort(porQualidade);
+
+  return [...piso, ...resto]
+    .slice(0, MAX_PAROQUIAS_PRERENDER)
     .map((p) => ({ uf: p.uf, cidade: p.cidadeSlug, slug: p.slug }));
 }
 

--- a/src/staticwebapp.config.json
+++ b/src/staticwebapp.config.json
@@ -2,7 +2,6 @@
   "navigationFallback": {
     "rewrite": "/index.csr.html",
     "exclude": [
-      "/paroquia/*",
       "/missas/*",
       "/assets/*",
       "/*.css",


### PR DESCRIPTION
Promoção de `dev` → `master` após o PR #174.

## O que vai a produção

O deploy de master de 14/08 falhou com `Failure during content distribution` aos 298,8 s — 6.050 arquivos contra o limite operacional de distribuição do SWA (~3.000), apesar de estar dentro da cota oficial. Produção segue no build de **12/08**, sem as cidades e sem o 404.

Este PR leva:

- **Teto de 1.900 paróquias** com critério de piso por cidade (802/802 cidades cobertas, 96,8% confiança Média/Alta) → **3.271 arquivos**, dentro dos 3.311 já provados.
- **`skip_app_build: true`** — o Azure passa a publicar o artefato que os guards validaram, em vez de reconstruir com o Oryx. Era a causa de as 987 cidades nunca terem chegado ao ar com a esteira verde.
- **`MAX_FILES` 15.000 → 3.400**, refletindo o limite real e não a cota documentada.
- `/paroquia/*` volta ao `navigationFallback` (shell CSR sem canonical); `/missas/*` mantém 404 real.

## Validado

- `build:prod` local: 3.153 rotas · 3.271 arquivos · 122,2 MB · guards verdes · `ng test` 27/27
- Preview do PR #174: 13/13 checagens de SEO/404 passaram
- Deploy da `dev` pós-merge: `Status: Succeeded` em 47,4 s, com `Skipping step to build ... with Oryx` confirmado

## O que este deploy testa

**A hipótese central.** 6.050 arquivos → 298,8 s → FAILED. Agora 3.271 → precisa dar SUCCESS. Nenhum ambiente anterior valida isso: o preview e a dev constroem com a API de dev e geram ~1.700 arquivos.

Se o prebuild abortar por `503` da API de prod (cold start), **não é regressão** — é o guard impedindo a publicação de um artefato incompleto. Basta reexecutar com a API quente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)