### PR TITLE
fix(home): invalida o cache de proximasFiltradas por identidade do array

### DIFF
--- a/src/app/modules/public/home/home.component.spec.ts
+++ b/src/app/modules/public/home/home.component.spec.ts
@@ -256,3 +256,105 @@ describe('HomeComponent — origem das distâncias', () => {
     expect(montar('server').origemDistancia).toBeNull();
   });
 });
+
+/**
+ * `proximasFiltradas` memoiza o array que vai para os filhos OnPush. A chave antiga
+ * (`quickFilter|length|churchId[0]`) descrevia a FORMA da lista, não o conteúdo: uma
+ * recarga com o mesmo tamanho e a mesma primeira igreja devolvia os cards antigos.
+ *
+ * Isso ficou visível quando a distância passou a existir só com geolocalização — que é
+ * exatamente a sequência abaixo, e o caso mais comum, já que o fallback da API também
+ * é São Paulo. Verificado em dados reais: com 1 card da mesma igreja o chip nunca
+ * aparecia; com a lista mudando de 1 para 2 cards, aparecia.
+ */
+describe('HomeComponent — cache de proximasFiltradas', () => {
+  let churches: jasmine.SpyObj<ChurchesService>;
+
+  /** Mesma igreja nas duas cargas: é o que fazia a chave antiga não invalidar. */
+  const itemApi = {
+    igrejaId: 66,
+    nome: 'Paróquia Santa Generosa',
+    slug: 'paroquia-santa-generosa',
+    uf: 'SP',
+    cidadeSlug: 'sao-paulo',
+    bairro: 'Paraíso',
+    missa: { id: 547, diaSemana: 1, horario: '10:00:00' },
+    distanciaKm: 2.86,
+    latitude: -23.5748,
+    longitude: -46.6422,
+  };
+
+  function montar(): HomeComponent {
+    churches = jasmine.createSpyObj<ChurchesService>('ChurchesService', [
+      'addressRange', 'searchByFilters', 'getInfo', 'proximasMissas', 'cidadesProximas',
+    ]);
+    churches.proximasMissas.and.returnValue(of({ data: [itemApi] } as any));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        FormBuilder,
+        DatePipe,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Router, useValue: jasmine.createSpyObj<Router>('Router', ['navigate']) },
+        { provide: ChurchesService, useValue: churches },
+        { provide: BuscaLocalService, useValue: jasmine.createSpyObj('BuscaLocalService', ['carregarIndice', 'buscarIgrejas', 'correspondenciasExatas']) },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {}, data: {} }, queryParams: of({}), data: of({}) } },
+        { provide: MessageService, useValue: jasmine.createSpyObj('MessageService', ['add']) },
+        { provide: AnalyticsService, useValue: jasmine.createSpyObj('AnalyticsService', ['searchStarted', 'trackEvent']) },
+        { provide: FavoritesService, useValue: { favoritos$: of([]), listar: () => [], ehFavorita: () => false } },
+        { provide: RedesSociaisService, useValue: { obterTipos: () => of([]) } },
+        { provide: GeolocationService, useValue: jasmine.createSpyObj('GeolocationService', ['obterPosicaoAtual', 'reverseGeocode', 'consultarCep']) },
+        { provide: SeoService, useValue: jasmine.createSpyObj('SeoService', ['update', 'setJsonLd', 'removeJsonLd']) },
+        { provide: MetricasService, useValue: jasmine.createSpyObj('MetricasService', ['registrarVisualizacaoHome', 'registrarVisualizacaoPagina']) },
+        { provide: SeoPaginasService, useValue: { getEstados: () => of([]) } },
+      ],
+    });
+    return TestBed.runInInjectionContext(() => new HomeComponent());
+  }
+
+  it('propaga a distância para os cards exibidos quando a localização é concedida', () => {
+    const c = montar();
+
+    // 1. Primeira carga, sem localização: a API mede do centro de SP, então a home
+    //    não propaga distância nenhuma.
+    (c as any)._loadProximasMissas();
+    expect(c.proximasFiltradas.length).toBe(1);
+    expect(c.proximasFiltradas[0].distanceMeters).toBeUndefined();
+
+    // 2. Segunda carga, com localização: MESMA quantidade e MESMA primeira igreja —
+    //    a forma da lista não mudou, só o conteúdo.
+    (c as any)._loadProximasMissas(-23.5505, -46.6333);
+    expect(c.proximasMissasCards.length).toBe(1);
+    expect(c.proximasMissasCards[0].churchId).toBe(66);
+
+    // 3. O que chega ao template precisa ter a distância — era aqui que o cache
+    //    devolvia o card antigo e o chip nunca aparecia.
+    expect(c.proximasFiltradas[0].distanceMeters).toBe(2860);
+  });
+
+  it('mantém a mesma referência enquanto nada muda — o memo continua valendo', () => {
+    const c = montar();
+    (c as any)._loadProximasMissas(-23.5505, -46.6333);
+
+    const primeira = c.proximasFiltradas;
+
+    expect(c.proximasFiltradas).toBe(primeira);
+    expect(c.proximasFiltradas).toBe(primeira);
+  });
+
+  it('reage ao quickFilter sem depender de uma nova carga', () => {
+    const c = montar();
+    (c as any)._loadProximasMissas(-23.5505, -46.6333);
+    const semFiltro = c.proximasFiltradas;
+
+    c.quickFilter = 'noite'; // a missa é às 10h — o filtro tem que esvaziar a lista
+    const comFiltro = c.proximasFiltradas;
+
+    expect(comFiltro).not.toBe(semFiltro);
+    expect(comFiltro.length).toBe(0);
+
+    c.quickFilter = null;
+    expect(c.proximasFiltradas.length).toBe(1);
+  });
+});

--- a/src/app/modules/public/home/home.component.ts
+++ b/src/app/modules/public/home/home.component.ts
@@ -185,12 +185,25 @@ export class HomeComponent {
   }
 
   // Memo: evita realocar o array a cada ciclo de CD (relevante p/ filhos OnPush — 3.L)
+  //
+  // A invalidação compara a IDENTIDADE de `proximasMissasCards`, não um resumo dele.
+  // A chave anterior era `quickFilter|length|churchId[0]`, que descreve a FORMA da
+  // lista e não o conteúdo: recarregar com o mesmo tamanho e a mesma primeira igreja
+  // devolvia os cards antigos. Isso ficou visível quando a distância passou a existir
+  // só com geolocalização — carga sem geo (São Paulo, sem distância) → o usuário
+  // concede a localização → mesma lista de SP, agora com `distanceMeters` — e o chip
+  // de distância nunca aparecia. `_loadProximasMissas()` sempre atribui um array novo
+  // (é o resultado de um `.map()`), então a comparação por referência é exata.
   private _proximasFiltradasCache: MassCardData[] = [];
-  private _proximasFiltradasKey = '';
+  private _proximasFiltradasFonte: MassCardData[] | null = null;
+  private _proximasFiltradasQuickFilter: typeof this.quickFilter | undefined;
   get proximasFiltradas(): MassCardData[] {
-    const key = `${this.quickFilter ?? ''}|${this.proximasMissasCards.length}|${this.proximasMissasCards[0]?.churchId ?? ''}`;
-    if (key !== this._proximasFiltradasKey) {
-      this._proximasFiltradasKey = key;
+    if (
+      this.proximasMissasCards !== this._proximasFiltradasFonte ||
+      this.quickFilter !== this._proximasFiltradasQuickFilter
+    ) {
+      this._proximasFiltradasFonte = this.proximasMissasCards;
+      this._proximasFiltradasQuickFilter = this.quickFilter;
       this._proximasFiltradasCache = this._aplicarQuickFilterCards(this.proximasMissasCards);
     }
     return this._proximasFiltradasCache;


### PR DESCRIPTION
Correção de um bug encontrado ao validar a Etapa 2 (#180) no staging, com dados reais. Escopo único: o memo de `proximasFiltradas`.

## O bug

Com a localização concedida, **o chip de distância não aparecia** quando a lista recarregada tinha o mesmo tamanho e a mesma primeira igreja — que é o caso mais comum, porque o fallback da API também é São Paulo.

A chave do memo era um resumo da **forma** da lista, não do conteúdo:

```ts
const key = `${this.quickFilter ?? ''}|${this.proximasMissasCards.length}|${this.proximasMissasCards[0]?.churchId ?? ''}`;
```

Sequência que quebrava: carga sem geo (São Paulo, sem distância) → o usuário concede a localização → a API devolve a mesma igreja, agora com `distanciaKm: 2.86` → a chave não muda → o cache devolve o card antigo, ainda com `distanceMeters: undefined`.

Confirmado por contraste no navegador, contra a API de produção:

| Cenário | Lista | Chips |
|---|---|---|
| SP sem geo → SP com geo | 1 card → 1 card, mesma igreja | nenhum ❌ |
| SP sem geo → Rio com geo | 1 card → 2 cards | "5,4 km", "5,9 km" ✅ |

O bug é **anterior à Etapa 2**, mas era inofensivo enquanto `distanceMeters` já vinha preenchido desde a primeira carga — com o valor errado, medido do centro de São Paulo. A Etapa 2 removeu esse valor errado e expôs o cache.

## A correção

Comparar a identidade de `proximasMissasCards` em vez de montar uma chave. `_loadProximasMissas()` sempre atribui um array novo (é o resultado de um `.map()`), então a comparação por referência é exata — e não um heurístico. O `quickFilter` continua na comparação, e o memo segue devolvendo a mesma referência enquanto nada muda, que é o motivo dele existir (filhos OnPush).

## Testes

Três casos novos em `home.component.spec.ts`:

1. **reproduz o bug** — carga sem localização (card sem `distanceMeters`) → carga com localização (mesma quantidade, mesma primeira igreja) → `proximasFiltradas[0].distanceMeters` tem que ser `2860`. **Falha no código antigo com `Expected undefined to be 2860`.**
2. **regressão do memo** — sem mudança nenhuma, `proximasFiltradas` devolve a mesma referência em chamadas sucessivas.
3. **regressão do quickFilter** — mudar o filtro recalcula sem precisar de nova carga, e voltar para `null` restaura a lista.

`npm test`: 73 SUCCESS. `build:prod`: guard-rails de prerender e dist-size verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
