### PR TITLE
Busca por nome de igreja na Home + correções do fluxo principal do hero

### DIFF
--- a/scripts/gerar-indice-busca.mjs
+++ b/scripts/gerar-indice-busca.mjs
@@ -14,7 +14,18 @@
  * cada paróquia, o mesmo conteúdo passaria de 380 KB para ~480 KB.
  *
  *   { "c": [[cidade, uf, cidadeSlug], ...],
- *     "i": [[nome, indiceDaCidade, slug], ...] }
+ *     "b": [bairro, ...],
+ *     "i": [[nome, indiceDaCidade, slug, indiceDoBairro], ...] }
+ *
+ * O bairro entra pelo mesmo motivo da cidade: sem ele, "Paróquia São José" na
+ * mesma cidade aparece duas vezes idêntica na lista e não há como escolher. E
+ * entra como TABELA deduplicada, não como string repetida em cada paróquia —
+ * bairro repete muito mais que cidade (uma cidade tem dezenas de paróquias no
+ * mesmo bairro), então inline custaria ~70 KB em prod contra ~15 KB assim.
+ *
+ * `indiceDoBairro` é -1 quando a paróquia não tem bairro cadastrado. Bairro é
+ * OPCIONAL: faltar não pode tirar a paróquia do índice, só deixa a linha sem o
+ * complemento.
  *
  * Best-effort de propósito: sem o cache, avisa e sai 0. A busca de CIDADES não
  * depende deste arquivo (vem do payload que a página já carrega), então a
@@ -43,6 +54,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const ENTRADA = join(ROOT, '.prerender-cache', 'paroquias.json');
 const SAIDA = join(ROOT, 'public', 'busca-index.json');
+
+/**
+ * Chave de deduplicação de bairro. Espelha `normalizarTexto` de
+ * `src/app/shared/utils/busca.utils.ts` — não dá para importar o .ts aqui, mas as
+ * duas precisam concordar, senão "Vila Nova" e "vila nova" viram dois bairros.
+ * Serve só como CHAVE; o texto exibido é sempre a primeira grafia original.
+ */
+function normalizar(valor) {
+  return String(valor ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')  // faixa escapada de propósito (combining marks)
+    .toLowerCase()
+    .replace(/['’`\-.]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 /** `--api=<base>` → base da API de onde buscar o bulk. Ausente = ler o cache. */
 function lerApiDoArgumento() {
@@ -93,8 +120,13 @@ function gerar(paroquias, origem) {
   // distintas num registro só e mandaria a pessoa para o estado errado.
   const cidades = [];
   const indicePorChave = new Map();
+  // Bairro é deduplicado por texto normalizado (case/acento), mas o que vai para o
+  // arquivo é a PRIMEIRA grafia vista — "Bela Vista" e não "bela vista".
+  const bairros = [];
+  const indiceBairroPorChave = new Map();
   const igrejas = [];
   let semSlug = 0;
+  let semBairro = 0;
 
   for (const p of paroquias) {
     const slug = p?.slug;
@@ -117,19 +149,37 @@ function gerar(paroquias, origem) {
       cidades.push([p.igreja?.endereco?.localidade ?? cidadeSlug, uf, cidadeSlug]);
     }
 
-    igrejas.push([nome, iCidade, slug]);
+    const bairro = String(p?.igreja?.endereco?.bairro ?? '').trim();
+    let iBairro = -1;
+    if (bairro) {
+      const chaveBairro = normalizar(bairro);
+      iBairro = indiceBairroPorChave.get(chaveBairro) ?? -1;
+      if (iBairro === -1) {
+        iBairro = bairros.length;
+        indiceBairroPorChave.set(chaveBairro, iBairro);
+        bairros.push(bairro);
+      }
+    } else {
+      semBairro++;
+    }
+
+    igrejas.push([nome, iCidade, slug, iBairro]);
   }
 
   mkdirSync(dirname(SAIDA), { recursive: true });
-  const json = JSON.stringify({ c: cidades, i: igrejas });
+  const json = JSON.stringify({ c: cidades, b: bairros, i: igrejas });
   writeFileSync(SAIDA, json);
 
   const kb = (json.length / 1024).toFixed(0);
   const descartadas = semSlug ? ` (${semSlug} sem slug/cidade, fora do índice)` : '';
   console.log(
-    `[indice-busca] ${igrejas.length} igrejas em ${cidades.length} cidades → ` +
+    `[indice-busca] ${igrejas.length} igrejas em ${cidades.length} cidades, ` +
+    `${bairros.length} bairros → ` +
     `public/busca-index.json (${kb} KB)${descartadas}.`,
   );
+  if (semBairro) {
+    console.log(`[indice-busca] ${semBairro} igrejas sem bairro cadastrado (entram sem o complemento).`);
+  }
   console.log(`[indice-busca] origem: ${origem}`);
 }
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -58,6 +58,18 @@ export const routes: Routes = [
           resultsMode: true,
           title: 'Resultados da busca | BuscaMissa',
           description: 'Resultados da busca de missas e igrejas católicas por estado, cidade e bairro.',
+          // Resultado de busca não é página de conteúdo, e o filtro por NOME tornou
+          // o espaço de URLs praticamente infinito: `?uf=SP&nome=a`, `&nome=ab`,
+          // `&nome=abc`... cada variação é uma URL distinta com conteúdo quase igual.
+          // Numa base que já sofre com duplicate/canonical no Search Console, isso
+          // é combustível. O material indexável são os hubs pré-renderizados
+          // (/cidades, /estados, /missas/:uf, /paroquia/...), que seguem intactos.
+          //
+          // Nada depende de /buscar estar indexada: não está no sitemap, nenhum
+          // link interno aponta para ela (só `router.navigate` após o submit), e o
+          // SearchAction do JSON-LD precisa que a URL FUNCIONE, não que seja
+          // indexada.
+          noindex: true,
         },
         loadComponent: () =>
           import("./modules/public/home/home.component").then(

--- a/src/app/core/layout/home/header/header.component.html
+++ b/src/app/core/layout/home/header/header.component.html
@@ -36,9 +36,11 @@
             <i class="pi pi-calendar" aria-hidden="true"></i>
             <span><strong>Por dia da semana</strong><small>Encontre missas por dia</small></span>
           </a>
-          <!-- "Por igreja" fica de fora até existir busca por nome na UI: o endpoint
-               buscar-por-filtro aceita `Nome`, mas /buscar não tem campo de nome nem
-               lê query param de texto — o item levaria a uma busca por UF/cidade. -->
+          <!-- "Por igreja" continua fora do menu, mas a razão mudou: a busca por nome
+               agora existe (campo "Nome da igreja" no hero da home e em /cidades, com
+               query param `nome`). O que falta é um DESTINO próprio — um item aqui
+               levaria a /buscar sem nome digitado, que é a busca por UF/cidade de
+               sempre. Reavaliar se/quando existir uma página de busca por nome. -->
         </div>
       </div>
 

--- a/src/app/core/services/busca-local.service.spec.ts
+++ b/src/app/core/services/busca-local.service.spec.ts
@@ -1,0 +1,226 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { BuscaLocalService } from './busca-local.service';
+
+/**
+ * O foco aqui é o que NÃO dá para ver na tela sem um índice montado à mão:
+ * a tolerância a índice antigo (sem a tabela `b`), o recorte por escopo, a
+ * ordenação que impede a lista de 6 ser preenchida por casamentos de bairro
+ * enquanto a igreja procurada fica de fora — e, sobretudo, a garantia de que
+ * `buscar()` (o caminho de `/cidades`) NÃO herdou nada disso.
+ */
+describe('BuscaLocalService', () => {
+  let service: BuscaLocalService;
+  let http: HttpTestingController;
+
+  /** Índice mínimo no formato compacto de `scripts/gerar-indice-busca.mjs`. */
+  const INDICE = {
+    c: [
+      ['São Paulo', 'sp', 'sao-paulo'],
+      ['Cachoeira', 'ba', 'cachoeira'],
+      ['Curitiba', 'pr', 'curitiba'],
+    ],
+    b: ['Bela Vista', 'Centro', 'São Francisco'],
+    i: [
+      ['Paróquia Nossa Senhora Achiropita', 0, 'paroquia-achiropita', 0],
+      ['Igreja Matriz', 1, 'igreja-matriz', 1],
+      ['Paróquia Santo Antônio', 2, 'paroquia-santo-antonio', 2],
+      ['Paróquia São José', 0, 'paroquia-sao-jose', 1],
+      ['Paróquia São José', 2, 'paroquia-sao-jose-cwb', 1],
+    ],
+  };
+
+  function responder(corpo: object = INDICE): void {
+    const req = http.expectOne((r) => r.url.includes('busca-index.json'));
+    req.flush(corpo);
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(BuscaLocalService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('materializa nome, cidade, uf, slug e bairro', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    const { igrejas } = service.buscarIgrejas('achiropita');
+    expect(igrejas.length).toBe(1);
+    expect(igrejas[0]).toEqual({
+      nome: 'Paróquia Nossa Senhora Achiropita',
+      cidade: 'São Paulo',
+      uf: 'sp',
+      cidadeSlug: 'sao-paulo',
+      slug: 'paroquia-achiropita',
+      bairro: 'Bela Vista',
+    });
+  });
+
+  it('aceita índice antigo, sem a tabela de bairros', () => {
+    // Deploy do frontend antes de rebuildar o índice: degrada a linha, não quebra.
+    service.carregarIndice().subscribe();
+    responder({ c: INDICE.c, i: [['Paróquia Nossa Senhora Achiropita', 0, 'paroquia-achiropita']] });
+
+    const { igrejas } = service.buscarIgrejas('achiropita');
+    expect(igrejas.length).toBe(1);
+    expect(igrejas[0].bairro).toBeUndefined();
+  });
+
+  it('buscarIgrejas casa por bairro', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    const { igrejas } = service.buscarIgrejas('achiropita bela vista');
+    expect(igrejas.map((i) => i.slug)).toEqual(['paroquia-achiropita']);
+  });
+
+  it('buscarIgrejas põe quem casa no NOME antes de quem casa só pelo local', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    // "sao francisco" é bairro da Santo Antônio (Curitiba). Nenhum nome casa.
+    expect(service.buscarIgrejas('sao francisco').igrejas.map((i) => i.slug))
+      .toEqual(['paroquia-santo-antonio']);
+
+    // "centro" é bairro de três; "sao jose" casa no NOME de duas delas, que
+    // portanto precisam vir antes.
+    const mistura = service.buscarIgrejas('sao');
+    expect(mistura.igrejas[0].nome).toContain('São José');
+  });
+
+  it('buscarIgrejas recorta por UF e por cidade quando há escopo', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    expect(service.buscarIgrejas('sao jose').total).toBe(2);
+    expect(service.buscarIgrejas('sao jose', { uf: 'pr' }).total).toBe(1);
+    expect(service.buscarIgrejas('sao jose', { cidade: 'São Paulo' }).total).toBe(1);
+    expect(service.buscarIgrejas('sao jose', { uf: 'sp', cidade: 'Curitiba' }).total).toBe(0);
+  });
+
+  it('total conta antes do corte da lista', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    const r = service.buscarIgrejas('paroquia');
+    // 4 paróquias no índice, todas dentro do cap de 6 — os dois números batem aqui.
+    expect(r.total).toBe(4);
+    expect(r.igrejas.length).toBe(4);
+  });
+
+  it('ignora acento, caixa e apóstrofo na consulta', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    expect(service.buscarIgrejas('ACHIROPITA').total).toBe(1);
+    expect(service.buscarIgrejas('paroquia sao jose').total).toBe(2);
+  });
+
+  it('consulta vazia não devolve nada', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    expect(service.buscarIgrejas('   ')).toEqual({ igrejas: [], total: 0 });
+    expect(service.buscar('   ', [])).toEqual({ cidades: [], igrejas: [] });
+  });
+
+  // ── A garantia de isolamento: `/cidades` não pode ter mudado ────────────────
+
+  it('buscar() NÃO casa por bairro — é o caminho de /cidades', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    // Na home isto acha a Achiropita (bairro Bela Vista). Em /cidades, não pode.
+    expect(service.buscarIgrejas('achiropita bela vista').total).toBe(1);
+    expect(service.buscar('achiropita bela vista', []).igrejas).toEqual([]);
+
+    // E "bela vista" sozinho não pode virar resultado em /cidades.
+    expect(service.buscar('bela vista', []).igrejas).toEqual([]);
+  });
+
+  it('buscar() NÃO reordena por relevância — mantém a ordem do índice', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    // "sao" casa três: a Achiropita pela CIDADE ("São Paulo") e as duas São José
+    // pelo NOME. É o contraste exato entre os dois caminhos — mesmo conjunto,
+    // ordens diferentes.
+    expect(service.buscar('sao', []).igrejas.map((i) => i.slug))
+      .toEqual(['paroquia-achiropita', 'paroquia-sao-jose', 'paroquia-sao-jose-cwb']);
+
+    // A home acha uma a MAIS (a Santo Antônio entra pelo bairro "São Francisco")
+    // e põe quem casa no nome na frente. /cidades não pode fazer nem uma coisa
+    // nem outra.
+    expect(service.buscarIgrejas('sao').igrejas.map((i) => i.slug)).toEqual([
+      'paroquia-sao-jose',      // peso 2: casou no nome
+      'paroquia-sao-jose-cwb',  // peso 2: casou no nome
+      'paroquia-achiropita',    // peso 3: casou só pela cidade
+      'paroquia-santo-antonio', // peso 3: casou só pelo bairro
+    ]);
+  });
+
+  it('buscar() devolve a forma antiga, sem campo de total', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    const r = service.buscar('paroquia', []);
+    expect(Object.keys(r).sort()).toEqual(['cidades', 'igrejas']);
+  });
+
+  it('buscar() continua devolvendo cidades', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    const cidades = [
+      { nome: 'São Paulo', uf: 'sp', cidadeSlug: 'sao-paulo', totalParoquias: 40 },
+      { nome: 'São José dos Campos', uf: 'sp', cidadeSlug: 'sjc', totalParoquias: 90 },
+    ];
+    // Mais paróquias primeiro — a ordenação que /cidades sempre teve.
+    expect(service.buscar('sao', cidades).cidades.map((c) => c.cidadeSlug))
+      .toEqual(['sjc', 'sao-paulo']);
+  });
+
+  it('correspondenciasExatas devolve TODAS as homônimas, não a primeira', () => {
+    service.carregarIndice().subscribe();
+    responder();
+
+    // Duas "Paróquia São José" em cidades diferentes: continua ambíguo, e quem
+    // chama precisa saber disso para não navegar por conta do usuário.
+    expect(service.correspondenciasExatas('Paróquia São José').length).toBe(2);
+    expect(service.correspondenciasExatas('Paróquia São José', { uf: 'pr' }).length).toBe(1);
+    expect(service.correspondenciasExatas('paróquia são').length).toBe(0);
+  });
+
+  it('índice indisponível vira índice vazio, não erro', () => {
+    let emitiu: boolean | undefined;
+    let errou = false;
+    service.carregarIndice().subscribe({ next: (v) => (emitiu = v), error: () => (errou = true) });
+
+    const req = http.expectOne((r) => r.url.includes('busca-index.json'));
+    req.flush('nao sou json', { status: 500, statusText: 'Server Error' });
+
+    expect(errou).toBeFalse();
+    expect(emitiu).toBeFalse();
+    expect(service.buscarIgrejas('achiropita')).toEqual({ igrejas: [], total: 0 });
+  });
+
+  it('baixa o índice uma vez só, por mais que peçam', () => {
+    // `shareReplay({ refCount: false })`: fechar o painel não pode descartar o
+    // cache e fazer a próxima digitação rebaixar o arquivo inteiro.
+    service.carregarIndice().subscribe();
+    service.carregarIndice().subscribe();
+    responder(); // `expectOne` aqui já falharia se tivessem saído dois requests.
+
+    let emitiuDepois: boolean | undefined;
+    service.carregarIndice().subscribe((v) => (emitiuDepois = v));
+
+    expect(http.match((r) => r.url.includes('busca-index.json')).length).toBe(0);
+    expect(emitiuDepois).toBeTrue();
+  });
+});

--- a/src/app/core/services/busca-local.service.ts
+++ b/src/app/core/services/busca-local.service.ts
@@ -25,9 +25,35 @@ export interface IgrejaBusca {
   bairro?: string;
 }
 
+/** Recorte opcional das sugestões pelo contexto já escolhido pelo usuário. */
+export interface EscopoBusca {
+  /** Sigla da UF, em qualquer caixa. */
+  uf?: string | null;
+  /** Nome da cidade (não o slug) — é o que o formulário da home tem em mãos. */
+  cidade?: string | null;
+}
+
 export interface ResultadoBusca {
   cidades: CidadeBusca[];
   igrejas: IgrejaBusca[];
+}
+
+/**
+ * Resultado da busca POR NOME da home. Tipo separado de `ResultadoBusca` de
+ * propósito: `/cidades` não deve mudar de forma nem de comportamento por causa
+ * de uma funcionalidade que é da home.
+ */
+export interface ResultadoIgrejas {
+  igrejas: IgrejaBusca[];
+  /**
+   * Quantas casaram ANTES do corte em `CAP_IGREJAS`.
+   *
+   * `igrejas.length` não responde "quantas existem": com o corte em 6, "sao
+   * francisco" devolve 6 de 183 e quem só olha o array conclui que há 6. Duas
+   * decisões dependem deste número — avisar que a lista está cortada, e saber se
+   * o resultado é REALMENTE único antes de navegar por conta do usuário.
+   */
+  total: number;
 }
 
 /** Formato compacto de `public/busca-index.json` (ver scripts/gerar-indice-busca.mjs). */
@@ -48,11 +74,10 @@ interface IgrejaIndexada extends IgrejaBusca {
    * escopo desta mudança. Incluir bairro aqui alteraria o que aquela página casa.
    */
   chave: string;
-  /**
-   * Bairro normalizado, guardado à parte justamente para NÃO entrar em `chave`.
-   * Quem quiser casar por bairro testa este campo separadamente.
-   */
+  /** Bairro normalizado, testado à parte pela busca da home (ver `buscarIgrejas`). */
   chaveBairro: string;
+  /** Só o nome — base da ordenação por relevância da home (ver `_pontuar`). */
+  chaveNome: string;
 }
 
 const CAP_CIDADES = 5;
@@ -106,8 +131,10 @@ export class BuscaLocalService {
   /**
    * Busca síncrona de CIDADE + IGREJA — o caminho de `/cidades`.
    *
-   * Casa por nome + cidade + UF. **Sem bairro**, mesmo agora que o índice o traz:
-   * incluí-lo aqui mudaria o que esta página casa, e `/cidades` está em produção.
+   * Comportamento preservado byte a byte: casa por nome + cidade + UF (sem bairro),
+   * sem ordenação por relevância, corte em `CAP_IGREJAS`. A busca por nome da home
+   * é outra coisa e mora em `buscarIgrejas()`; misturar as duas mudaria uma página
+   * de produção que não é escopo desta alteração.
    */
   buscar(consulta: string, cidades: CidadeBusca[]): ResultadoBusca {
     const tokens = tokensDeBusca(consulta);
@@ -123,9 +150,96 @@ export class BuscaLocalService {
     const igrejasCasadas = this._igrejas
       .filter((i) => casaTokens(i.chave, tokens))
       .slice(0, CAP_IGREJAS)
-      .map(({ chave, chaveBairro, ...igreja }) => igreja);
+      .map(({ chave, chaveBairro, chaveNome, ...igreja }) => igreja);
 
     return { cidades: cidadesCasadas, igrejas: igrejasCasadas };
+  }
+
+  /**
+   * Busca por NOME DE IGREJA — o campo do hero da home. Só igrejas, nunca cidades.
+   *
+   * Três diferenças em relação a `buscar()`, todas exigidas por aquele campo e
+   * NENHUMA aplicada a `/cidades`:
+   *
+   *  1. **bairro entra no casamento**, para "achiropita bela vista" funcionar;
+   *  2. **escopo por UF/cidade**, para respeitar o que já foi escolhido no formulário;
+   *  3. **ordenação por relevância de nome** — sem ela, digitar "ach" devolvia seis
+   *     paróquias de *Cachoeira* (casadas pelo bairro e pela cidade) e a Achiropita,
+   *     que é o que a pessoa foi procurar, ficava fora do corte de 6.
+   */
+  buscarIgrejas(consulta: string, escopo?: EscopoBusca): ResultadoIgrejas {
+    const tokens = tokensDeBusca(consulta);
+    if (!tokens.length) return { igrejas: [], total: 0 };
+
+    const ufEscopo = escopo?.uf ? normalizarTexto(escopo.uf) : null;
+    const cidadeEscopo = escopo?.cidade ? normalizarTexto(escopo.cidade) : null;
+
+    const todasCasadas = this._igrejas.filter((i) => {
+      if (ufEscopo && normalizarTexto(i.uf) !== ufEscopo) return false;
+      if (cidadeEscopo && normalizarTexto(i.cidade) !== cidadeEscopo) return false;
+      return this._casaComBairro(i, tokens);
+    });
+
+    // `sort` é estável em JS: dentro de cada faixa a ordem do índice se mantém.
+    const alvo = normalizarTexto(consulta);
+    const ordenadas = todasCasadas
+      .map((igreja) => ({ igreja, peso: this._pontuar(igreja, alvo, tokens) }))
+      .sort((a, b) => a.peso - b.peso)
+      .map(({ igreja }) => igreja);
+
+    return {
+      igrejas: ordenadas
+        .slice(0, CAP_IGREJAS)
+        .map(({ chave, chaveBairro, chaveNome, ...igreja }) => igreja),
+      total: todasCasadas.length,
+    };
+  }
+
+  /**
+   * Cada token precisa estar na chave OU no bairro.
+   *
+   * Testar as duas partes separadamente equivale a testar a concatenação — tokens
+   * nunca contêm espaço, então nenhum deles poderia cruzar a emenda — e evita
+   * montar uma string nova por igreja a cada tecla.
+   */
+  private _casaComBairro(igreja: IgrejaIndexada, tokens: string[]): boolean {
+    return tokens.every((t) => igreja.chave.includes(t) || igreja.chaveBairro.includes(t));
+  }
+
+  /**
+   * Menor é melhor. Quatro faixas, da mais para a menos literal:
+   * 0 o nome É a consulta · 1 o nome começa com ela · 2 todos os tokens estão no
+   * nome · 3 só casou por bairro/cidade/UF.
+   */
+  private _pontuar(igreja: IgrejaIndexada, alvo: string, tokens: string[]): number {
+    if (igreja.chaveNome === alvo) return 0;
+    if (igreja.chaveNome.startsWith(alvo)) return 1;
+    if (casaTokens(igreja.chaveNome, tokens)) return 2;
+    return 3;
+  }
+
+  /**
+   * Paróquias cujo nome é EXATAMENTE a consulta (ignorando acento, caixa e
+   * pontuação), dentro do escopo. Serve à decisão de navegar sozinho: "achiropita"
+   * pode casar várias linhas por substring e ainda assim ter um único nome exato.
+   *
+   * Devolve a lista inteira, não a primeira: dois nomes idênticos em cidades
+   * diferentes continuam ambíguos e quem chama precisa saber disso.
+   */
+  correspondenciasExatas(consulta: string, escopo?: EscopoBusca): IgrejaBusca[] {
+    const alvo = normalizarTexto(consulta);
+    if (!alvo) return [];
+
+    const ufEscopo = escopo?.uf ? normalizarTexto(escopo.uf) : null;
+    const cidadeEscopo = escopo?.cidade ? normalizarTexto(escopo.cidade) : null;
+
+    return this._igrejas
+      .filter((i) => {
+        if (ufEscopo && normalizarTexto(i.uf) !== ufEscopo) return false;
+        if (cidadeEscopo && normalizarTexto(i.cidade) !== cidadeEscopo) return false;
+        return i.chaveNome === alvo;
+      })
+      .map(({ chave, chaveBairro, chaveNome, ...igreja }) => igreja);
   }
 
   /** Índice já materializado, para o caminho síncrono de `buscar()`. */
@@ -186,6 +300,7 @@ export class BuscaLocalService {
         // Bairro fica FORA daqui — ver o comentário em `IgrejaIndexada.chave`.
         chave: normalizarTexto(`${nome} ${nomeCidade} ${uf}`),
         chaveBairro: normalizarTexto(bairro ?? ''),
+        chaveNome: normalizarTexto(nome),
       });
     }
 

--- a/src/app/core/services/busca-local.service.ts
+++ b/src/app/core/services/busca-local.service.ts
@@ -21,6 +21,8 @@ export interface IgrejaBusca {
   uf: string;
   cidadeSlug: string;
   slug: string;
+  /** Ausente em paróquias sem bairro cadastrado e em índices gerados antes da tabela `b`. */
+  bairro?: string;
 }
 
 export interface ResultadoBusca {
@@ -32,13 +34,25 @@ export interface ResultadoBusca {
 interface IndiceBruto {
   /** [cidade, uf, cidadeSlug] */
   c: [string, string, string][];
-  /** [nome, índice em `c`, slug] */
-  i: [string, number, string][];
+  /** Tabela de bairros deduplicada. Ausente em índices anteriores à sua introdução. */
+  b?: string[];
+  /** [nome, índice em `c`, slug, índice em `b` (-1 = sem bairro)] */
+  i: [string, number, string, number?][];
 }
 
 /** Igreja com o texto de busca já normalizado — normalizar dentro do laço, a cada tecla, custaria caro. */
 interface IgrejaIndexada extends IgrejaBusca {
+  /**
+   * Nome + cidade + UF. **Não inclui bairro**, e isso é deliberado: é a chave que
+   * `buscar()` usa, e `buscar()` serve `/cidades`, que está em produção e não é
+   * escopo desta mudança. Incluir bairro aqui alteraria o que aquela página casa.
+   */
   chave: string;
+  /**
+   * Bairro normalizado, guardado à parte justamente para NÃO entrar em `chave`.
+   * Quem quiser casar por bairro testa este campo separadamente.
+   */
+  chaveBairro: string;
 }
 
 const CAP_CIDADES = 5;
@@ -90,8 +104,10 @@ export class BuscaLocalService {
   }
 
   /**
-   * Busca síncrona. `cidades` é sempre o que o componente já tem em mãos; as igrejas
-   * saem do índice se ele já tiver chegado, e de lista vazia caso contrário.
+   * Busca síncrona de CIDADE + IGREJA — o caminho de `/cidades`.
+   *
+   * Casa por nome + cidade + UF. **Sem bairro**, mesmo agora que o índice o traz:
+   * incluí-lo aqui mudaria o que esta página casa, e `/cidades` está em produção.
    */
   buscar(consulta: string, cidades: CidadeBusca[]): ResultadoBusca {
     const tokens = tokensDeBusca(consulta);
@@ -107,7 +123,7 @@ export class BuscaLocalService {
     const igrejasCasadas = this._igrejas
       .filter((i) => casaTokens(i.chave, tokens))
       .slice(0, CAP_IGREJAS)
-      .map(({ chave, ...igreja }) => igreja);
+      .map(({ chave, chaveBairro, ...igreja }) => igreja);
 
     return { cidades: cidadesCasadas, igrejas: igrejasCasadas };
   }
@@ -147,20 +163,29 @@ export class BuscaLocalService {
       throw new Error('formato inesperado');
     }
 
+    // `b` ausente = índice gerado antes da tabela de bairros. Tolerado de propósito:
+    // um deploy do frontend sem rebuildar o índice degrada a linha (fica sem o
+    // complemento de bairro) em vez de quebrar a busca inteira.
+    const tabelaBairros = Array.isArray(bruto.b) ? bruto.b : [];
+
     const igrejas: IgrejaIndexada[] = [];
-    for (const [nome, iCidade, slug] of bruto.i) {
+    for (const [nome, iCidade, slug, iBairro] of bruto.i) {
       const cidade = bruto.c[iCidade];
       if (!cidade || !nome || !slug) continue;
       const [nomeCidade, uf, cidadeSlug] = cidade;
+      const bairro = typeof iBairro === 'number' && iBairro >= 0 ? tabelaBairros[iBairro] : undefined;
       igrejas.push({
         nome,
         cidade: nomeCidade,
         uf,
         cidadeSlug,
         slug,
+        bairro,
         // Cidade e UF entram na chave para que "Curitiba Nossa Senhora" funcione:
         // um token casa o nome da igreja, o outro casa a cidade dela.
+        // Bairro fica FORA daqui — ver o comentário em `IgrejaIndexada.chave`.
         chave: normalizarTexto(`${nome} ${nomeCidade} ${uf}`),
+        chaveBairro: normalizarTexto(bairro ?? ''),
       });
     }
 

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -75,6 +75,66 @@
             </p-iftalabel>
           </div>
 
+          <!-- Nome da igreja: refina a busca acima (vai como `Nome` para a API) e,
+               ao mesmo tempo, é o atalho direto para a paróquia — a lista abaixo sai
+               do índice estático, único jeito de achar por nome no Brasil inteiro. -->
+          <div class="search-form__nome-wrap">
+            <p-iftalabel class="search-form__field search-form__field--nome">
+              <input pInputText type="text" id="Nome" formControlName="Nome" class="w-full"
+                     placeholder="Digite o nome da igreja ou paróquia"
+                     autocomplete="off" role="combobox" aria-controls="sugestoes-igreja"
+                     [attr.aria-expanded]="mostrarSugestoes"
+                     [attr.aria-activedescendant]="sugestaoAtiva >= 0 ? 'sugestao-igreja-' + sugestaoAtiva : null"
+                     (input)="onNomeInput()"
+                     (focus)="garantirIndiceIgrejas()"
+                     (keydown.arrowdown)="$event.preventDefault(); moverSugestao(1)"
+                     (keydown.arrowup)="$event.preventDefault(); moverSugestao(-1)"
+                     (keydown.escape)="limparSugestoes()"
+                     (keydown.enter)="$event.preventDefault(); onEnterNome()" />
+              <label for="Nome">Nome da igreja</label>
+            </p-iftalabel>
+
+            <div class="sugestoes sugestoes--inline" id="sugestoes-igreja" *ngIf="mostrarSugestoes">
+              <p class="sugestoes__grupo" id="grupo-igrejas">Qual igreja você procura?</p>
+
+              <ul role="listbox" aria-labelledby="grupo-igrejas" *ngIf="sugestoesIgrejas.length">
+                <li *ngFor="let i of sugestoesIgrejas; let idx = index">
+                  <a [routerLink]="linkIgrejaSugerida(i)" class="sugestoes__igreja"
+                     [id]="'sugestao-igreja-' + idx" role="option"
+                     [class.sugestoes__igreja--ativa]="sugestaoAtiva === idx"
+                     [attr.aria-selected]="sugestaoAtiva === idx"
+                     (click)="limparSugestoes()">
+                    <i class="pi pi-building" aria-hidden="true"></i>
+                    <span class="sugestoes__texto">
+                      <span class="sugestoes__nome">{{ i.nome }}</span>
+                      <span class="sugestoes__local">
+                        <ng-container *ngIf="i.bairro">{{ i.bairro }} · </ng-container>{{ i.cidade }} — {{ i.uf | uppercase }}
+                      </span>
+                    </span>
+                  </a>
+                </li>
+              </ul>
+
+              <p class="sugestoes__mais" *ngIf="sugestoesCortadas">
+                Mostrando {{ sugestoesIgrejas.length }} de {{ totalSugestoes }} — refine o nome ou escolha um estado.
+              </p>
+
+              <p class="sugestoes__vazio" *ngIf="carregandoSugestoes">
+                Carregando a lista de igrejas…
+              </p>
+
+              <p class="sugestoes__vazio" *ngIf="buscaSemResultado">
+                Não encontramos nenhuma igreja com esse nome.<br>
+                Tente só o nome principal, ou busque por estado e cidade.
+              </p>
+
+              <p class="sugestoes__vazio" *ngIf="indiceIndisponivel">
+                Não foi possível carregar a lista de igrejas agora.<br>
+                Busque por estado e cidade.
+              </p>
+            </div>
+          </div>
+
           <div class="search-form__advanced">
             <p-iftalabel class="search-form__field">
               <p-select [options]="weakDays" [filter]="true" filterBy="weakDays" optionLabel="nome" optionValue="id"

--- a/src/app/modules/public/home/home.component.html
+++ b/src/app/modules/public/home/home.component.html
@@ -51,9 +51,10 @@
         <form [formGroup]="form" class="search-form">
           <div class="search-form__row">
             <p-iftalabel class="search-form__field">
-              <p-select [options]="statesList" (onChange)="onStateChange($event)" [filter]="true" [filterBy]="'label'"
+              <p-select #ufSelect [options]="statesList" (onChange)="onStateChange($event)" [filter]="true" [filterBy]="'label'"
                         [showClear]="!!form.get('Uf')?.value" formControlName="Uf" placeholder="Selecione"
-                        class="w-full" appendTo="body" [loading]="isLoadingAddress" id="Uf"></p-select>
+                        class="w-full" appendTo="body" [loading]="isLoadingAddress" id="Uf"
+                        [attr.aria-invalid]="!!erroFormulario || null"></p-select>
               <label for="Uf">Estado *</label>
             </p-iftalabel>
 
@@ -91,11 +92,15 @@
             </p-iftalabel>
 
             <button type="button" class="btn-primary search-form__submit"
-                    [disabled]="form.invalid || isLoading" (click)="onBuscarClick()">
+                    [disabled]="isLoading" (click)="onBuscarClick()">
               <i class="pi" [ngClass]="isLoading ? 'pi-spin pi-spinner' : 'pi-search'"></i>
               Buscar missas
             </button>
           </div>
+
+          <p class="search-form__erro" *ngIf="erroFormulario" role="alert">
+            <i class="pi pi-exclamation-circle"></i> {{ erroFormulario }}
+          </p>
         </form>
       </div>
 

--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -1,3 +1,5 @@
+@use '../../../shared/styles/sugestoes' as *;
+
 // ── Tokens ────────────────────────────────────────────────────────────────────
 $laranja: #bc5d10;
 $laranja-hover: #a34f0c;
@@ -359,6 +361,12 @@ $texto-2: #6b7280;
   // alvo mínimo de toque de 44px (WCAG 2.5.5). Era o menor clicável do formulário
   // sendo o mais importante dele.
   &__submit { flex: 1 1 150px; min-width: 150px; min-height: 48px; }
+
+  // O campo de nome ocupa a linha inteira: é texto livre, e a lista de sugestões
+  // ancora nele. Espremido entre os selects, o painel ficaria mais estreito que os
+  // nomes que precisa mostrar.
+  &__nome-wrap { position: relative; }
+  &__field--nome ::ng-deep input { width: 100%; }
 
   // Cobra o estado que a API exige, no lugar do botão inerte que não dizia nada.
   &__erro {

--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -269,11 +269,17 @@ $texto-2: #6b7280;
   &:hover { color: $laranja; background: #fff9f4; }
   &--ativa { color: $laranja; border-bottom-color: $laranja; }
 
+  // `font-size: 0` escondia os rótulos aqui e deixava duas lupas/alfinetes sem
+  // legenda e sem aria-label — some justamente "Buscar perto de mim", que é o
+  // caminho de um toque. Com duas abas os dois rótulos cabem inteiros em 375px.
+  //
+  // `px` e não `rem`: a raiz do app é 14px, então `0.78rem` renderizava 10,9px,
+  // pequeno demais para um rótulo que é o único sinal do que a aba faz.
   @media (max-width: 480px) {
-    font-size: 0;
-    gap: 0;
-    padding: 0.85rem 0.25rem;
-    .pi { font-size: 1.15rem; }
+    font-size: 12px;
+    gap: 0.3rem;
+    padding: 0.85rem 0.35rem;
+    .pi { font-size: 12px; }
   }
 }
 

--- a/src/app/modules/public/home/home.component.scss
+++ b/src/app/modules/public/home/home.component.scss
@@ -348,7 +348,18 @@ $texto-2: #6b7280;
     }
   }
   &__advanced { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: stretch; }
-  &__submit { flex: 1 1 150px; min-width: 150px; }
+
+  // 48px: o CTA media 36,75px — menor que os selects de 47px ao lado e abaixo do
+  // alvo mínimo de toque de 44px (WCAG 2.5.5). Era o menor clicável do formulário
+  // sendo o mais importante dele.
+  &__submit { flex: 1 1 150px; min-width: 150px; min-height: 48px; }
+
+  // Cobra o estado que a API exige, no lugar do botão inerte que não dizia nada.
+  &__erro {
+    display: flex; align-items: center; gap: 0.4rem;
+    margin: 0; font-size: 0.8rem; color: #b45309;
+    .pi { font-size: 0.85rem; }
+  }
 
   @media (max-width: 560px) {
     &__row, &__advanced { flex-direction: column; }

--- a/src/app/modules/public/home/home.component.spec.ts
+++ b/src/app/modules/public/home/home.component.spec.ts
@@ -14,6 +14,7 @@ import { RedesSociaisService } from '../../../core/services/redes-sociais.servic
 import { GeolocationService } from '../../../core/services/geolocation.service';
 import { SeoService } from '../../../core/services/seo.service';
 import { MetricasService } from '../../../core/services/metricas.service';
+import { SeoPaginasService } from '../../../core/services/seo-paginas.service';
 import { BuscaLocalService, IgrejaBusca } from '../../../core/services/busca-local.service';
 
 /**
@@ -74,6 +75,11 @@ describe('HomeComponent — /buscar?nome= sem UF', () => {
         { provide: GeolocationService, useValue: jasmine.createSpyObj('GeolocationService', ['obterPosicaoAtual', 'reverseGeocode', 'consultarCep']) },
         { provide: SeoService, useValue: jasmine.createSpyObj('SeoService', ['update', 'setJsonLd', 'removeJsonLd']) },
         { provide: MetricasService, useValue: jasmine.createSpyObj('MetricasService', ['registrarVisualizacaoHome', 'registrarVisualizacaoPagina']) },
+        // Dependência que a home ganhou em 1d43291 (cidadeSlug real vindo de
+        // `/v2/seo/estados`). Só é usada no caminho da geolocalização, que estes
+        // testes não exercitam — sem o stub, o serviço real puxa `HttpClient` e o
+        // TestBed quebra por NullInjector.
+        { provide: SeoPaginasService, useValue: { getEstados: () => of([]) } },
       ],
     });
 

--- a/src/app/modules/public/home/home.component.spec.ts
+++ b/src/app/modules/public/home/home.component.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+
+import { HomeComponent } from './home.component';
+import { ChurchesService } from '../../../core/services/churches.service';
+import { AnalyticsService } from '../../../core/services/analytics.service';
+import { FavoritesService } from '../../../core/services/favorites.service';
+import { RedesSociaisService } from '../../../core/services/redes-sociais.service';
+import { GeolocationService } from '../../../core/services/geolocation.service';
+import { SeoService } from '../../../core/services/seo.service';
+import { MetricasService } from '../../../core/services/metricas.service';
+import { BuscaLocalService, IgrejaBusca } from '../../../core/services/busca-local.service';
+
+/**
+ * Cobre só o caminho `/buscar?nome=...` SEM UF — a URL que o `SearchAction` do
+ * JSON-LD declara ao Google e que, até então, chegava e era descartada: o valor
+ * era restaurado da query e apagado no mesmo tick pelo `form.reset()`.
+ *
+ * O componente é construído fora do template (`runInInjectionContext`): o que
+ * está sob teste é a decisão — preservar o nome, não chamar a API sem UF, e
+ * navegar apenas quando o destino é inequívoco —, não a renderização.
+ */
+describe('HomeComponent — /buscar?nome= sem UF', () => {
+  const igreja = (nome: string, slug: string, cidadeSlug = 'sao-jose-dos-campos'): IgrejaBusca => ({
+    nome, slug, cidadeSlug, cidade: 'São José dos Campos', uf: 'sp', bairro: 'Centro',
+  });
+
+  let router: jasmine.SpyObj<Router>;
+  let churches: jasmine.SpyObj<ChurchesService>;
+  let busca: jasmine.SpyObj<BuscaLocalService>;
+
+  // Os spies nascem aqui, e não em `montar`, porque cada teste ajusta o retorno
+  // ANTES de montar o componente.
+  beforeEach(() => {
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    router.navigate.and.returnValue(Promise.resolve(true));
+
+    churches = jasmine.createSpyObj<ChurchesService>('ChurchesService', [
+      'addressRange', 'searchByFilters', 'getInfo', 'proximasMissas', 'cidadesProximas',
+    ]);
+    // `addressRange` é o gatilho: `_restoreFromQueryParams` roda no `finalize` dele.
+    churches.addressRange.and.returnValue(of({ data: {} } as any));
+    churches.getInfo.and.returnValue(of({ data: {} } as any));
+    churches.searchByFilters.and.returnValue(of({ data: { items: [], totalItems: 0 } } as any));
+
+    busca = jasmine.createSpyObj<BuscaLocalService>('BuscaLocalService', [
+      'carregarIndice', 'buscarIgrejas', 'correspondenciasExatas',
+    ]);
+    busca.carregarIndice.and.returnValue(of(true));
+    busca.buscarIgrejas.and.returnValue({ igrejas: [], total: 0 });
+    busca.correspondenciasExatas.and.returnValue([]);
+  });
+
+  /** Monta o componente com os params de query informados e roda `ngOnInit`. */
+  function montar(queryParams: Record<string, string>): HomeComponent {
+    TestBed.configureTestingModule({
+      providers: [
+        FormBuilder,
+        DatePipe,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Router, useValue: router },
+        { provide: ChurchesService, useValue: churches },
+        { provide: BuscaLocalService, useValue: busca },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams, data: {} }, queryParams: of(queryParams), data: of({}) } },
+        { provide: MessageService, useValue: jasmine.createSpyObj('MessageService', ['add']) },
+        { provide: AnalyticsService, useValue: jasmine.createSpyObj('AnalyticsService', ['searchStarted', 'trackEvent']) },
+        { provide: FavoritesService, useValue: { favoritos$: of([]), listar: () => [], ehFavorita: () => false } },
+        { provide: RedesSociaisService, useValue: { obterTipos: () => of([]) } },
+        { provide: GeolocationService, useValue: jasmine.createSpyObj('GeolocationService', ['obterPosicaoAtual', 'reverseGeocode', 'consultarCep']) },
+        { provide: SeoService, useValue: jasmine.createSpyObj('SeoService', ['update', 'setJsonLd', 'removeJsonLd']) },
+        { provide: MetricasService, useValue: jasmine.createSpyObj('MetricasService', ['registrarVisualizacaoHome', 'registrarVisualizacaoPagina']) },
+      ],
+    });
+
+    const c = TestBed.runInInjectionContext(() => new HomeComponent());
+    (c as any).resultsMode = true;
+    c.ngOnInit();
+    return c;
+  }
+
+  it('preserva o Nome vindo da URL, sem exigir Uf', () => {
+    busca.buscarIgrejas.and.returnValue({
+      igrejas: [igreja('Catedral São Dimas', 'catedral-sao-dimas'), igreja('Catedral de Taubaté', 'catedral-taubate')],
+      total: 32,
+    });
+    const c = montar({ nome: 'catedral' });
+
+    expect(c.form.get('Nome')?.value).toBe('catedral');
+  });
+
+  it('NÃO chama a API quando não há Uf — buscar-por-filtro exige UF', () => {
+    busca.buscarIgrejas.and.returnValue({ igrejas: [igreja('Catedral A', 'a')], total: 1 });
+    montar({ nome: 'catedral' });
+
+    expect(churches.searchByFilters).not.toHaveBeenCalled();
+  });
+
+  it('carrega o índice sob demanda e abre a lista', () => {
+    busca.buscarIgrejas.and.returnValue({ igrejas: [igreja('Catedral A', 'a'), igreja('Catedral B', 'b')], total: 2 });
+    const c = montar({ nome: 'catedral' });
+
+    expect(busca.carregarIndice).toHaveBeenCalled();
+    expect(c.painelAberto).toBeTrue();
+    expect(c.mostrarSugestoes).toBeTrue();
+    expect(c.totalSugestoes).toBe(2);
+  });
+
+  it('navega direto quando há exatamente uma correspondência', () => {
+    busca.buscarIgrejas.and.returnValue({ igrejas: [igreja('Catedral São Dimas', 'catedral-sao-dimas')], total: 1 });
+    montar({ nome: 'catedral sao dimas' });
+
+    expect(router.navigate).toHaveBeenCalledWith(['/paroquia', 'sp', 'sao-jose-dos-campos', 'catedral-sao-dimas']);
+  });
+
+  it('NÃO navega quando há várias — a regra de ambiguidade vale igual à da home', () => {
+    busca.buscarIgrejas.and.returnValue({
+      igrejas: [igreja('Catedral A', 'a'), igreja('Catedral B', 'b')],
+      total: 32,
+    });
+    const c = montar({ nome: 'catedral' });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(c.sugestaoAtiva).toBe(0);
+    expect(c.erroFormulario).toContain('32');
+  });
+
+  it('navega quando há uma única correspondência EXATA entre várias', () => {
+    busca.buscarIgrejas.and.returnValue({
+      igrejas: [igreja('Catedral', 'catedral'), igreja('Catedral Velha', 'catedral-velha')],
+      total: 2,
+    });
+    busca.correspondenciasExatas.and.returnValue([igreja('Catedral', 'catedral')]);
+    montar({ nome: 'catedral' });
+
+    expect(router.navigate).toHaveBeenCalledWith(['/paroquia', 'sp', 'sao-jose-dos-campos', 'catedral']);
+  });
+
+  it('avisa quando o nome não casa nada', () => {
+    busca.buscarIgrejas.and.returnValue({ igrejas: [], total: 0 });
+    const c = montar({ nome: 'zzzzz' });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(c.erroFormulario).toContain('Não encontramos essa igreja');
+  });
+
+  it('com Uf presente segue o fluxo da API, sem tocar no índice', () => {
+    const c = montar({ uf: 'SP', nome: 'catedral', pagina: '1' });
+
+    expect(churches.searchByFilters).toHaveBeenCalled();
+    const filtros = churches.searchByFilters.calls.mostRecent().args[0];
+    expect(filtros.Uf).toBe('SP');
+    expect(filtros.Nome).toBe('catedral');
+    expect(busca.carregarIndice).not.toHaveBeenCalled();
+    expect(c.painelAberto).toBeFalse();
+  });
+
+  it('sem uf e sem nome, o formulário é limpo como antes', () => {
+    const c = montar({});
+
+    expect(c.form.get('Nome')?.value).toBeNull();
+    expect(busca.carregarIndice).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -43,6 +43,7 @@ import { linkParoquia } from "../../../shared/utils/church-link.utils";
 import { SeoPaginasService } from "../../../core/services/seo-paginas.service";
 import { SeoService } from "../../../core/services/seo.service";
 import { MetricasService } from "../../../core/services/metricas.service";
+import { BuscaLocalService, IgrejaBusca } from "../../../core/services/busca-local.service";
 
 interface AddressData {
   [uf: string]: {
@@ -86,6 +87,7 @@ export class HomeComponent {
   private _seo = inject(SeoService);
   private _seoPaginas = inject(SeoPaginasService);
   private _metricas = inject(MetricasService);
+  private _buscaLocal = inject(BuscaLocalService);
   tiposRedeSocial: TipoRedeSocial[] = [];
 
   /** Status da geolocalização */
@@ -325,6 +327,41 @@ export class HomeComponent {
   /** Select de Estado — para devolver o foco quando o usuário busca sem escolher um. */
   @ViewChild('ufSelect') private _ufSelect?: Select;
 
+  /** ── Busca por NOME de igreja (índice estático local) ────────────────────────
+   *
+   * Não existe endpoint que ache paróquia por nome no Brasil inteiro
+   * (`buscar-por-filtro` exige `Uf`), então o autocomplete vem do índice que o
+   * prebuild gera — o mesmo já usado em `/cidades`. Nenhuma API nova.
+   *
+   * Os dois caminhos convivem no MESMO campo: a lista é o atalho direto para a
+   * paróquia (nacional, ou recortada pelo estado/cidade já escolhidos), e o valor
+   * digitado também viaja como `Nome` na busca filtrada quando há estado. */
+
+  /** Consulta abaixo disto não sugere nada — 1 ou 2 letras casariam meia base. */
+  private static readonly MIN_CONSULTA = 3;
+
+  sugestoesIgrejas: IgrejaBusca[] = [];
+  /** Total de paróquias que casaram, antes do corte da lista. */
+  totalSugestoes = 0;
+  /** Índice do item com foco de teclado; -1 = foco no campo. */
+  sugestaoAtiva = -1;
+
+  /**
+   * O painel abre porque o usuário está PROCURANDO, não porque o campo tem texto.
+   *
+   * A diferença aparece ao chegar em `/buscar?nome=catedral`: o valor é restaurado
+   * da URL sem ninguém digitar, e o índice — que só é pedido no foco do campo —
+   * nunca foi baixado. Sem esta flag o painel abria sozinho e ficava preso em
+   * "Carregando a lista de igrejas…", esperando um download que ninguém pediu.
+   */
+  painelAberto = false;
+
+  /** Já pedimos o índice nesta sessão? (o serviço é idempotente, isto evita ruído) */
+  private _indicePedido = false;
+  /** O índice chegou (com dados ou vazio) — é o que distingue "carregando" de "não achei". */
+  indiceResolvido = false;
+  /** O índice resolveu SEM dados: rede caiu, 404, ou HTML no lugar do JSON. */
+  indiceIndisponivel = false;
 
   /** Estatísticas (números reais via getInfo, com fallback) */
   stats = { igrejas: 2000, horarios: 9100, cidades: 213, estados: 26 };
@@ -346,6 +383,8 @@ export class HomeComponent {
     this.churchInfo = [];
     this.showNoChurchCard = false;
     this.erroFormulario = null;
+    this.form?.get('Nome')?.setValue(null);
+    this.limparSugestoes();
   }
 
   toggleMaisFiltros(): void {
@@ -458,6 +497,7 @@ export class HomeComponent {
       Uf: [null],
       Localidade: [null],
       Bairro: [null],
+      Nome: [null],
       DiaDaSemana: [null],
       Horario: [null],
       HorarioFim: [null],
@@ -935,6 +975,7 @@ export class HomeComponent {
     }
 
     if (p['bairro']) this.form.get('Bairro')?.setValue(p['bairro']);
+    if (p['nome']) this.form.get('Nome')?.setValue(p['nome']);
     if (p['dia'] != null) this.form.get('DiaDaSemana')?.setValue(Number(p['dia']));
     if (p['horario']) {
       const [h, m] = p['horario'].split(':').map(Number);
@@ -1002,6 +1043,7 @@ export class HomeComponent {
     uf: string | null;
     cidade: string | null;
     bairro: string | null;
+    nome: string | null;
     dia: number | null;
     horario: string | null;
     horarioFim: string | null;
@@ -1010,6 +1052,7 @@ export class HomeComponent {
     const uf = this.form.get("Uf")?.value;
     const localidade = this.form.get("Localidade")?.value;
     const bairro = this.form.get("Bairro")?.value;
+    const nome = String(this.form.get("Nome")?.value ?? '').trim();
     const diaDaSemana = this.form.get("DiaDaSemana")?.value;
     const horarioRaw = this.form.value.Horario;
     const horario = horarioRaw ? (typeof horarioRaw === 'string' ? horarioRaw : this._datePipe.transform(horarioRaw, 'HH:mm')) : null;
@@ -1021,6 +1064,7 @@ export class HomeComponent {
       uf: uf ?? null,
       cidade: localidade ?? null,
       bairro: bairro ?? null,
+      nome: nome || null,
       dia: diaDaSemana ?? null,
       horario: horario ?? null,
       horarioFim: horarioFim ?? null,
@@ -1028,34 +1072,226 @@ export class HomeComponent {
     };
   }
 
+  // ── Autocomplete de nome de igreja ──────────────────────────────────────────
+
+  /** Escopo atual das sugestões: o que o usuário já escolheu no formulário. */
+  private get _escopoBusca() {
+    return {
+      uf: this.form?.get('Uf')?.value ?? null,
+      cidade: this.form?.get('Localidade')?.value ?? null,
+    };
+  }
+
+  private get _consultaNome(): string {
+    return String(this.form?.get('Nome')?.value ?? '').trim();
+  }
+
   /**
-   * Clique no botão "Buscar": na home navega p/ /buscar; em /buscar refaz inline.
+   * Baixa o índice no FOCO do campo, não no load da página. Quem nunca usa a busca
+   * por nome não paga o download — e quem usa já os tem quando termina
+   * de digitar as três primeiras letras.
+   */
+  garantirIndiceIgrejas(): void {
+    if (this._indicePedido || !this._isBrowser) return;
+    this._indicePedido = true;
+
+    this._buscaLocal
+      .carregarIndice()
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe((temIndice) => {
+        this.indiceResolvido = true;
+        this.indiceIndisponivel = !temIndice;
+        // O usuário pode ter digitado enquanto o índice vinha: recalcula.
+        this._recalcularSugestoes();
+      });
+  }
+
+  onNomeInput(): void {
+    this.erroFormulario = null;
+    this.sugestaoAtiva = -1;
+    this.painelAberto = true;
+    this.garantirIndiceIgrejas();
+    this._recalcularSugestoes();
+  }
+
+  private _recalcularSugestoes(): void {
+    const consulta = this._consultaNome;
+    if (consulta.length < HomeComponent.MIN_CONSULTA) {
+      this.sugestoesIgrejas = [];
+      this.totalSugestoes = 0;
+      return;
+    }
+    // `buscarIgrejas` e não `buscar`: só igrejas, com bairro e escopo. `buscar()`
+    // é o caminho de `/cidades` e continua intocado.
+    const r = this._buscaLocal.buscarIgrejas(consulta, this._escopoBusca);
+    this.sugestoesIgrejas = r.igrejas;
+    this.totalSugestoes = r.total;
+  }
+
+  /** Mostrar o painel? Só com consulta útil e algo a dizer. */
+  get mostrarSugestoes(): boolean {
+    return (
+      this.painelAberto &&
+      this._consultaNome.length >= HomeComponent.MIN_CONSULTA &&
+      (this.sugestoesIgrejas.length > 0 || !this.indiceResolvido || this.indiceIndisponivel || this.buscaSemResultado)
+    );
+  }
+
+  /** Índice já respondeu, tem dados, e mesmo assim nada casou. */
+  get buscaSemResultado(): boolean {
+    return (
+      this.indiceResolvido &&
+      !this.indiceIndisponivel &&
+      this._consultaNome.length >= HomeComponent.MIN_CONSULTA &&
+      this.sugestoesIgrejas.length === 0
+    );
+  }
+
+  /** Carregando: o índice ainda não chegou e já há o que buscar com ele. */
+  get carregandoSugestoes(): boolean {
+    return !this.indiceResolvido && this._consultaNome.length >= HomeComponent.MIN_CONSULTA;
+  }
+
+  /** A lista está cortada — quantas ficaram de fora importa para não enganar. */
+  get sugestoesCortadas(): boolean {
+    return this.totalSugestoes > this.sugestoesIgrejas.length;
+  }
+
+  /**
+   * Enter no campo de nome. Com um item percorrido pelo teclado, abre esse item;
+   * sem item ativo, faz exatamente o que o botão faz — inclusive a recusa de
+   * escolher sozinho quando o nome é ambíguo.
+   */
+  onEnterNome(): void {
+    if (this.sugestaoAtiva >= 0 && this.sugestoesIgrejas[this.sugestaoAtiva]) {
+      this.abrirSugestao(this.sugestoesIgrejas[this.sugestaoAtiva]);
+      return;
+    }
+    this.onBuscarClick();
+  }
+
+  linkIgrejaSugerida(i: IgrejaBusca): string[] {
+    // Slugs sempre os do backend, nunca gerados aqui. Mesma montagem de /cidades.
+    return ['/paroquia', i.uf, i.cidadeSlug, i.slug];
+  }
+
+  abrirSugestao(i: IgrejaBusca): void {
+    this.limparSugestoes();
+    this._router.navigate(this.linkIgrejaSugerida(i));
+  }
+
+  limparSugestoes(): void {
+    this.sugestoesIgrejas = [];
+    this.totalSugestoes = 0;
+    this.sugestaoAtiva = -1;
+    this.painelAberto = false;
+  }
+
+  /** Seta para baixo/cima percorre a lista; -1 devolve o foco ao campo. */
+  moverSugestao(delta: number): void {
+    if (!this.sugestoesIgrejas.length) return;
+    const ultimo = this.sugestoesIgrejas.length - 1;
+    const proximo = this.sugestaoAtiva + delta;
+    this.sugestaoAtiva = proximo < 0 ? -1 : Math.min(proximo, ultimo);
+  }
+
+  // ── Ação principal ──────────────────────────────────────────────────────────
+
+  /**
+   * Clique no botão "Buscar" (e Enter no formulário) — os dois fazem o mesmo.
    *
    * O botão NÃO nasce mais desabilitado. Antes era `[disabled]="form.invalid"` com
    * `Uf` obrigatório, mas pintado como primário cheio (laranja 100%, opacidade 1,
    * cursor pointer): clicar não fazia nada e não dizia por quê. O requisito é
    * cobrado AQUI, com mensagem e foco — errar e ser corrigido ensina, botão inerte
    * não.
+   *
+   * Com estado: busca filtrada normal, agora levando `Nome` junto.
+   * Sem estado, só com nome: o índice local resolve — mas SÓ navega sozinho quando
+   * o destino é inequívoco (ver `_resolverPorNome`).
    */
   public onBuscarClick(): void {
     if (this.isLoading) return;
 
-    if (!this.form.get('Uf')?.value) {
-      this._exigirEstado();
+    if (this.form.get('Uf')?.value) {
+      this.erroFormulario = null;
+      this.limparSugestoes();
+      if (this.resultsMode) {
+        this.searchFilter();
+      } else {
+        this.submitBusca();
+      }
+      return;
+    }
+
+    if (this._consultaNome.length >= HomeComponent.MIN_CONSULTA) {
+      this._resolverPorNome();
+      return;
+    }
+
+    this._exigirEstado();
+  }
+
+  /**
+   * Caminho "só o nome, sem estado".
+   *
+   * A regra que importa: **não escolher pelo usuário quando há mais de um destino.**
+   * "São Francisco" casa dezenas de paróquias em cidades diferentes; abrir a
+   * primeira o levaria em silêncio para a igreja errada, sem que ele percebesse que
+   * houve uma escolha. Navegar direto só quando o destino é único — ou quando um
+   * único nome bate EXATAMENTE com o que ele digitou.
+   */
+  private _resolverPorNome(): void {
+    // Pode ser a primeira interação com o campo (valor veio da URL): garante o
+    // índice e recalcula antes de decidir qualquer coisa.
+    this.painelAberto = true;
+    this.garantirIndiceIgrejas();
+    this._recalcularSugestoes();
+
+    if (this.carregandoSugestoes) {
+      this.erroFormulario = 'Carregando a lista de igrejas. Tente de novo em um instante.';
+      return;
+    }
+
+    if (this.indiceIndisponivel) {
+      this.erroFormulario = 'A busca por nome está indisponível agora. Escolha um estado para buscar.';
+      return;
+    }
+
+    if (this.totalSugestoes === 0) {
+      this.erroFormulario = 'Não encontramos essa igreja. Escolha um estado para buscar pelos horários.';
       return;
     }
 
     this.erroFormulario = null;
-    if (this.resultsMode) {
-      this.searchFilter();
-    } else {
-      this.submitBusca();
+    this._analytics.searchStarted();
+
+    if (this.totalSugestoes === 1) {
+      this.abrirSugestao(this.sugestoesIgrejas[0]);
+      return;
     }
+
+    const exatas = this._buscaLocal.correspondenciasExatas(this._consultaNome, this._escopoBusca);
+    if (exatas.length === 1) {
+      this.abrirSugestao(exatas[0]);
+      return;
+    }
+
+    // Ambíguo: a lista já está na tela; leva o foco para ela e deixa a escolha
+    // com quem sabe qual é a igreja certa.
+    //
+    // E DIZ isso. Destacar um item em silêncio depois de um clique é o mesmo
+    // defeito do botão desabilitado que esta etapa remove: a pessoa age e nada
+    // explica o que aconteceu.
+    this.sugestaoAtiva = 0;
+    this.erroFormulario =
+      `Encontramos ${this.totalSugestoes} igrejas com esse nome. ` +
+      `Escolha uma na lista ou informe o estado.`;
   }
 
   /** Mensagem + foco quando falta o estado, que é o único filtro que a API exige. */
   private _exigirEstado(): void {
-    this.erroFormulario = 'Escolha um estado para buscar.';
+    this.erroFormulario = 'Escolha um estado ou digite o nome da igreja.';
     this.form.get('Uf')?.markAsTouched();
     this._ufSelect?.focus();
   }
@@ -1090,6 +1326,7 @@ export class HomeComponent {
       Uf: params.uf!,
       Localidade: params.cidade || undefined,
       Bairro: params.bairro || undefined,
+      Nome: params.nome || undefined,
       DiaDaSemana: params.dia || undefined,
       Horario: params.horario || undefined,
       HorarioFim: params.horarioFim || undefined,

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -1,16 +1,16 @@
-import { Component, DestroyRef, inject, NgZone, PLATFORM_ID } from "@angular/core";
+import { Component, DestroyRef, inject, NgZone, PLATFORM_ID, ViewChild } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { finalize } from "rxjs/operators";
 import { firstValueFrom } from "rxjs";
 import { CommonModule, DatePipe, isPlatformBrowser } from "@angular/common";
 import {
   FormGroup,
-  Validators,
   ReactiveFormsModule,
   FormBuilder,
 } from "@angular/forms";
 import { ChurchesService } from "../../../core/services/churches.service";
 import { MessageService } from "primeng/api";
+import { Select } from "primeng/select";
 import { WEEK_DAYS } from "../../../core/constants/weekdays";
 import { PrimeNgModule } from "../../../shared/primeng.module";
 import {
@@ -319,6 +319,13 @@ export class HomeComponent {
   /** Raio (km) da busca por localização */
   raioCep = 5;
 
+  /** Erro de preenchimento do formulário, mostrado inline sob os campos. */
+  erroFormulario: string | null = null;
+
+  /** Select de Estado — para devolver o foco quando o usuário busca sem escolher um. */
+  @ViewChild('ufSelect') private _ufSelect?: Select;
+
+
   /** Estatísticas (números reais via getInfo, com fallback) */
   stats = { igrejas: 2000, horarios: 9100, cidades: 213, estados: 26 };
 
@@ -338,6 +345,7 @@ export class HomeComponent {
     this._router.navigate([], { queryParams: {}, replaceUrl: true });
     this.churchInfo = [];
     this.showNoChurchCard = false;
+    this.erroFormulario = null;
   }
 
   toggleMaisFiltros(): void {
@@ -444,7 +452,10 @@ export class HomeComponent {
     }
 
     this.form = this._fb.group({
-      Uf: [null, Validators.required],
+      // Sem `Validators.required` em `Uf` de propósito: com ele o formulário nasce
+      // inválido e o botão principal nasce desabilitado, sem dizer o que falta.
+      // A exigência de estado é cobrada em `onBuscarClick()`, com mensagem e foco.
+      Uf: [null],
       Localidade: [null],
       Bairro: [null],
       DiaDaSemana: [null],
@@ -466,6 +477,7 @@ export class HomeComponent {
       if (!params['uf']) {
         this.churchInfo = [];
         this.showNoChurchCard = false;
+        this.erroFormulario = null;
         this.form.reset();
       }
     });
@@ -951,6 +963,8 @@ export class HomeComponent {
 
   public onStateChange(event: any): void {
     this.selectedState = event.value;
+    // Escolher o estado é a correção do erro — a mensagem some junto.
+    if (this.selectedState) this.erroFormulario = null;
     if (this.selectedState) {
       // Guarda: se o addressRange falhou, fullAddressData é undefined — não pode
       // derrubar o fluxo (a busca da URL ainda precisa rodar e mostrar o erro dela)
@@ -1014,14 +1028,36 @@ export class HomeComponent {
     };
   }
 
-  /** Clique no botão "Buscar": na home navega p/ /buscar; em /buscar refaz inline */
+  /**
+   * Clique no botão "Buscar": na home navega p/ /buscar; em /buscar refaz inline.
+   *
+   * O botão NÃO nasce mais desabilitado. Antes era `[disabled]="form.invalid"` com
+   * `Uf` obrigatório, mas pintado como primário cheio (laranja 100%, opacidade 1,
+   * cursor pointer): clicar não fazia nada e não dizia por quê. O requisito é
+   * cobrado AQUI, com mensagem e foco — errar e ser corrigido ensina, botão inerte
+   * não.
+   */
   public onBuscarClick(): void {
-    if (this.form.invalid) return;
+    if (this.isLoading) return;
+
+    if (!this.form.get('Uf')?.value) {
+      this._exigirEstado();
+      return;
+    }
+
+    this.erroFormulario = null;
     if (this.resultsMode) {
       this.searchFilter();
     } else {
       this.submitBusca();
     }
+  }
+
+  /** Mensagem + foco quando falta o estado, que é o único filtro que a API exige. */
+  private _exigirEstado(): void {
+    this.erroFormulario = 'Escolha um estado para buscar.';
+    this.form.get('Uf')?.markAsTouched();
+    this._ufSelect?.focus();
   }
 
   /** Navega para a página de resultados com os filtros como query params */
@@ -1033,7 +1069,9 @@ export class HomeComponent {
   }
 
   public searchFilter(resetPage = true): void {
-    if (this.isLoading || this.form.invalid) return;
+    // `Uf` é `[Required]` no backend — sem ele a chamada volta 400. A validação de
+    // formulário saiu do `Validators` para o clique, então o guard checa o campo.
+    if (this.isLoading || !this.form.get('Uf')?.value) return;
 
     if (resetPage) this.pageIndex = 1;
 

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -363,6 +363,13 @@ export class HomeComponent {
   /** O índice resolveu SEM dados: rede caiu, 404, ou HTML no lugar do JSON. */
   indiceIndisponivel = false;
 
+  /**
+   * Há uma consulta vinda da URL esperando o índice chegar para ser resolvida.
+   * A decisão (navegar ou não) depende de saber quantas paróquias casaram, e isso
+   * só se sabe depois do download.
+   */
+  private _resolverAposIndice = false;
+
   /** Estatísticas (números reais via getInfo, com fallback) */
   stats = { igrejas: 2000, horarios: 9100, cidades: 213, estados: 26 };
 
@@ -514,7 +521,10 @@ export class HomeComponent {
     // Usa a key 'uf' (minúscula) — a mesma gravada por searchFilter — senão o form
     // seria resetado a cada busca/paginação, deixando-o inválido e travando a paginação.
     this._route.queryParams.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(params => {
-      if (!params['uf']) {
+      // `nome` na guarda porque `/buscar?nome=catedral` é uma busca legítima, sem
+      // UF: é o alvo declarado pelo SearchAction do JSON-LD. Sem isto o valor era
+      // restaurado da URL e apagado no mesmo tick pelo `form.reset()` abaixo.
+      if (!params['uf'] && !params['nome']) {
         this.churchInfo = [];
         this.showNoChurchCard = false;
         this.erroFormulario = null;
@@ -550,7 +560,9 @@ export class HomeComponent {
         "@type": "SearchAction",
         target: {
           "@type": "EntryPoint",
-          urlTemplate: `${base}/buscar?busca={search_term_string}`,
+          // `nome`, não `busca`: o app nunca leu um param chamado `busca`, então
+          // este alvo levava a uma página de busca vazia desde sempre.
+          urlTemplate: `${base}/buscar?nome={search_term_string}`,
         },
         "query-input": "required name=search_term_string",
       },
@@ -963,7 +975,14 @@ export class HomeComponent {
 
   private _restoreFromQueryParams(): void {
     const p = this._route.snapshot.queryParams;
-    if (!p['uf']) return;
+
+    // Sem UF não existe busca de API: `buscar-por-filtro` exige `Uf`. Mas com
+    // `nome` ainda existe o índice local — e é exatamente essa a URL que o
+    // SearchAction declara ao Google.
+    if (!p['uf']) {
+      if (p['nome']) this._restaurarBuscaPorNome(String(p['nome']));
+      return;
+    }
 
     // Restaura UF e popula cidades
     this.form.get('Uf')?.setValue(p['uf']);
@@ -1000,6 +1019,28 @@ export class HomeComponent {
     }
 
     this.searchFilter(false);
+  }
+
+  /**
+   * `/buscar?nome=...` sem UF — a URL que o `SearchAction` do JSON-LD declara.
+   *
+   * Reproduz o que acontece quando a pessoa digita no campo: índice sob demanda,
+   * os mesmos estados de lista e a MESMA regra de ambiguidade. Nenhuma chamada de
+   * API, porque sem `Uf` não há o que chamar.
+   */
+  private _restaurarBuscaPorNome(nome: string): void {
+    this.form.get('Nome')?.setValue(nome);
+    this.painelAberto = true;
+
+    // O índice pode já estar em memória (voltar para cá dentro da mesma sessão).
+    if (this.indiceResolvido) {
+      this._recalcularSugestoes();
+      this._resolverPorNome();
+      return;
+    }
+
+    this._resolverAposIndice = true;
+    this.garantirIndiceIgrejas();
   }
 
   public onStateChange(event: any): void {
@@ -1103,6 +1144,12 @@ export class HomeComponent {
         this.indiceIndisponivel = !temIndice;
         // O usuário pode ter digitado enquanto o índice vinha: recalcula.
         this._recalcularSugestoes();
+
+        // Consulta que veio da URL: agora dá para decidir se navega.
+        if (this._resolverAposIndice) {
+          this._resolverAposIndice = false;
+          this._resolverPorNome();
+        }
       });
   }
 

--- a/src/app/shared/styles/_sugestoes.scss
+++ b/src/app/shared/styles/_sugestoes.scss
@@ -1,0 +1,100 @@
+// Painel de sugestões da busca (cidade e/ou igreja).
+//
+// Mora aqui pela mesma razão de `_hero-busca.scss`: o markup da lista pertence à
+// PÁGINA (cada uma decide o que sugere e para onde navega), então só o SCSS da
+// página alcança aqueles elementos com a encapsulação emulada. Este partial é a
+// gramática visual comum — extraída de `/cidades`, que é a versão mais completa.
+//
+// Uso: `@use '../../../shared/styles/sugestoes' as *;` no topo do SCSS da página.
+//
+// VARIANTE `--inline`: por padrão o painel flutua ancorado ao campo (`absolute`),
+// que é o comportamento de `/cidades` e `/missas/:uf`. Na home isso não serve — o
+// `.search-card` tem `overflow: hidden` e recortaria o painel — então lá a lista
+// entra no fluxo, dentro do próprio cartão de busca.
+
+$sg-laranja-vivo: #e2761b;
+$sg-creme: #fdf6f0;
+$sg-borda: #e5e7eb;
+$sg-texto: #374151;
+$sg-muted: #6b7280;
+
+.sugestoes {
+  position: absolute; z-index: 5; top: calc(100% + 0.35rem); left: 0; right: 0;
+  margin: 0; padding: 0.3rem;
+  background: #fff; border: 1px solid $sg-borda; border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .10);
+  // Teto pensado para 375x667 com o teclado aberto: o painel rola por dentro em
+  // vez de empurrar a página, para que o primeiro resultado NUNCA exija rolar a
+  // tela. `min()` com vh porque em telas baixas 19rem já passaria da área útil.
+  max-height: min(19rem, 46vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+
+  ul { list-style: none; margin: 0; padding: 0; }
+  li + li { border-top: 1px solid #f3f4f6; }
+
+  a {
+    display: flex; align-items: center; gap: 0.6rem;
+    padding: 0.6rem 0.7rem; border-radius: 8px;
+    text-decoration: none; color: $sg-texto;
+  }
+  a:hover, a:focus-visible { background: $sg-creme; }
+  i { color: $sg-laranja-vivo; font-size: 0.9rem; flex: 0 0 auto; }
+
+  &__nome { font-weight: 600; }
+
+  // Rótulo do grupo: minúsculo e discreto de propósito. Ele responde "o que é esta
+  // linha", que é a única dúvida real do painel — não é um cabeçalho de seção e
+  // não deve competir com os resultados.
+  &__grupo {
+    margin: 0.35rem 0 0.15rem; padding: 0 0.7rem;
+    font-size: 0.6875rem; font-weight: 700; letter-spacing: 0.06em;
+    text-transform: uppercase; color: $sg-muted;
+  }
+  ul + &__grupo { margin-top: 0.5rem; border-top: 1px solid #f3f4f6; padding-top: 0.5rem; }
+
+  // CIDADE: nome à esquerda, UF + total à direita, uma linha só.
+  &__meta {
+    margin-left: auto; color: $sg-muted; font-size: 0.8125rem; white-space: nowrap;
+    padding-left: 0.5rem;
+  }
+
+  // IGREJA: duas linhas. O local embaixo do nome é o que impede confundir
+  // "São José" (a cidade) com "Paróquia São José" (a igreja) — e, quando há
+  // bairro, é o que separa duas homônimas na mesma cidade.
+  &__igreja { align-items: flex-start; }
+  &__igreja i { margin-top: 0.15rem; }
+  // Item percorrido pelo teclado. O foco real fica no campo (padrão combobox com
+  // `aria-activedescendant`), então quem está no teclado precisa VER onde está —
+  // sem isso as setas não dariam sinal nenhum.
+  &__igreja--ativa { background: $sg-creme; box-shadow: inset 2px 0 0 $sg-laranja-vivo; }
+  &__texto { display: flex; flex-direction: column; gap: 0.1rem; min-width: 0; }
+  &__local { color: $sg-muted; font-size: 0.8125rem; }
+
+  &__vazio {
+    margin: 0; padding: 0.9rem 0.7rem;
+    color: $sg-muted; font-size: 0.875rem; line-height: 1.45; text-align: center;
+  }
+
+  // Rodapé de "há mais que isto". Sem ele, uma lista cortada em 6 se passa por
+  // lista completa e quem não vê a sua conclui que ela não existe.
+  //
+  // `sticky`: com 6 resultados a lista já passa do teto e rola por dentro, o que
+  // empurrava justamente este aviso para fora da vista — o recado sobre a lista
+  // estar cortada não pode depender de rolar a lista cortada.
+  &__mais {
+    position: sticky; bottom: 0;
+    margin: 0; padding: 0.55rem 0.7rem 0.45rem;
+    border-top: 1px solid #f3f4f6;
+    background: #fff;
+    color: $sg-muted; font-size: 0.78rem; text-align: center;
+  }
+
+  // Dentro de um cartão com `overflow: hidden`, flutuar não é opção.
+  &--inline {
+    position: static;
+    margin-top: 0.5rem;
+    box-shadow: none;
+    max-height: min(17rem, 42vh);
+  }
+}


### PR DESCRIPTION
Etapa 1 do plano de melhorias da Home. Escopo deliberadamente restrito ao **fluxo principal do hero** — a reorganização da página fica para depois.

## O que muda

**1. Busca por nome de igreja** (`6fc73e7`… `68b47d8`)

Quem chega sabendo o nome — "Achiropita" — não tinha por onde entrar: o formulário só oferecia Estado, Cidade, Bairro, Dia e Horário.

O campo entra **dentro** de "Buscar uma missa", não como terceira aba, e é isso que permite combinar nome com cidade e bairro: `SP + São Paulo + Bela Vista + Achiropita` é uma busca só. Como aba separada, escolher a cidade excluiria buscar pelo nome.

**Nenhuma API nova.** Dois caminhos que já existiam se encontram no mesmo campo:

- enquanto digita, as sugestões saem do índice estático (`BuscaLocalService`), nacional ou recortado pelo Estado/Cidade já selecionados, e clicar leva direto a `/paroquia/:uf/:cidade/:slug` — é o único jeito de achar paróquia por nome no Brasil inteiro, porque `buscar-por-filtro` exige `Uf`;
- ao submeter com Estado preenchido, `Nome` viaja junto de `Localidade` e `Bairro` para `v1/Igreja/buscar-por-filtro`, que **já aceitava o campo**. `FilterSearchChurch.Nome` já estava declarado; faltava só o input na tela.

**A regra que mais importa: nunca escolher a igreja pelo usuário quando há mais de um destino.** "São Francisco" casa 183 paróquias em produção; abrir a primeira o levaria em silêncio para a igreja errada, sem que ele percebesse que houve uma escolha. Botão e Enter navegam sozinhos apenas com resultado único ou com uma única correspondência exata de nome; havendo ambiguidade, a lista fica aberta, o primeiro item recebe foco virtual (`aria-activedescendant`) e uma mensagem diz quantas existem.

**2. CTA "Buscar missas" deixa de nascer inerte** (`6fc73e7`)

Era `[disabled]="form.invalid || isLoading"` com `Uf` obrigatório, mas pintado como primário cheio: laranja 100%, `opacity: 1`, `cursor: pointer`. Clicar não fazia nada e não dizia por quê. A exigência de estado passa para o clique, com mensagem inline e foco no select. Junto: 48px de altura — media 36,75px, abaixo do mínimo do WCAG 2.5.5 e menor que os selects ao lado.

**3. Rótulos das abas no mobile** (`d7e8dd0`)

Abaixo de 480px havia `font-size: 0`. Sobravam duas lupas sem legenda e sem `aria-label`, escondendo "Buscar perto de mim" — o caminho de um toque — justamente onde ele vale mais.

**4. Bairro no índice estático** (`a601122`)

Sem bairro, duas paróquias homônimas na mesma cidade aparecem como linhas idênticas. Entra como tabela deduplicada (`b`), não como string repetida. Medido: dev 173.421 → 203.822 bytes (gzip 31.591 → 44.118); prod 388.910 → 450.620 (gzip 68.991 → 93.684). Bairro é opcional em toda a cadeia, e o frontend tolera índice **antigo** sem a chave `b` — deploy do frontend antes de rebuildar o índice degrada a linha, não quebra a busca.

**5. SEO** (`4391573`, `ab70d9d`)

O filtro por `nome` tornou o espaço de URLs de `/buscar` praticamente infinito. Numa base que já sofre com duplicate/canonical no Search Console, isso é combustível — daí o `noindex`. Validado antes: nenhum link interno aponta para `/buscar`, não está no sitemap, não define canonical própria.

E o `SearchAction` do JSON-LD apontava para `?busca={search_term_string}` — **um parâmetro que a aplicação nunca leu**. Defeito pré-existente. Trocar por `nome` sozinho não bastava: sem `uf`, o valor chegava e era descartado no mesmo tick. Por isso o fluxo vem primeiro e a meta tag depois.

## `/cidades` não muda

A busca por nome é funcionalidade da **Home**. `buscar()` (o caminho de `/cidades`) e `buscarIgrejas()` (o da Home) são métodos separados, e `chaveBairro` fica fora de `chave`. Quatro testes travam esse isolamento: `buscar()` não casa por bairro, não reordena por relevância, devolve a forma antiga e mantém a ordenação de cidades.

Verificado na tela: `curitiba sao francisco` traz 3 igrejas só por nome; `bela vista` não casa nada; sem rodapé "Mostrando N".

## Validação

`npx ng test` → **51 SUCCESS** (27 pré-existentes + 24 novos)
`npm run build` → **verde, 1.578 páginas** prerenderizadas

Smoke tests em 1440px e 375px:

| Caso | Resultado |
|---|---|
| `ach` (prod) | Achiropita em 1º de 39 |
| `sao francisco` + Enter | não navega · "Mostrando 6 de 83" |
| `catedral sao dimas` | navega para a paróquia |
| `/buscar?nome=catedral` | nome preservado, sugestões abertas, **0 chamadas à API** |
| `/buscar?uf=SP&…&nome=catedral` | `Uf=SP&Localidade=…&Bairro=Centro&Nome=catedral` |
| `/buscar` | `noindex, nofollow` |
| geolocalização (PR) | `/missas/pr/itapejara-d-oeste` — integração com `1d43291` ok |
| 375px | duas abas com texto, sem corte; CTA 48px |

SSG: no HTML pré-renderizado o painel não existe e o botão sai **sem** `disabled`.

## Fora do escopo (pendências conhecidas)

Levantadas durante a auditoria, deliberadamente não corrigidas aqui:

- `geoStatus === 'error'` não renderiza mensagem — quem cair nele vê o spinner parar e nada mais;
- `stats = { igrejas: 2000, horarios: 9100 }` hardcoded sobrescreve o SSG na hidratação;
- `/buscar` não é pré-renderizada, então o `noindex` é aplicado em runtime;
- duplicata em produção: "Paróquia N. Sra. da Boa Viagem" (Cachoeirinha/RS), slugs `…-boa-viagem` e `…-boa-viagem-2`;
- warning pré-existente de `disabled` com reactive forms nos selects Cidade/Bairro;
- ao abrir, a lista empurra Dia/Horário/Buscar para baixo.

## Antes de mergear

Rodar `npm run indice:dev` (ou o prebuild do ambiente) — o índice só ganha bairro num build que execute `gerar-indice-busca.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)