### PR TITLE
fix(home): usa o cidadeSlug do backend e corrige a resolução de UF na geolocalização

### DIFF
--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, DestroyRef, inject, NgZone, PLATFORM_ID } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { finalize } from "rxjs/operators";
+import { firstValueFrom } from "rxjs";
 import { CommonModule, DatePipe, isPlatformBrowser } from "@angular/common";
 import {
   FormGroup,
@@ -39,6 +40,7 @@ import { HomeExplorarComponent } from "./sections/home-explorar/home-explorar.co
 import { DIAS_INTENCAO } from "../../../core/constants/dias-intencao";
 import { HomeMissasMapaComponent } from "./sections/home-missas-mapa/home-missas-mapa.component";
 import { linkParoquia } from "../../../shared/utils/church-link.utils";
+import { SeoPaginasService } from "../../../core/services/seo-paginas.service";
 import { SeoService } from "../../../core/services/seo.service";
 import { MetricasService } from "../../../core/services/metricas.service";
 
@@ -82,6 +84,7 @@ export class HomeComponent {
   private _redesSociais = inject(RedesSociaisService);
   private _geo = inject(GeolocationService);
   private _seo = inject(SeoService);
+  private _seoPaginas = inject(SeoPaginasService);
   private _metricas = inject(MetricasService);
   tiposRedeSocial: TipoRedeSocial[] = [];
 
@@ -791,33 +794,88 @@ export class HomeComponent {
     }));
   }
 
+  /**
+   * Cidades por UF com o `cidadeSlug` REAL do backend (`GET /v2/seo/estados`, a mesma
+   * fonte de `/cidades`, `/estados` e do autocomplete de `missa-agora`).
+   *
+   * Só é buscada no caminho da geolocalização — nunca no load da home — e fica em cache
+   * porque `_reverseGeocode()` roda de novo no CTA "Encontrar missas perto de mim".
+   * Falha de rede vira mapa vazio: sem slug a gente não navega (ver `_reverseGeocode`).
+   */
+  private _cidadesPorUf?: Promise<Map<string, { nome: string; slug: string }[]>>;
+
+  private _carregarCidadesPorUf(): Promise<Map<string, { nome: string; slug: string }[]>> {
+    this._cidadesPorUf ??= firstValueFrom(this._seoPaginas.getEstados())
+      .then((res: unknown) => {
+        const lista: any[] = Array.isArray(res) ? res : ((res as any)?.data ?? []);
+        const mapa = new Map<string, { nome: string; slug: string }[]>();
+        lista.filter((e) => e?.uf).forEach((e) => {
+          mapa.set(
+            String(e.uf).toUpperCase(),
+            (e.cidades ?? []).map((c: any) => ({ nome: c.cidade, slug: c.cidadeSlug })),
+          );
+        });
+        return mapa;
+      })
+      .catch(() => new Map<string, { nome: string; slug: string }[]>());
+    return this._cidadesPorUf;
+  }
+
+  /**
+   * UF a partir da resposta do Nominatim.
+   *
+   * Prefere o código ISO 3166-2 (`BR-PR`), que é inequívoco. O fallback por nome faz
+   * match EXATO antes de tentar substring: "Paraná" normalizado ("parana") CONTÉM
+   * "Pará" ("para"), e como Pará vem antes na lista, a busca por substring devolvia PA
+   * para quem estava no Paraná — a home simplesmente nunca detectava a cidade lá.
+   */
+  private _resolverUf(addr: any): string | null {
+    const iso = String(addr?.['ISO3166-2-lvl4'] ?? '');
+    const daIso = iso.startsWith('BR-') ? iso.slice(3).toUpperCase() : '';
+    if (STATES.some(s => s.sigla === daIso)) return daIso;
+
+    const nomeEstado = this._norm(addr?.state ?? '');
+    if (!nomeEstado) return null;
+    const exato = STATES.find(s => this._norm(s.nome) === nomeEstado);
+    if (exato) return exato.sigla;
+    const parcial = STATES.find(s =>
+      nomeEstado.includes(this._norm(s.nome)) || this._norm(s.nome).includes(nomeEstado)
+    );
+    return parcial?.sigla ?? null;
+  }
+
+  /**
+   * Resolve a cidade do usuário a partir das coordenadas.
+   *
+   * O slug vem do BACKEND, nunca de um `slugify()` no cliente. O slug real não é
+   * derivável do nome: além do apóstrofo ("São João do Pau d'Alho" → `sao-joao-do-pau-d-alho`,
+   * não `...-dalho`), há cidades cujo slug é de um distrito ou bairro ("Guaranésia" →
+   * `santa-cruz-da-prata-distrito-de-guaranesia`). Como `/missas/*` está fora do
+   * `navigationFallback` do `staticwebapp.config.json`, errar o slug é 404 de verdade,
+   * não shell CSR — por isso, sem slug conhecido, preferimos não navegar.
+   */
   private _reverseGeocode(lat: number, lng: number): void {
-    this._geo.reverseGeocode(lat, lng)
-      .then((addr) => {
+    Promise.all([this._geo.reverseGeocode(lat, lng), this._carregarCidadesPorUf()])
+      .then(([addr, cidadesPorUf]) => {
         if (!addr) { this.geoStatus = 'error'; return; }
         const nomeCidade = addr.city || addr.town || addr.village || addr.municipality || '';
-        const nomeEstado = addr.state || '';
-        const estado = STATES.find(s =>
-          this._norm(nomeEstado).includes(this._norm(s.nome)) ||
-          this._norm(s.nome).includes(this._norm(nomeEstado))
-        );
-        if (!estado || !nomeCidade) { this.geoStatus = 'error'; return; }
-
-        const uf = estado.sigla;
-        const cidadesDoEstado = this.fullAddressData[uf] ? Object.keys(this.fullAddressData[uf]) : [];
-        const match = cidadesDoEstado.find(c => this._norm(c) === this._norm(nomeCidade));
+        const uf = this._resolverUf(addr);
+        if (!uf || !nomeCidade) { this.geoStatus = 'error'; return; }
+        // Só cidades que têm página gerada — o índice de `/v2/seo/estados` é o mesmo
+        // conjunto que o prerender publica, então nenhum link daqui aponta para o vazio.
+        const cidadesDoEstado = cidadesPorUf.get(uf) ?? [];
+        const match = cidadesDoEstado.find(c => this._norm(c.nome) === this._norm(nomeCidade));
 
         if (!match) { this.geoStatus = 'error'; return; }
 
-        const slug = this._slugify(match);
-        this.cidadeDetectada = { nome: match, uf, slug };
+        this.cidadeDetectada = { nome: match.nome, uf, slug: match.slug };
 
         const outras = cidadesDoEstado
-          .filter(c => this._norm(c) !== this._norm(match))
+          .filter(c => this._norm(c.nome) !== this._norm(match.nome))
           .slice(0, 7)
-          .map(c => ({ nome: c, uf, slug: this._slugify(c) }));
+          .map(c => ({ nome: c.nome, uf, slug: c.slug }));
 
-        this.cidadesGrid = [{ nome: match, uf, slug }, ...outras];
+        this.cidadesGrid = [{ nome: match.nome, uf, slug: match.slug }, ...outras];
         this.geoStatus = 'found';
       })
       .catch(() => { this.geoStatus = 'error'; });
@@ -849,10 +907,6 @@ export class HomeComponent {
 
   private _norm(s: string): string {
     return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().trim();
-  }
-
-  private _slugify(s: string): string {
-    return this._norm(s).replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
   }
 
   private _restoreFromQueryParams(): void {


### PR DESCRIPTION
## 1. Correção da origem dos slugs na home

`_reverseGeocode()` montava o slug da cidade detectada no cliente, via `_slugify()`, a partir dos nomes de `addressRange()` (`v1/Igreja/v2/obter-enderecos`) — endpoint que não devolve slug. Como `/missas/*` está fora do `navigationFallback` do `staticwebapp.config.json`, slug errado é **404 de verdade**, não shell CSR. E `cidadeDetectada.slug` é justamente o destino do CTA "Encontrar missas perto de mim".

Comparei o `_slugify()` com o slug real das **1026 cidades de produção**: 6 divergem, e o apóstrofo é só um dos modos de falha.

| cidade | slug do cliente | slug real |
|---|---|---|
| São João do Pau d'Alho | `sao-joao-do-pau-dalho` | `sao-joao-do-pau-d-alho` |
| Guaranésia | `guaranesia` | `santa-cruz-da-prata-distrito-de-guaranesia` |
| Americana | `americana` | `jardim-america-ii-americana` |
| Americana | `americana` | `iate-clube-campinas-americana` |
| São João Batista do Glória | `sao-joao-batista-do-gloria` | `ao-joao-batista-do-gloria` |
| ` Macau` | `-macau` | `macau` |

Os quatro últimos **não são deriváveis do nome por regex nenhuma** — o slug é de um distrito ou bairro. Por isso a correção troca a FONTE, não a regex: passa a consumir `GET /v2/seo/estados` (`SeoPaginasService`), o mesmo índice que já alimenta `/cidades`, `/estados` e o autocomplete de `missa-agora` (#edc94e1), e o mesmo conjunto que o prerender publica — então o grid só linka cidade que tem página.

`_slugify()` deixa de existir no repositório.

Sobre custo: a busca é **lazy**, só no caminho da geolocalização, nunca no load da home, e fica em cache porque `_reverseGeocode()` roda de novo no CTA. Confirmado que não entra no SSR (ver validações). Não usei `cidadesProximas` como fonte porque ela filtra por `Horas=2` — voltaria vazia de madrugada e quebraria o caso comum.

## 2. Correção da resolução de UF (Pará × Paraná)

Bug **pré-existente**, encontrado porque bloqueava a validação do item 1: `STATES.find` casava por substring, e `_norm("Paraná")` = `"parana"` **contém** `_norm("Pará")` = `"para"`. Como Pará vem antes na lista, quem estava no Paraná resolvia para **PA** — a home nunca detectava a cidade no estado inteiro.

O mesmo valia para outros pares com prefixo comum, como Mato Grosso × Mato Grosso do Sul.

`_resolverUf()` passa a usar o código ISO 3166-2 do Nominatim (`BR-PR`), que é inequívoco, e só cai para nome com **match exato antes** de substring.

## 3. Validações realizadas

- `tsc -p tsconfig.app.json --noEmit` — limpo.
- `ng test --watch=false --browsers=ChromeHeadless` — **27/27 SUCCESS**.
- `npm run build:dev` — sucesso, 1578 páginas geradas (só warnings de Sass pré-existentes).
- **SSR:** `home/index.html` prerenderiza normalmente (159 KB) e `grep cidadeSlug` retorna **0** — o payload de `/v2/seo/estados` não vaza para o HTML prerenderizado, confirmando que a busca é mesmo lazy.
- **`_resolverUf()`, 11 casos, todos OK:** ISO Paraná→PR, ISO Pará→PA, e sem ISO: Paraná→PR, Pará→PA, Rio Grande do Sul→RS, Rio Grande do Norte→RN, Mato Grosso→MT, Mato Grosso do Sul→MS, Amazonas→AM, São Paulo→SP, vazio→null.
- **Fluxo de geolocalização, app rodando:** coordenadas de Itapejara d'Oeste/PR → `{uf: PR, slug: itapejara-d-oeste}`, status `found`; CTA leva a `/missas/pr/itapejara-d-oeste`, que carrega com 1 igreja. Caso comum (Campinas/SP) → `{uf: SP, slug: campinas}`, sem regressão.
- **Autocomplete de `missa-agora`** reconferido na mesma rodada: continua levando a `/missas/pr/itapejara-d-oeste`.
- Sem erros no console em nenhum dos fluxos.
- 404 confirmado ao vivo em produção: `/missas/sp/sao-joao-do-pau-dalho` → **404**, `/missas/sp/sao-joao-do-pau-d-alho` → **200**.

## Fora do escopo deste PR

A comparação expôs problemas de **qualidade da base**, que por decisão **não são corrigidos aqui**:

- `São João Batista do Glória` tem slug `ao-joao-batista-do-gloria` — falta o "S". É a página que está no ar e indexada.
- ` Macau` (RN) tem espaço à esquerda no nome.
- Duas `Americana` (SP) com slugs de bairro (`jardim-america-ii-americana`, `iate-clube-campinas-americana`).

Merecem um passe próprio de data quality no backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
